### PR TITLE
feat(eslint-plugin): add no-input-prefix rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ If you are interested in creating this, we would be very grateful to receive a P
 | [`component-max-inline-declarations`] | :white_check_mark: |
 | [`no-conflicting-lifecycle`]          | :white_check_mark: |
 | [`no-forward-ref`]                    | :white_check_mark: |
-| [`no-input-prefix`]                   |                    |
+| [`no-input-prefix`]                   | :white_check_mark: |
 | [`no-input-rename`]                   | :white_check_mark: |
 | [`no-output-on-prefix`]               | :white_check_mark: |
 | [`no-output-rename`]                  | :white_check_mark: |
@@ -190,5 +190,7 @@ If you are interested in creating this, we would be very grateful to receive a P
 [`use-pipe-transform-interface`]: https://codelyzer.com/rules/use-pipe-transform-interface
 
 <!-- PR Links -->
+
+[`pr55`]: https://api.github.com/repos/angular-eslint/angular-eslint/pulls/55
 
 <!-- end rule list -->

--- a/packages/eslint-plugin/src/index.ts
+++ b/packages/eslint-plugin/src/index.ts
@@ -25,6 +25,9 @@ import noForwardRef, {
 import noHostMetadataProperty, {
   RULE_NAME as noHostMetadataPropertyRuleName,
 } from './rules/no-host-metadata-property';
+import noInputPrefix, {
+  RULE_NAME as noInputPrefixRuleName,
+} from './rules/no-input-prefix';
 import noInputRename, {
   RULE_NAME as noInputRenameRuleName,
 } from './rules/no-input-rename';
@@ -91,6 +94,7 @@ export default {
     [noConflictingLifecycleRuleName]: noConflictingLifecycle,
     [noForwardRefRuleName]: noForwardRef,
     [noHostMetadataPropertyRuleName]: noHostMetadataProperty,
+    [noInputPrefixRuleName]: noInputPrefix,
     [noInputRenameRuleName]: noInputRename,
     [noInputsMetadataPropertyRuleName]: noInputsMetadataProperty,
     [noLifecycleCallRuleName]: noLifecycleCall,

--- a/packages/eslint-plugin/src/rules/no-input-prefix.ts
+++ b/packages/eslint-plugin/src/rules/no-input-prefix.ts
@@ -1,0 +1,85 @@
+import { TSESTree } from '@typescript-eslint/experimental-utils';
+import { createESLintRule } from '../utils/create-eslint-rule';
+import { getClassPropertyName, isImportedFrom } from '../utils/utils';
+
+type Options = [
+  {
+    prefixes: string[];
+  },
+];
+export type MessageIds = 'noInputPrefix';
+export const RULE_NAME = 'no-input-prefix';
+
+export default createESLintRule<Options, MessageIds>({
+  name: RULE_NAME,
+  meta: {
+    type: 'suggestion',
+    docs: {
+      description:
+        'Input names should not be prefixed by the configured disallowed prefixes.',
+      category: 'Best Practices',
+      recommended: false,
+    },
+    schema: [
+      {
+        type: 'object',
+        properties: {
+          prefixes: {
+            type: 'array',
+            items: {
+              type: 'string',
+            },
+          },
+        },
+        additionalProperties: false,
+      },
+    ],
+    messages: {
+      noInputPrefix: `@Inputs should not be prefixed by {{disallowedPrefixes}}`,
+    },
+  },
+  defaultOptions: [
+    {
+      prefixes: [],
+    },
+  ],
+  create(context, [options]) {
+    return {
+      ':matches(ClassProperty, MethodDefinition[kind="set"]) > Decorator[expression.callee.name="Input"]'(
+        node: TSESTree.Decorator,
+      ) {
+        const inputCallExpression = node.expression as TSESTree.CallExpression;
+
+        if (
+          !isImportedFrom(
+            inputCallExpression.callee as TSESTree.Identifier,
+            '@angular/core',
+          )
+        ) {
+          return;
+        }
+
+        const property = node.parent as TSESTree.ClassProperty;
+        const memberName = getClassPropertyName(property);
+
+        const disallowedPrefixes = options.prefixes;
+
+        const isDisallowedPrefix = disallowedPrefixes.some(
+          x => x === memberName || new RegExp(`^${x}[^a-z]`).test(memberName),
+        );
+
+        if (!isDisallowedPrefix) {
+          return;
+        }
+
+        context.report({
+          node: property,
+          messageId: 'noInputPrefix',
+          data: {
+            disallowedPrefixes: disallowedPrefixes.join(', '),
+          },
+        });
+      },
+    };
+  },
+});

--- a/packages/eslint-plugin/tests/rules/no-input-prefix.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-input-prefix.test.ts
@@ -1,0 +1,149 @@
+import rule, { MessageIds, RULE_NAME } from '../../src/rules/no-input-prefix';
+import {
+  convertAnnotatedSourceToFailureCase,
+  RuleTester,
+} from '../test-helper';
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+const ruleTester = new RuleTester({
+  parser: '@typescript-eslint/parser',
+  parserOptions: {
+    sourceType: 'module',
+  },
+});
+
+const messageId: MessageIds = 'noInputPrefix';
+
+ruleTester.run(RULE_NAME, rule, {
+  valid: [
+    {
+      code: `
+        import { Input } from '@angular/core';
+        @Component()
+        class TestComponent {
+          @Input() label: string;
+        }
+      `,
+      options: [
+        {
+          prefixes: ['is'],
+        },
+      ],
+    },
+    {
+      code: `
+        import { Input } from '@angular/core';
+        @Component()
+        class TestComponent {
+          @Input() issueName: string;
+        }
+      `,
+      options: [
+        {
+          prefixes: ['is'],
+        },
+      ],
+    },
+    {
+      code: `
+        import { Input } from '@angular/core';
+        @Component()
+        class TestComponent {
+          @Input() isEnabled: boolean;
+        }
+      `,
+      options: [
+        {
+          prefixes: ['should'],
+        },
+      ],
+    },
+    {
+      code: `
+        import { Output } from '@angular/core';
+        @Component()
+        class TestComponent {
+          @Output() isEnabled: boolean;
+        }
+      `,
+      options: [
+        {
+          prefixes: ['is'],
+        },
+      ],
+    },
+    // should succeed when an Input decorator is not imported from '@angular/core'
+    {
+      code: `
+        @Component()
+        class TestComponent {
+          @Input() isEnabled: boolean;
+        }
+      `,
+      options: [
+        {
+          prefixes: ['is'],
+        },
+      ],
+    },
+  ],
+  invalid: [
+    convertAnnotatedSourceToFailureCase({
+      description:
+        'it should fail when a component input property is named with a disallowed prefix',
+      annotatedSource: `
+        import { Input } from '@angular/core';
+        @Component()
+        class TestComponent {
+          @Input() isEnabled: string;
+          ~~~~~~~~~~~~~~~~~~~~~~~~~~~
+        }
+      `,
+      messageId,
+      options: [
+        {
+          prefixes: ['is', 'should'],
+        },
+      ],
+    }),
+    convertAnnotatedSourceToFailureCase({
+      description:
+        'it should fail when a component input property is named with a disallowed prefix',
+      annotatedSource: `
+        import { Input } from '@angular/core';
+        @Component()
+        class TestComponent {
+          @Input() shouldLoad: string;
+          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+        }
+      `,
+      messageId,
+      options: [
+        {
+          prefixes: ['is', 'should'],
+        },
+      ],
+    }),
+    convertAnnotatedSourceToFailureCase({
+      description:
+        'it should fail when a component input property is named with a disallowed prefix',
+      annotatedSource: `
+        import { Input } from '@angular/core';
+        @Component()
+        class TestComponent {
+          @Input() is: string;
+          ~~~~~~~~~~~~~~~~~~~~
+        }
+      `,
+      messageId,
+      options: [
+        {
+          prefixes: ['is', 'should'],
+        },
+      ],
+    }),
+  ],
+});


### PR DESCRIPTION
Two small changes from the rule on Codelyzer:
- To be consistent with the message on the other rules, the error message is:
`@Inputs should not be prefixed by foo, bar` instead of `@Inputs should not be prefixed by "foo", or "bar"`
- The prefixes are configured on a `prefixes` object:
```
        "@angular-eslint/no-input-prefix": ["error", {
            prefixes: ['test'],
        }],
```

Instead of being an array like on Codelyzer.

Please tell me if I should change something. This is my first PR so I am not sure of the preferred ways to do things here. 😄 

**References**
https://github.com/mgechev/codelyzer/blob/master/docs/rules/no-input-prefix/index.html
https://github.com/mgechev/codelyzer/blob/master/src/noInputPrefixRule.ts

---

Also, I think we may have an issue with Windows development. When I run `yarn format:check` on my Win10 I get that the *.json and *.md files are not formatted correctly.

My VSCode says that these files have the line ending as `CRLF`, and after running `yarn format` they change to `LF`.

I skipped this validation to be able to push, but should I run prettier on my machine and commit the changes to the repo?