### PR TITLE
fix(eslint-plugin): improve regular expression

### DIFF
--- a/packages/eslint-plugin-template/src/processors.ts
+++ b/packages/eslint-plugin-template/src/processors.ts
@@ -1,7 +1,7 @@
 import ts from 'typescript';
 
 function quickExtractComponentDecorator(text: string) {
-  const matches = text.match(/@Component\({(\s.*\s)*}\)/);
+  const matches = text.match(/@Component\s*\(\s*{(?:(?!}\s*\))(?:\s|.))*}\s*\)/);
   if (!matches || !matches.length) {
     return null;
   }


### PR DESCRIPTION
fixes #68

Attempting to match TS with a regex is a folly, but this should perform better.