### PR TITLE
feat(eslint-plugin): no output rename Rule

### DIFF
--- a/packages/eslint-plugin/src/index.ts
+++ b/packages/eslint-plugin/src/index.ts
@@ -10,6 +10,9 @@ import noInputsMetadataProperty, {
 import noOutputOnPrefix, {
   RULE_NAME as noOutputOnPrefixRuleName,
 } from './rules/no-output-on-prefix';
+import noOutputRename, {
+  RULE_NAME as noOutputRenameRuleName,
+} from './rules/no-output-rename';
 import noOutputsMetadataProperty, {
   RULE_NAME as noOutputsMetadataPropertyRuleName,
 } from './rules/no-outputs-metadata-property';
@@ -53,5 +56,6 @@ export default {
     [componentClassSuffixRuleName]: componentClassSuffix,
     [noPipeImpureRuleName]: noPipeImpure,
     [preferOnPushComponentChangeDetectionRuleName]: preferOnPushComponentChangeDetection,
+    [noOutputRenameRuleName]: noOutputRename,
   },
 };

--- a/packages/eslint-plugin/src/rules/no-output-rename.ts
+++ b/packages/eslint-plugin/src/rules/no-output-rename.ts
@@ -1,0 +1,88 @@
+import { TSESTree } from '@typescript-eslint/experimental-utils';
+import { createESLintRule } from '../utils/create-eslint-rule';
+import {
+  getDecoratorPropertyValue,
+  isIdentifier,
+  isLiteral,
+} from '../utils/utils';
+
+type Options = [];
+export type MessageIds = 'noOutputRename';
+export const RULE_NAME = 'no-output-rename';
+
+export default createESLintRule<Options, MessageIds>({
+  name: RULE_NAME,
+  meta: {
+    type: 'suggestion',
+    docs: {
+      description:
+        'Disallows renaming directive outputs by providing a string to the decorator.',
+      category: 'Best Practices',
+      recommended: false,
+    },
+    schema: [],
+    messages: {
+      noOutputRename: '@Outputs should not be renamed',
+    },
+  },
+  defaultOptions: [],
+  create(context) {
+    return {
+      'ClassProperty > Decorator[expression.callee.name="Output"]'(
+        node: TSESTree.Decorator,
+      ) {
+        const outputCallExpression = node.expression as TSESTree.CallExpression;
+
+        if (outputCallExpression.arguments.length === 0) return;
+
+        // handle directive's selector is also an output property
+        let directiveSelectors: ReadonlySet<any>;
+
+        const canPropertyBeAliased = (
+          propertyAlias: string,
+          propertyName: string,
+        ): boolean => {
+          return !!(
+            directiveSelectors &&
+            directiveSelectors.has(propertyAlias) &&
+            propertyAlias !== propertyName
+          );
+        };
+
+        const classProperty = node.parent as TSESTree.ClassProperty;
+        const classDeclaration = (classProperty.parent as TSESTree.ClassBody)
+          .parent as TSESTree.ClassDeclaration;
+
+        const decorator =
+          classDeclaration.decorators && classDeclaration.decorators[0];
+
+        if (decorator) {
+          const selector = getDecoratorPropertyValue(decorator, 'selector');
+
+          if (selector && isLiteral(selector) && selector.value) {
+            directiveSelectors = new Set(
+              (selector.value.toString() || '')
+                .replace(/[\[\]\s]/g, '')
+                .split(','),
+            );
+          }
+        }
+
+        const propertyAlias = (outputCallExpression
+          .arguments[0] as TSESTree.Literal).value;
+
+        if (
+          propertyAlias &&
+          isIdentifier(classProperty.key) &&
+          canPropertyBeAliased(propertyAlias.toString(), classProperty.key.name)
+        )
+          return;
+
+        context.report({
+          node: classProperty,
+          messageId: 'noOutputRename',
+        });
+      },
+    };
+  },
+});

--- a/packages/eslint-plugin/tests/rules/no-output-rename.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-output-rename.test.ts
@@ -1,0 +1,82 @@
+import rule, { MessageIds, RULE_NAME } from '../../src/rules/no-output-rename';
+import {
+  convertAnnotatedSourceToFailureCase,
+  RuleTester,
+} from '../test-helper';
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+const ruleTester = new RuleTester({
+  parser: '@typescript-eslint/parser',
+});
+
+const messageId: MessageIds = 'noOutputRename';
+
+ruleTester.run(RULE_NAME, rule, {
+  valid: [
+    // should succeed when a directive output property is properly used
+    `
+    @Component({
+      template: 'test'
+    })
+    class TestComponent {
+      @Output() change = new EventEmitter<void>();
+    }
+    `,
+    // should succeed when the directive's selector is also an output property
+    `
+    @Directive({
+      selector: '[foo], test'
+    })
+    class TestDirective {
+      @Output('foo') bar = new EventEmitter<void>();
+    }
+    `,
+  ],
+  invalid: [
+    convertAnnotatedSourceToFailureCase({
+      description: 'should fail when a directive output property is renamed',
+      annotatedSource: `
+     @Component({
+       template: 'test'
+     })
+     class TestComponent {
+       @Output('onChange') change = new EventEmitter<void>();
+       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     }
+          `,
+      messageId,
+    }),
+    convertAnnotatedSourceToFailureCase({
+      description:
+        'should fail when a directive output property is renamed and its name is strictly equal to the property',
+      annotatedSource: `
+      @Component({
+        template: 'test'
+      })
+      class TestComponent {
+        @Output('change') change = new EventEmitter<void>();
+        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      }
+      `,
+      messageId,
+    }),
+
+    convertAnnotatedSourceToFailureCase({
+      description:
+        "should fail when the directive's selector matches exactly both property name and the alias",
+      annotatedSource: `
+      @Directive({
+        selector: '[test], foo'
+      })
+      class TestDirective {
+        @Output('test') test = new EventEmitter<void>();
+        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      }
+      `,
+      messageId,
+    }),
+  ],
+});


### PR DESCRIPTION
This one was a bit more challenging than the previous rules. It might some refactoring.