### PR TITLE
feat(builder): add ignorePath option

### DIFF
--- a/packages/builder/src/index.ts
+++ b/packages/builder/src/index.ts
@@ -201,6 +201,7 @@ async function _lint(
     useEslintrc: false,
     fix: !!options.fix,
     cache: !!options.cache,
+    ignorePath: options.ignorePath,
   });
 
   const lintReports: eslint.CLIEngine.LintReport[] = [];

--- a/packages/builder/src/schema.json
+++ b/packages/builder/src/schema.json
@@ -80,6 +80,10 @@
         },
         { "minLength": 1 }
       ]
+    },
+    "ignorePath": {
+      "type": "string",
+      "description": "The path of the ignore file."
     }
   },
   "additionalProperties": false,


### PR DESCRIPTION
Related to #26 

**Behavior**
- If ignorePath is not set on `angular.json` and `.eslintignore` does exists, the linter will proceed as usual
- If ignorePath is not set on `angular.json` but `.eslintignore` exists, then the files mentioned on the file will be ignored
- If ignorePath is set on `angular.json` then the custom ignore file will be used instead of `.eslintignore`, note that this file must exist or eslint will throw an error, even if you set as `.eslintignore`

**Considerations**
- Should I add tests on `integration-tests`?
- The name of the option on eslint is `ignorePath`, I personally find it kinda confusing but decided to keep it since changing could cause other types of confusion... 