### PR TITLE
fix(integration-tests): uncomment converted rule

### DIFF
--- a/packages/integration-tests/fixtures/angular-cli-workspace/.eslintrc.js
+++ b/packages/integration-tests/fixtures/angular-cli-workspace/.eslintrc.js
@@ -39,10 +39,7 @@ module.exports = {
         '@angular-eslint/contextual-lifecycle': 'error',
 
         // ORIGINAL tslint.json -> "directive-class-suffix": true,
-        /**
-         * TODO: Not converted yet
-         */
-        // '@angular-eslint/directive-class-suffix': 'error'
+        '@angular-eslint/directive-class-suffix': 'error',
 
         // ORIGINAL tslint.json -> "directive-selector": [true, "attribute", "app", "camelCase"],
         '@angular-eslint/directive-selector': [


### PR DESCRIPTION
According to https://github.com/angular-eslint/angular-eslint/pull/51 `directive-class-suffix` is converted and no longer TODO