### PR TITLE
docs: add an example config to main docs for template linting

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,42 @@ Please follow the links below for the packages you care about.
 
 <br>
 
+### Linting templates with Angular ESLint
+
+You can change the parser in the main section of your eslint config file to the template parser in this project. The rules in /template will then be available to use in your main config section. If any rules in OTHER packages then complain about not having access to the parser they need, you can add an 'overrides' section to your config specifically for the template rules instead, e.g.:
+
+```json
+// ... more config
+"overrides": [
+    {
+      "files": ["*.component.html"],
+      "parser": "@angular-eslint/template-parser",
+      "plugins": ["@angular-eslint/template"],
+      "rules": {
+        "@angular-eslint/template/banana-in-a-box": "error",
+        "@angular-eslint/template/cyclomatic-complexity": "error",
+        "@angular-eslint/template/no-call-expression": "error",
+        "@angular-eslint/template/no-negated-async": "error",
+        "@angular-eslint/template/i18n": [
+          "error",
+          {
+            "checkId": false,
+            "checkText": true,
+            "checkAttributes": true,
+            "ignoreAttributes": [
+              "field",
+              "identifier"
+            ]
+          }
+        ]
+      }
+    }
+  ]
+// ... more config
+```
+
+<br>
+
 ### Linting inline-templates with the VSCode extension for ESLint
 
 If you use vscode-eslint, and inline-templates on your Angular Components, you will need to make sure you add the following to your VSCode settings:


### PR DESCRIPTION
I upgraded my Angular Dev environment from 7 to 9 earlier this week and I moved from TSLint to ESLint at the same time.  I had some Codelyzer rules that need the eslint rule that converts tslint rules to eslint rules.  That package requires a specific parser that parser is not compatible with the template rules in this project.

It took me too long (I nearly gave up) to figure out the correct config to get your amazing project to work correctly.  I believe if this snippet (which I took from your own source code) is added to your main doc then it will help others start using your project more quickly and easily.  Hope you agree.