### PR TITLE
feat(eslint-plugin-template): no-negated-async (with location issues)

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "@commitlint/cli": "^8.1.0",
     "@commitlint/config-conventional": "^8.1.0",
     "@types/eslint": "^4.16.6",
+    "@types/eslint-scope": "^3.7.0",
     "@types/jest": "^24.0.13",
     "@types/json-schema": "^7.0.3",
     "@types/node": "^10.12.2",

--- a/packages/eslint-plugin-template/src/rules/no-negated-async.ts
+++ b/packages/eslint-plugin-template/src/rules/no-negated-async.ts
@@ -1,0 +1,82 @@
+import {
+  createESLintRule,
+  getTemplateParserServices,
+} from '../utils/create-eslint-rule';
+
+type Options = [];
+export type MessageIds = 'noNegatedAsync' | 'noLooseEquality';
+export const RULE_NAME = 'no-negated-async';
+
+export default createESLintRule<Options, MessageIds>({
+  name: RULE_NAME,
+  meta: {
+    type: 'suggestion',
+    docs: {
+      description: `Ensures that strict equality is used when evaluating negations on async pipe output`,
+      category: 'Best Practices',
+      recommended: false,
+    },
+    fixable: 'code',
+    schema: [],
+    messages: {
+      noNegatedAsync:
+        'Async pipes should not be negated. Use (observable | async) === (false | null | undefined) to check its value instead',
+      noLooseEquality:
+        'Async pipes must use strict equality `===` when comparing with `false`',
+    },
+  },
+  defaultOptions: [],
+  create(context) {
+    const parserServices = getTemplateParserServices(context);
+    const sourceCode = context.getSourceCode();
+
+    return parserServices.defineTemplateBodyVisitor({
+      ['BindingPipe[name=async]'](node: any) {
+        if (node.parent.type === 'PrefixNot') {
+          const additionalStartOffset =
+            node.parent.parent.type === 'Interpolation' ? -1 : -0;
+          const additionalEndOffset =
+            node.parent.parent.type === 'Interpolation' ? -2 : 0;
+
+          const start = sourceCode.getLocFromIndex(
+            node.parent.sourceSpan.start + additionalStartOffset,
+          );
+          const end = sourceCode.getLocFromIndex(
+            node.parent.sourceSpan.end + additionalEndOffset,
+          );
+
+          context.report({
+            messageId: 'noNegatedAsync',
+            loc: {
+              start,
+              end,
+            },
+          });
+          return;
+        }
+
+        if (node.parent.type === 'Binary' && node.parent.operation === '==') {
+          const additionalStartOffset =
+            node.parent.parent.type === 'Interpolation' ? -2 : -1;
+          const additionalEndOffset =
+            node.parent.parent.type === 'Interpolation' ? -2 : 0;
+          const start = sourceCode.getLocFromIndex(
+            node.parent.sourceSpan.start + additionalStartOffset,
+          );
+          const end = sourceCode.getLocFromIndex(
+            node.parent.sourceSpan.end + additionalEndOffset,
+          );
+
+          context.report({
+            messageId: 'noLooseEquality',
+            loc: {
+              start,
+              end,
+            },
+          });
+          return;
+        }
+      },
+    });
+  },
+});

--- a/packages/eslint-plugin-template/tests/rules/no-negated-async.test.ts
+++ b/packages/eslint-plugin-template/tests/rules/no-negated-async.test.ts
@@ -1,0 +1,101 @@
+import rule, { RULE_NAME } from '../../src/rules/no-negated-async';
+import {
+  convertAnnotatedSourceToFailureCase,
+  RuleTester,
+} from '../test-helper';
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+const ruleTester = new RuleTester({
+  parser: '@angular-eslint/template-parser',
+});
+
+ruleTester.run(RULE_NAME, rule, {
+  valid: [
+    // it should succeed if async pipe is not negated
+    `
+      {{ (foo | async) }}
+    `,
+    // it should succeed if async pipe is not the last pipe in the negated chain
+    `
+      {{ !(foo | async | somethingElse) }}
+    `,
+    // it should succeed if async pipe uses strict equality
+    `
+      {{ (foo | async) === false }}
+    `,
+    // it should succeed if any other pipe is negated
+    `
+      {{ !(foo | notAnAsyncPipe) }}
+    `,
+  ],
+  invalid: [
+    convertAnnotatedSourceToFailureCase({
+      description: 'it should fail if async pipe is negated',
+      annotatedSource: `
+        {{ !(foo | async) }}
+           ~~~~~~~~~~~~~~
+      `,
+      messageId: 'noNegatedAsync',
+    }),
+    convertAnnotatedSourceToFailureCase({
+      description:
+        'it should fail if async pipe is the last pipe in the negated chain',
+      annotatedSource: `
+          {{ !(foo | somethingElse | async) }}
+             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      `,
+      messageId: 'noNegatedAsync',
+    }),
+    convertAnnotatedSourceToFailureCase({
+      description: 'it should fail if the async pipe uses loose equality',
+      annotatedSource: `
+        {{ (foo | async) == false }}
+           ~~~~~~~~~~~~~~~~~~~~~~
+      `,
+      messageId: 'noLooseEquality',
+    }),
+    convertAnnotatedSourceToFailureCase({
+      description: 'it should fail if async pipe is negated using *ngIf',
+      annotatedSource: `
+        <div *ngIf="!(a | async)"></div>
+                    ~~~~~~~~~~~~
+      `,
+      messageId: 'noNegatedAsync',
+    }),
+    convertAnnotatedSourceToFailureCase({
+      description:
+        'it should fail for multiple negated/loose equality async pipes',
+      annotatedSource: `
+        <div *ngFor="let elem of [1, 2, 3]; trackBy: trackByFn">
+          {{ elem }}
+        </div>
+        <div *ngIf="!(foo | async)">
+                    ~~~~~~~~~~~~~~
+          {{ (foo | async) == false }}
+             ^^^^^^^^^^^^^^^^^^^^^^
+          <div *ngIf="(foo | async) == false">
+                      ######################
+            works!
+          </div>
+        </div>
+      `,
+      messages: [
+        {
+          char: '~',
+          messageId: 'noNegatedAsync',
+        },
+        {
+          char: '^',
+          messageId: 'noLooseEquality',
+        },
+        {
+          char: '#',
+          messageId: 'noLooseEquality',
+        },
+      ],
+    }),
+  ],
+});

