### PR TITLE
feat(eslint-plugin): no-input-rename rule

### DIFF
--- a/packages/eslint-plugin/src/index.ts
+++ b/packages/eslint-plugin/src/index.ts
@@ -34,6 +34,9 @@ import noOutputOnPrefix, {
 import noOutputRename, {
   RULE_NAME as noOutputRenameRuleName,
 } from './rules/no-output-rename';
+import noInputRename, {
+  RULE_NAME as noInputRenameRuleName,
+} from './rules/no-input-rename';
 import noOutputsMetadataProperty, {
   RULE_NAME as noOutputsMetadataPropertyRuleName,
 } from './rules/no-outputs-metadata-property';
@@ -76,6 +79,7 @@ export default {
     [noOutputNativeRuleName]: noOutputNative,
     [noOutputOnPrefixRuleName]: noOutputOnPrefix,
     [noOutputRenameRuleName]: noOutputRename,
+    [noInputRenameRuleName]: noInputRename,
     [noOutputsMetadataPropertyRuleName]: noOutputsMetadataProperty,
     [noPipeImpureRuleName]: noPipeImpure,
     [noQueriesMetadataPropertyRuleName]: noQueriesMetadataProperty,

--- a/packages/eslint-plugin/src/rules/no-input-rename.ts
+++ b/packages/eslint-plugin/src/rules/no-input-rename.ts
@@ -1,0 +1,149 @@
+import { TSESTree } from '@typescript-eslint/experimental-utils';
+import { createESLintRule } from '../utils/create-eslint-rule';
+import {
+  getDecoratorPropertyValue,
+  isIdentifier,
+  isLiteral,
+  isCallExpression,
+  kebabToCamelCase,
+  AngularClassDecorators,
+} from '../utils/utils';
+
+type Options = [];
+export type MessageIds = 'noInputRename';
+export const RULE_NAME = 'no-input-rename';
+
+// source: https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques
+const whiteListAliases = new Set<string>([
+  'aria-activedescendant',
+  'aria-atomic',
+  'aria-autocomplete',
+  'aria-busy',
+  'aria-checked',
+  'aria-controls',
+  'aria-current',
+  'aria-describedby',
+  'aria-disabled',
+  'aria-dragged',
+  'aria-dropeffect',
+  'aria-expanded',
+  'aria-flowto',
+  'aria-haspopup',
+  'aria-hidden',
+  'aria-invalid',
+  'aria-label',
+  'aria-labelledby',
+  'aria-level',
+  'aria-live',
+  'aria-multiline',
+  'aria-multiselectable',
+  'aria-orientation',
+  'aria-owns',
+  'aria-posinset',
+  'aria-pressed',
+  'aria-readonly',
+  'aria-relevant',
+  'aria-required',
+  'aria-selected',
+  'aria-setsize',
+  'aria-sort',
+  'aria-valuemax',
+  'aria-valuemin',
+  'aria-valuenow',
+  'aria-valuetext',
+]);
+
+export default createESLintRule<Options, MessageIds>({
+  name: RULE_NAME,
+  meta: {
+    type: 'suggestion',
+    docs: {
+      description:
+        'Disallows renaming directive inputs by providing a string to the decorator.',
+      category: 'Best Practices',
+      recommended: false,
+    },
+    schema: [],
+    messages: {
+      noInputRename: `In the class {{className}}, the directive input property {{propertyName}} should not be renamed`,
+    },
+  },
+  defaultOptions: [],
+  create(context) {
+    return {
+      ':matches(ClassProperty, MethodDefinition[kind="set"]) > Decorator[expression.callee.name="Input"]'(
+        node: TSESTree.Decorator,
+      ) {
+        const inputCallExpression = node.expression as TSESTree.CallExpression;
+
+        if (inputCallExpression.arguments.length === 0) return;
+
+        // handle directive's selector is also an input property
+        let directiveSelectors: ReadonlyArray<any>;
+
+        const canPropertyBeAliased = (
+          propertyAlias: string,
+          propertyName: string,
+        ): boolean => {
+          return !!(
+            (propertyAlias !== propertyName &&
+              directiveSelectors &&
+              directiveSelectors.some(x =>
+                new RegExp(
+                  `^${x}((${propertyName[0].toUpperCase() +
+                    propertyName.slice(1)}$)|(?=$))`,
+                ).test(propertyAlias),
+              )) ||
+            (whiteListAliases.has(propertyAlias) &&
+              propertyName === kebabToCamelCase(propertyAlias))
+          );
+        };
+
+        const classProperty = node.parent as
+          | TSESTree.ClassProperty
+          | TSESTree.MethodDefinition;
+        const classDeclaration = (classProperty.parent as TSESTree.ClassBody)
+          .parent as TSESTree.ClassDeclaration;
+
+        const decorator =
+          classDeclaration.decorators &&
+          classDeclaration.decorators.find(
+            decorator =>
+              isCallExpression(decorator.expression) &&
+              isIdentifier(decorator.expression.callee) &&
+              decorator.expression.callee.name ===
+                AngularClassDecorators.Directive,
+          );
+
+        if (decorator) {
+          const selector = getDecoratorPropertyValue(decorator, 'selector');
+
+          if (selector && isLiteral(selector) && selector.value) {
+            directiveSelectors = (selector.value.toString() || '')
+              .replace(/[\[\]\s]/g, '')
+              .split(',');
+          }
+        }
+
+        const propertyAlias = (inputCallExpression
+          .arguments[0] as TSESTree.Literal).value;
+
+        if (
+          propertyAlias &&
+          isIdentifier(classProperty.key) &&
+          canPropertyBeAliased(propertyAlias.toString(), classProperty.key.name)
+        )
+          return;
+
+        context.report({
+          node: classProperty,
+          messageId: 'noInputRename',
+          data: {
+            className: classDeclaration.id && classDeclaration.id.name,
+            propertyName: (classProperty.key as TSESTree.Identifier).name,
+          },
+        });
+      },
+    };
+  },
+});

--- a/packages/eslint-plugin/src/rules/no-input-rename.ts
+++ b/packages/eslint-plugin/src/rules/no-input-rename.ts
@@ -7,6 +7,7 @@ import {
   isCallExpression,
   kebabToCamelCase,
   AngularClassDecorators,
+  isImportedFrom,
 } from '../utils/utils';
 
 type Options = [];
@@ -76,6 +77,13 @@ export default createESLintRule<Options, MessageIds>({
       ) {
         const inputCallExpression = node.expression as TSESTree.CallExpression;
 
+        if (
+          !isImportedFrom(
+            inputCallExpression.callee as TSESTree.Identifier,
+            '@angular/core',
+          )
+        )
+          return;
         if (inputCallExpression.arguments.length === 0) return;
 
         // handle directive's selector is also an input property

--- a/packages/eslint-plugin/src/rules/no-output-rename.ts
+++ b/packages/eslint-plugin/src/rules/no-output-rename.ts
@@ -4,6 +4,8 @@ import {
   getDecoratorPropertyValue,
   isIdentifier,
   isLiteral,
+  isCallExpression,
+  AngularClassDecorators,
 } from '../utils/utils';
 
 type Options = [];
@@ -54,7 +56,14 @@ export default createESLintRule<Options, MessageIds>({
           .parent as TSESTree.ClassDeclaration;
 
         const decorator =
-          classDeclaration.decorators && classDeclaration.decorators[0];
+          classDeclaration.decorators &&
+          classDeclaration.decorators.find(
+            decorator =>
+              isCallExpression(decorator.expression) &&
+              isIdentifier(decorator.expression.callee) &&
+              decorator.expression.callee.name ===
+                AngularClassDecorators.Directive,
+          );
 
         if (decorator) {
           const selector = getDecoratorPropertyValue(decorator, 'selector');

--- a/packages/eslint-plugin/src/rules/no-output-rename.ts
+++ b/packages/eslint-plugin/src/rules/no-output-rename.ts
@@ -6,6 +6,7 @@ import {
   isLiteral,
   isCallExpression,
   AngularClassDecorators,
+  isImportedFrom,
 } from '../utils/utils';
 
 type Options = [];
@@ -35,6 +36,13 @@ export default createESLintRule<Options, MessageIds>({
       ) {
         const outputCallExpression = node.expression as TSESTree.CallExpression;
 
+        if (
+          !isImportedFrom(
+            outputCallExpression.callee as TSESTree.Identifier,
+            '@angular/core',
+          )
+        )
+          return;
         if (outputCallExpression.arguments.length === 0) return;
 
         // handle directive's selector is also an output property

--- a/packages/eslint-plugin/src/utils/utils.ts
+++ b/packages/eslint-plugin/src/utils/utils.ts
@@ -156,6 +156,18 @@ export function isTemplateLiteral(
   return node.type === 'TemplateLiteral';
 }
 
+function isImportDeclaration(
+  node: TSESTree.Node,
+): node is TSESTree.ImportDeclaration {
+  return node.type === 'ImportDeclaration';
+}
+
+function isImportSpecifier(
+  node: TSESTree.Node,
+): node is TSESTree.ImportSpecifier {
+  return node.type === 'ImportSpecifier';
+}
+
 type LiteralWithStringValue = TSESTree.Literal & {
   value: string;
 };
@@ -442,3 +454,25 @@ export const SelectorValidator = {
 
 export const kebabToCamelCase = (value: string) =>
   value.replace(/-[a-zA-Z]/g, x => x[1].toUpperCase());
+
+export function isImportedFrom(
+  identifier: TSESTree.Identifier,
+  module: string,
+) {
+  let parentNode: TSESTree.Node | undefined = identifier;
+  while ((parentNode = parentNode.parent)) {
+    if (parentNode.type !== 'Program') continue;
+    return parentNode.body.some(
+      node =>
+        isImportDeclaration(node) &&
+        (node.source as TSESTree.Literal).value === module &&
+        node.specifiers.some(
+          specifier =>
+            isImportSpecifier(specifier) &&
+            specifier.imported.name === identifier.name &&
+            specifier.local.name === identifier.name,
+        ),
+    );
+  }
+  return false;
+}

--- a/packages/eslint-plugin/src/utils/utils.ts
+++ b/packages/eslint-plugin/src/utils/utils.ts
@@ -439,3 +439,6 @@ export const SelectorValidator = {
     };
   },
 };
+
+export const kebabToCamelCase = (value: string) =>
+  value.replace(/-[a-zA-Z]/g, x => x[1].toUpperCase());

--- a/packages/eslint-plugin/tests/rules/no-input-rename.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-input-rename.test.ts
@@ -10,6 +10,9 @@ import {
 
 const ruleTester = new RuleTester({
   parser: '@typescript-eslint/parser',
+  parserOptions: {
+    sourceType: 'module',
+  },
 });
 
 const messageId: MessageIds = 'noInputRename';
@@ -18,6 +21,7 @@ ruleTester.run(RULE_NAME, rule, {
   valid: [
     // should succeed when a component input property is not renamed
     `
+    import { Input } from '@angular/core';
     @Component
     class TestComponent {
       @Input() label: string;
@@ -25,6 +29,7 @@ ruleTester.run(RULE_NAME, rule, {
     `,
     // should succeed when a component input setter is not renamed
     `
+    import { Input } from '@angular/core';
     @Component
     class TestComponent {
       @Input() set label(label: string) {}
@@ -32,6 +37,7 @@ ruleTester.run(RULE_NAME, rule, {
     `,
     // should succeed when a directive selector is strictly equal to the alias
     `
+    import { Input } from '@angular/core';
     @Directive({
       selector: '[foo]'
     })
@@ -41,6 +47,7 @@ ruleTester.run(RULE_NAME, rule, {
     `,
     // should succeed when the first directive selector is strictly equal to the alias
     `
+    import { Input } from '@angular/core';
     @Directive({
       selector: '[foo], test'
     })
@@ -50,6 +57,7 @@ ruleTester.run(RULE_NAME, rule, {
     `,
     // should succeed when the second directive selector is strictly equal to the alias
     `
+    import { Input } from '@angular/core';
     @Directive({
       selector: '[foo], myselector'
     })
@@ -59,6 +67,7 @@ ruleTester.run(RULE_NAME, rule, {
     `,
     // should succeed when a directive selector is also an input property
     `
+    import { Input } from '@angular/core';
     @Directive({
       selector: '[foo], label2'
     })
@@ -68,6 +77,7 @@ ruleTester.run(RULE_NAME, rule, {
     `,
     // should succeed when a directive selector is also an input property with tag
     `
+    import { Input } from '@angular/core';
     @Directive({
       selector: 'foo[bar]'
     })
@@ -77,6 +87,7 @@ ruleTester.run(RULE_NAME, rule, {
     `,
     // should succeed when an input alias is kebab-cased and whitelisted
     `
+    import { Input } from '@angular/core';
     @Directive({
       selector: 'foo'
     })
@@ -86,6 +97,7 @@ ruleTester.run(RULE_NAME, rule, {
     `,
     // should succeed when an input alias is strictly equal to the selector plus the property name
     `
+    import { Input } from '@angular/core';
     @Directive({
       selector: 'foo'
     })
@@ -93,11 +105,22 @@ ruleTester.run(RULE_NAME, rule, {
       @Input('fooMyColor') myColor: string;
     }
     `,
+    // should succeed when an Input decorator is not imported from '@angular/core'
+    `
+    import { Input } from 'baz';
+    @Component({
+      selector: 'foo'
+    })
+    class TestComponent {
+      @Input('bar') label: string;
+    }
+    `,
   ],
   invalid: [
     convertAnnotatedSourceToFailureCase({
       description: 'should fail when a component input property is renamed',
       annotatedSource: `
+      import { Input } from '@angular/core';
       @Component({
         selector: 'foo'
       })
@@ -111,6 +134,7 @@ ruleTester.run(RULE_NAME, rule, {
     convertAnnotatedSourceToFailureCase({
       description: 'should fail when a component input setter is renamed',
       annotatedSource: `
+      import { Input } from '@angular/core';
       @Component({
         selector: 'foo'
       })
@@ -125,6 +149,7 @@ ruleTester.run(RULE_NAME, rule, {
       description:
         'should fail when a component input property is fake renamed',
       annotatedSource: `
+      import { Input } from '@angular/core';
       @Component({
         selector: 'foo'
       })
@@ -138,6 +163,7 @@ ruleTester.run(RULE_NAME, rule, {
     convertAnnotatedSourceToFailureCase({
       description: 'should fail when a component input setter is fake renamed',
       annotatedSource: `
+      import { Input } from '@angular/core';
       @Component({
         selector: 'foo'
       })
@@ -151,6 +177,7 @@ ruleTester.run(RULE_NAME, rule, {
     convertAnnotatedSourceToFailureCase({
       description: 'should fail when a directive input property is renamed',
       annotatedSource: `
+      import { Input } from '@angular/core';
       @Directive({
         selector: '[foo]'
       })
@@ -165,6 +192,7 @@ ruleTester.run(RULE_NAME, rule, {
       description:
         'should fail when a directive input property is renamed and its name is strictly equal to the property',
       annotatedSource: `
+      import { Input } from '@angular/core';
       @Directive({
         selector: '[label]'
       })
@@ -179,6 +207,7 @@ ruleTester.run(RULE_NAME, rule, {
       description:
         'should fail when a directive input property has the same name as the alias',
       annotatedSource: `
+      import { Input } from '@angular/core';
       @Directive({
         selector: '[foo]'
       })
@@ -192,6 +221,7 @@ ruleTester.run(RULE_NAME, rule, {
     convertAnnotatedSourceToFailureCase({
       description: `should fail when a directive input alias is kebab-cased and whitelisted, but the property doesn't match the alias`,
       annotatedSource: `
+      import { Input } from '@angular/core';
       @Directive({
         selector: 'foo'
       })
@@ -205,6 +235,7 @@ ruleTester.run(RULE_NAME, rule, {
     convertAnnotatedSourceToFailureCase({
       description: `should fail when a directive input alias is prefixed by directive's selector, but the suffix does not match the property name`,
       annotatedSource: `
+      import { Input } from '@angular/core';
       @Directive({
         selector: 'foo'
       })
@@ -219,6 +250,7 @@ ruleTester.run(RULE_NAME, rule, {
       description:
         'should fail when a directive input alias is not strictly equal to the selector plus the property name',
       annotatedSource: `
+      import { Input } from '@angular/core';
       @Directive({
         selector: 'foo'
       })

--- a/packages/eslint-plugin/tests/rules/no-input-rename.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-input-rename.test.ts
@@ -1,0 +1,233 @@
+import rule, { MessageIds, RULE_NAME } from '../../src/rules/no-input-rename';
+import {
+  convertAnnotatedSourceToFailureCase,
+  RuleTester,
+} from '../test-helper';
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+const ruleTester = new RuleTester({
+  parser: '@typescript-eslint/parser',
+});
+
+const messageId: MessageIds = 'noInputRename';
+
+ruleTester.run(RULE_NAME, rule, {
+  valid: [
+    // should succeed when a component input property is not renamed
+    `
+    @Component
+    class TestComponent {
+      @Input() label: string;
+    }
+    `,
+    // should succeed when a component input setter is not renamed
+    `
+    @Component
+    class TestComponent {
+      @Input() set label(label: string) {}
+    }
+    `,
+    // should succeed when a directive selector is strictly equal to the alias
+    `
+    @Directive({
+      selector: '[foo]'
+    })
+    class TestDirective {
+      @Input('foo') bar = new EventEmitter<void>();
+    }
+    `,
+    // should succeed when the first directive selector is strictly equal to the alias
+    `
+    @Directive({
+      selector: '[foo], test'
+    })
+    class TestDirective {
+      @Input('foo') bar = new EventEmitter<void>();
+    }
+    `,
+    // should succeed when the second directive selector is strictly equal to the alias
+    `
+    @Directive({
+      selector: '[foo], myselector'
+    })
+    class TestDirective {
+      @Input('myselector') bar: string;
+    }
+    `,
+    // should succeed when a directive selector is also an input property
+    `
+    @Directive({
+      selector: '[foo], label2'
+    })
+    class TestDirective {
+      @Input() foo: string;
+    }
+    `,
+    // should succeed when a directive selector is also an input property with tag
+    `
+    @Directive({
+      selector: 'foo[bar]'
+    })
+    class TestDirective {
+      @Input() bar: string;
+    }
+    `,
+    // should succeed when an input alias is kebab-cased and whitelisted
+    `
+    @Directive({
+      selector: 'foo'
+    })
+    class TestDirective {
+      @Input('aria-label') ariaLabel: string;
+    }
+    `,
+    // should succeed when an input alias is strictly equal to the selector plus the property name
+    `
+    @Directive({
+      selector: 'foo'
+    })
+    class TestDirective {
+      @Input('fooMyColor') myColor: string;
+    }
+    `,
+  ],
+  invalid: [
+    convertAnnotatedSourceToFailureCase({
+      description: 'should fail when a component input property is renamed',
+      annotatedSource: `
+      @Component({
+        selector: 'foo'
+      })
+      class TestComponent {
+        @Input('bar') label: string;
+        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      }
+      `,
+      messageId,
+    }),
+    convertAnnotatedSourceToFailureCase({
+      description: 'should fail when a component input setter is renamed',
+      annotatedSource: `
+      @Component({
+        selector: 'foo'
+      })
+      class TestComponent {
+        @Input('bar') set label(label: string) {}
+        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      }
+      `,
+      messageId,
+    }),
+    convertAnnotatedSourceToFailureCase({
+      description:
+        'should fail when a component input property is fake renamed',
+      annotatedSource: `
+      @Component({
+        selector: 'foo'
+      })
+      class TestComponent {
+        @Input('foo') label: string;
+        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      }
+      `,
+      messageId,
+    }),
+    convertAnnotatedSourceToFailureCase({
+      description: 'should fail when a component input setter is fake renamed',
+      annotatedSource: `
+      @Component({
+        selector: 'foo'
+      })
+      class TestComponent {
+        @Input('foo') set label(label: string) {}
+        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~s
+      }
+      `,
+      messageId,
+    }),
+    convertAnnotatedSourceToFailureCase({
+      description: 'should fail when a directive input property is renamed',
+      annotatedSource: `
+      @Directive({
+        selector: '[foo]'
+      })
+      class TestDirective {
+        @Input('labelText') label: string;
+        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      }
+      `,
+      messageId,
+    }),
+    convertAnnotatedSourceToFailureCase({
+      description:
+        'should fail when a directive input property is renamed and its name is strictly equal to the property',
+      annotatedSource: `
+      @Directive({
+        selector: '[label]'
+      })
+      class TestDirective {
+        @Input('label') label: string;
+        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      }
+      `,
+      messageId,
+    }),
+    convertAnnotatedSourceToFailureCase({
+      description:
+        'should fail when a directive input property has the same name as the alias',
+      annotatedSource: `
+      @Directive({
+        selector: '[foo]'
+      })
+      class TestDirective {
+        @Input('label') label: string;
+        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      }
+      `,
+      messageId,
+    }),
+    convertAnnotatedSourceToFailureCase({
+      description: `should fail when a directive input alias is kebab-cased and whitelisted, but the property doesn't match the alias`,
+      annotatedSource: `
+      @Directive({
+        selector: 'foo'
+      })
+      class TestDirective {
+        @Input('aria-invalid') ariaBusy: string;
+        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      }
+      `,
+      messageId,
+    }),
+    convertAnnotatedSourceToFailureCase({
+      description: `should fail when a directive input alias is prefixed by directive's selector, but the suffix does not match the property name`,
+      annotatedSource: `
+      @Directive({
+        selector: 'foo'
+      })
+      class TestDirective {
+        @Input('fooColor') colors: string;
+        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      }
+      `,
+      messageId,
+    }),
+    convertAnnotatedSourceToFailureCase({
+      description:
+        'should fail when a directive input alias is not strictly equal to the selector plus the property name',
+      annotatedSource: `
+      @Directive({
+        selector: 'foo'
+      })
+      class TestDirective {
+        @Input('foocolor') color: string;
+        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      }
+      `,
+      messageId,
+    }),
+  ],
+});

--- a/packages/eslint-plugin/tests/rules/no-output-rename.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-output-rename.test.ts
@@ -10,6 +10,9 @@ import {
 
 const ruleTester = new RuleTester({
   parser: '@typescript-eslint/parser',
+  parserOptions: {
+    sourceType: 'module',
+  },
 });
 
 const messageId: MessageIds = 'noOutputRename';
@@ -18,6 +21,7 @@ ruleTester.run(RULE_NAME, rule, {
   valid: [
     // should succeed when a directive output property is properly used
     `
+    import { Output } from '@angular/core';
     @Component({
       template: 'test'
     })
@@ -27,6 +31,7 @@ ruleTester.run(RULE_NAME, rule, {
     `,
     // should succeed when the directive's selector is also an output property
     `
+    import { Output } from '@angular/core';
     @Directive({
       selector: '[foo], test'
     })
@@ -34,25 +39,37 @@ ruleTester.run(RULE_NAME, rule, {
       @Output('foo') bar = new EventEmitter<void>();
     }
     `,
+    // should succeed when an Output decorator is not imported from '@angular/core'
+    `
+    import { Output } from 'baz';
+    @Component({
+      template: 'test'
+    })
+    class TestComponent {
+      @Output('onChange') change = new EventEmitter<void>();
+    }
+    `,
   ],
   invalid: [
     convertAnnotatedSourceToFailureCase({
       description: 'should fail when a directive output property is renamed',
       annotatedSource: `
-     @Component({
-       template: 'test'
-     })
-     class TestComponent {
-       @Output('onChange') change = new EventEmitter<void>();
-       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-     }
-          `,
+      import { Output } from '@angular/core';
+      @Component({
+        template: 'test'
+      })
+      class TestComponent {
+        @Output('onChange') change = new EventEmitter<void>();
+        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      }
+      `,
       messageId,
     }),
     convertAnnotatedSourceToFailureCase({
       description:
         'should fail when a directive output property is renamed and its name is strictly equal to the property',
       annotatedSource: `
+      import { Output } from '@angular/core';
       @Component({
         template: 'test'
       })
@@ -68,6 +85,7 @@ ruleTester.run(RULE_NAME, rule, {
       description:
         "should fail when the directive's selector matches exactly both property name and the alias",
       annotatedSource: `
+      import { Output } from '@angular/core';
       @Directive({
         selector: '[test], foo'
       })


### PR DESCRIPTION
In addition to the original no-input-rename rule behavior of codelyzer, I added check for the names of setters.
Since the use of RegExp `/\p{L}\S*/gu` seems not necessary (at least the necessity is not obviously shown in the tests in codelyzer), I got rid of it.

I also made sure that `Input` is imported from `@angular/core` and also fixed `no-output-rename` rule accordingly.