### PR TITLE
fix(builder): remove `rule` section before running CLI engine

### DIFF
--- a/packages/builder/src/index.ts
+++ b/packages/builder/src/index.ts
@@ -200,9 +200,6 @@ async function _lint(
     configFile: eslintConfigPath,
     useEslintrc: false,
     fix: !!options.fix,
-    rules: {
-      semi: 2,
-    },
   });
 
   const lintReports: eslint.CLIEngine.LintReport[] = [];


### PR DESCRIPTION
Some users of nrwl/nx (nrwl/nx#2051) are requesting that `semi` not be a hard error while using eslint. 

This PR removes that rule before running the CLI Engine