--- a/packages/integration-tests/fixtures/angular-cli-workspace/.eslintrc.js
+++ b/packages/integration-tests/fixtures/angular-cli-workspace/.eslintrc.js
@@ -156,10 +156,7 @@ module.exports = {
         '@angular-eslint/no-host-metadata-property': 'error',
 
         // ORIGINAL tslint.json -> "no-input-rename": true,
-        /**
-         * TODO: Not converted yet
-         */
-        // '@angular-eslint/no-input-rename': 'error',
+        '@angular-eslint/no-input-rename': 'error',
 
         // ORIGINAL tslint.json -> "no-inputs-metadata-property": true,
         '@angular-eslint/no-inputs-metadata-property': 'error',
@@ -180,9 +177,7 @@ module.exports = {
         // APPLIED VIA TEMPLATE-RELATED CONFIG BELOW
 
         // ORIGINAL tslint.json -> "template-no-negated-async": true,
-        /**
-         * TODO: Not converted yet
-         */
+        // APPLIED VIA TEMPLATE-RELATED CONFIG BELOW
 
         // ORIGINAL tslint.json -> "use-lifecycle-interface": true,
         '@angular-eslint/use-lifecycle-interface': 'warn',
@@ -196,7 +191,11 @@ module.exports = {
       parser: '@angular-eslint/template-parser',
       plugins: ['@angular-eslint/template'],
       rules: {
+        // ORIGINAL tslint.json -> "template-banana-in-box": true,
         '@angular-eslint/template/banana-in-a-box': 'error',
+
+        // ORIGINAL tslint.json -> "template-no-negated-async": true,
+        '@angular-eslint/template/no-negated-async': 'error',
       },
     },
   ],

--- a/yarn.lock
+++ b/yarn.lock
@@ -2092,10 +2092,26 @@
   dependencies:
     "@babel/types" "^7.3.0"
 
+"@types/eslint-scope@^3.7.0":
+  version "3.7.0"
+  resolved "https://registry.yarnpkg.com/@types/eslint-scope/-/eslint-scope-3.7.0.tgz#4792816e31119ebd506902a482caec4951fabd86"
+  integrity sha512-O/ql2+rrCUe2W2rs7wMR+GqPRcgB6UiqN5RhrR5xruFlY7l9YLMn0ZkDzjoHLeiFkR8MCQZVudUuuvQ2BLC9Qw==
+  dependencies:
+    "@types/eslint" "*"
+    "@types/estree" "*"
+
 "@types/eslint-visitor-keys@^1.0.0":
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/@types/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz#1ee30d79544ca84d68d4b3cdb0af4f205663dd2d"
   integrity sha512-OCutwjDZ4aFS6PB1UZ988C4YgwlBHJd6wCeQqaLdmadZ/7e+w79+hbMUFC1QXDNCmdyoRfAFdm0RypzwR+Qpag==
+
+"@types/eslint@*":
+  version "6.1.8"
+  resolved "https://registry.yarnpkg.com/@types/eslint/-/eslint-6.1.8.tgz#7e868f89bc1e520323d405940e49cb912ede5bba"
+  integrity sha512-CJBhm9pYdUS8cFVbXACWlLxZWFBTQMiM0eI6RYxng3u9oQ9gHdQ5PN89DHPrK4RISRzX62nRsteUlbBgEIdSug==
+  dependencies:
+    "@types/estree" "*"
+    "@types/json-schema" "*"
 
 "@types/eslint@^4.16.6":
   version "4.16.6"


### PR DESCRIPTION
Opening for visibility only right now.

@mgechev Do you know if there is any information/spec anywhere for how location information is applied to Angular Template AST nodes?

I have made progress on the `no-negated-async` rule here, but it's all through trial and error and I'm not very happy with it.

The use, and logic, of `sourceSpan` and `span` appears to be hard to predict, and inconsistent depending on hierarchies within the template.

E.g. the location data for a an async `BindingPipe` seems to change how it is given depending on whether or not an `Element` exists within its ancestors...

Please let me know if there are any resources in this area, or if I missed some existing utilities in the codelyzer codebase that could help with this!