### PR TITLE
test: use codecov bash uploader instead of js uploader

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -32,7 +32,7 @@ jobs:
         displayName: 'Run unit tests'
 
       - script: |
-          npx codecov -t $(CODECOV_TOKEN)
+          bash <(curl -s https://codecov.io/bash) -t $(CODECOV_TOKEN)
         displayName: 'Publish code coverage report'
 
   - job: unit_tests_on_other_node_versions


### PR DESCRIPTION
Copied from: https://github.com/typescript-eslint/typescript-eslint/pull/1353

The js uploader keeps on timing out which causes coverage to not report, causing PR status to get stuck in pending.

The bash reporter has a retry mechanism, so it is supposed to be be more resilient.