### PR TITLE
fix(eslint-plugin): expose new rules and use type guards

### DIFF
--- a/packages/eslint-plugin/src/index.ts
+++ b/packages/eslint-plugin/src/index.ts
@@ -1,3 +1,27 @@
+import componentClassSuffix, {
+  RULE_NAME as componentClassSuffixRuleName,
+} from './rules/component-class-suffix';
+import noHostMetadataProperty, {
+  RULE_NAME as noHostMetadataPropertyRuleName,
+} from './rules/no-host-metadata-property';
+import noInputsMetadataProperty, {
+  RULE_NAME as noInputsMetadataPropertyRuleName,
+} from './rules/no-inputs-metadata-property';
+import noOutputOnPrefix, {
+  RULE_NAME as noOutputOnPrefixRuleName,
+} from './rules/no-output-on-prefix';
+import noOutputsMetadataProperty, {
+  RULE_NAME as noOutputsMetadataPropertyRuleName,
+} from './rules/no-outputs-metadata-property';
+import noPipeImpure, {
+  RULE_NAME as noPipeImpureRuleName,
+} from './rules/no-pipe-impure';
+import noQueriesMetadataProperty, {
+  RULE_NAME as noQueriesMetadataPropertyRuleName,
+} from './rules/no-queries-metadata-property';
+import preferOnPushComponentChangeDetection, {
+  RULE_NAME as preferOnPushComponentChangeDetectionRuleName,
+} from './rules/prefer-on-push-component-change-detection';
 import useComponentSelector, {
   RULE_NAME as useComponentSelectorRuleName,
 } from './rules/use-component-selector';
@@ -13,24 +37,6 @@ import usePipeDecorator, {
 import usePipeTransformInterface, {
   RULE_NAME as usePipeTransformInterfaceRuleName,
 } from './rules/use-pipe-transform-interface';
-import noOutputOnPrefix, {
-  RULE_NAME as noOutputOnPrefixRuleName,
-} from './rules/no-output-on-prefix';
-import noHostMetadataProperty, {
-  RULE_NAME as noHostMetadataPropertyRuleName,
-} from './rules/no-host-metadata-property';
-import noInputsMetadataProperty, {
-  RULE_NAME as noInputsMetadataPropertyRuleName,
-} from './rules/no-inputs-metadata-property';
-import noOutputsMetadataProperty, {
-  RULE_NAME as noOutputsMetadataPropertyRuleName,
-} from './rules/no-outputs-metadata-property';
-import noQueriesMetadataProperty, {
-  RULE_NAME as noQueriesMetadataPropertyRuleName,
-} from './rules/no-queries-metadata-property';
-import componentClassSuffix, {
-  RULE_NAME as componentClassSuffixRuleName,
-} from './rules/component-class-suffix';
 
 export default {
   rules: {
@@ -45,5 +51,7 @@ export default {
     [noOutputsMetadataPropertyRuleName]: noOutputsMetadataProperty,
     [noQueriesMetadataPropertyRuleName]: noQueriesMetadataProperty,
     [componentClassSuffixRuleName]: componentClassSuffix,
+    [noPipeImpureRuleName]: noPipeImpure,
+    [preferOnPushComponentChangeDetectionRuleName]: preferOnPushComponentChangeDetection,
   },
 };

--- a/packages/eslint-plugin/src/rules/no-pipe-impure.ts
+++ b/packages/eslint-plugin/src/rules/no-pipe-impure.ts
@@ -1,7 +1,7 @@
 import { TSESTree } from '@typescript-eslint/experimental-utils';
 import { createESLintRule } from '../utils/create-eslint-rule';
 import { PIPE_CLASS_DECORATOR } from '../utils/selectors';
-import { getDecoratorProperty } from '../utils/utils';
+import { getDecoratorProperty, isLiteral } from '../utils/utils';
 
 type Options = [];
 export type MessageIds = 'noPipeImpure';
@@ -31,8 +31,13 @@ export default createESLintRule<Options, MessageIds>({
           'pure',
         ) as TSESTree.Property;
 
-        if (!pureProperty || !!(pureProperty.value as TSESTree.Literal).value)
+        if (
+          !pureProperty ||
+          !isLiteral(pureProperty.value) ||
+          !!pureProperty.value.value
+        ) {
           return;
+        }
 
         context.report({
           node: pureProperty.value,

--- a/packages/eslint-plugin/src/rules/prefer-on-push-component-change-detection.ts
+++ b/packages/eslint-plugin/src/rules/prefer-on-push-component-change-detection.ts
@@ -1,7 +1,7 @@
 import { TSESTree } from '@typescript-eslint/experimental-utils';
 import { createESLintRule } from '../utils/create-eslint-rule';
 import { COMPONENT_CLASS_DECORATOR } from '../utils/selectors';
-import { getDecoratorPropertyValue } from '../utils/utils';
+import { getDecoratorPropertyValue, isIdentifier } from '../utils/utils';
 
 type Options = [];
 export type MessageIds = 'preferOnPushComponentChangeDetection';
@@ -37,14 +37,18 @@ export default createESLintRule<Options, MessageIds>({
             node,
             messageId: 'preferOnPushComponentChangeDetection',
           });
-        } else if (
-          (changeDetectionExpression.property as TSESTree.Identifier).name !==
-          ON_PUSH
+          return;
+        }
+
+        if (
+          !isIdentifier(changeDetectionExpression.property) ||
+          changeDetectionExpression.property.name !== ON_PUSH
         ) {
           context.report({
             node: changeDetectionExpression,
             messageId: 'preferOnPushComponentChangeDetection',
           });
+          return;
         }
       },
     };


### PR DESCRIPTION
Hey @sfabriece I'm sorry I forgot on my PR reviews to point out that the new rules need to be exported in order to be used, so they need to be added to: `packages/eslint-plugin/src/index.ts`

I also did a couple of minor refactorings that were not worth blocking the original PRs over - they now use the type guards available in utils rather than type assertions where possible