### PR TITLE
feat(eslint-plugin-template): possible new template-i18n rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ If you are looking for general help in migrating from TSLint to ESLint, you can 
 | [`relative-url-prefix`]               | :white_check_mark: |
 | [`template-conditional-complexity`]   |                    |
 | [`template-cyclomatic-complexity`]    | :white_check_mark: |
-| [`template-i18n`]                     |                    |
+| [`template-i18n`]                     | :white_check_mark: |
 | [`template-no-call-expression`]       | :white_check_mark: |
 | [`template-use-track-by-function`]    |                    |
 | [`use-component-selector`]            | :white_check_mark: |

--- a/packages/eslint-plugin-template/src/index.ts
+++ b/packages/eslint-plugin-template/src/index.ts
@@ -11,6 +11,7 @@ import noCallExpression, {
 import noNegatedAsync, {
   RULE_NAME as noNegatedAsyncRuleName,
 } from './rules/no-negated-async';
+import i18n, { RULE_NAME as i18nRuleName } from './rules/i18n';
 
 export default {
   processors,
@@ -19,5 +20,6 @@ export default {
     [cyclomaticComplexityRuleName]: cyclomaticComplexity,
     [noCallExpressionRule]: noCallExpression,
     [noNegatedAsyncRuleName]: noNegatedAsync,
+    [i18nRuleName]: i18n,
   },
 };

--- a/packages/eslint-plugin-template/src/rules/i18n.ts
+++ b/packages/eslint-plugin-template/src/rules/i18n.ts
@@ -1,0 +1,247 @@
+import {
+  createESLintRule,
+  getTemplateParserServices,
+} from '../utils/create-eslint-rule';
+
+const TEXT_TYPE_NAMES = ['Text', 'BoundText', 'Icu'];
+const ATTRIB_I18N = 'i18n';
+const DEFAULT_IGNORE_ATTRIBUTES = [
+  'class',
+  'style',
+  'color',
+  'svgIcon',
+  'href',
+  'src',
+  'id',
+  'lang',
+  'charset',
+  'height',
+  'width',
+  'target',
+  'type',
+  'colspan',
+  'uiSref',
+  'uiSrefActive',
+  'ui-view',
+  'xmlns',
+  'stroke-width',
+  'stroke',
+  'fill',
+  'viewBox',
+  'tabindex',
+  'formControlName',
+];
+
+type Options = [
+  {
+    checkId?: boolean;
+    checkText?: boolean;
+    checkAttributes?: boolean;
+    ignoreAttributes?: string[];
+  },
+];
+
+const defaultOptions = {
+  checkId: true,
+  checkText: true,
+  checkAttributes: true,
+  ignoreAttributes: [''],
+};
+
+export type MessageIds =
+  | 'i18nId'
+  | 'i18nText'
+  | 'i18nAttrib'
+  | 'i18nIdOnAttrib'
+  | 'i18nSuggestIgnore';
+export const RULE_NAME = 'i18n';
+
+export default createESLintRule<Options, MessageIds>({
+  name: RULE_NAME,
+  meta: {
+    type: 'suggestion',
+    docs: {
+      description:
+        'Helps to ensure following best practices for i18n. ' +
+        'Checks for missing i18n attributes on elements and non-ignored attributes ' +
+        'containing text. Can also highlight tags that do not use Custom ID (@@) feature. ' +
+        'Default Config = ' +
+        JSON.stringify(defaultOptions),
+      category: 'Best Practices',
+      recommended: false,
+      // url: '',  // Not sure why we are excluding this, it is in the docs at eslint
+    },
+    fixable: 'code',
+    schema: [
+      {
+        type: 'object',
+        properties: {
+          checkId: {
+            type: 'boolean',
+          },
+          checkText: {
+            type: 'boolean',
+          },
+          checkAttributes: {
+            type: 'boolean',
+          },
+          ignoreAttributes: {
+            type: 'array',
+            items: {
+              type: 'string',
+            },
+          },
+        },
+        additionalProperties: false,
+      },
+    ],
+    messages: {
+      i18nId:
+        'Missing custom message identifier. ' +
+        'For more information visit https://angular.io/guide/i18n#use-a-custom-id-with-a-description',
+      i18nIdOnAttrib:
+        "Missing custom message identifier on attribute '{{attribName}}'. " +
+        'For more information visit https://angular.io/guide/i18n#use-a-custom-id-with-a-description',
+      i18nText:
+        'Each element containing text node should have an i18n attribute. ' +
+        'See https://angular.io/guide/i18n',
+      i18nAttrib:
+        "Attribute '{{attribName}}' has no corresponding i18n attribute. " +
+        'See https://angular.io/guide/i18n#translate-attributes',
+      i18nSuggestIgnore:
+        "Add the attribute name '{{attribName}}' to the ignoreAttributes option in the eslint config.",
+    },
+  },
+  defaultOptions: [defaultOptions],
+  create(context, [options]) {
+    const parserServices = getTemplateParserServices(context);
+    const sourceCode = context.getSourceCode();
+    const { checkId, checkText, checkAttributes, ignoreAttributes } = options;
+
+    // build a big list of attributes to ignore
+    const allIgnoredAttribs: string[] = DEFAULT_IGNORE_ATTRIBUTES;
+    if (ignoreAttributes) {
+      allIgnoredAttribs.push(...ignoreAttributes);
+    }
+
+    function isSizeOrNumber(value: string) {
+      let temp = value;
+      if (temp.endsWith('px')) {
+        temp = temp.substr(0, temp.length - 2);
+      }
+      return String(Number(temp)) === String(temp);
+    }
+
+    function checkNode(node: any, name: string): void {
+      const loc = parserServices.convertNodeSourceSpanToLoc(node.sourceSpan);
+      const startIndex = sourceCode.getIndexFromLoc(loc.start);
+      let insertIndex = startIndex + 1;
+      if (!name) {
+        console.log(node);
+      } else {
+        insertIndex += name.length;
+      }
+
+      // Check all of the text attributes on the element
+      node.attributes.forEach((attrib: any) => {
+        if (attrib.i18n) {
+          if (checkId && !attrib.i18n.customId) {
+            // i18n attribute does not contain '@@'
+            // see https://angular.io/guide/i18n#use-a-custom-id-with-a-description
+            context.report({
+              messageId: 'i18nIdOnAttrib',
+              loc,
+              data: {
+                attribName: attrib.name,
+              },
+            });
+          }
+        } else {
+          if (
+            checkAttributes &&
+            attrib.value &&
+            typeof attrib.value === 'string' &&
+            attrib.value.length > 0 &&
+            attrib.value !== 'true' &&
+            attrib.value !== 'false' &&
+            !isSizeOrNumber(attrib.value) &&
+            !attrib.name.startsWith(':xml') &&
+            !allIgnoredAttribs.includes(attrib.name)
+          ) {
+            context.report({
+              messageId: 'i18nAttrib',
+              loc,
+              data: {
+                attribName: attrib.name,
+              },
+              fix: fixer =>
+                fixer.replaceTextRange(
+                  [insertIndex, insertIndex],
+                  ' ' + ATTRIB_I18N + '-' + attrib.name,
+                ),
+              suggest: [
+                {
+                  messageId: 'i18nSuggestIgnore',
+                  data: {
+                    attribName: attrib.name,
+                  },
+                  fix: () => null,
+                },
+              ],
+            });
+          }
+        }
+      });
+
+      if (node.i18n) {
+        // if this element already has i18n
+        if (checkId) {
+          if (!node.i18n.customId) {
+            // i18n attribute does not contain '@@'
+            // see https://angular.io/guide/i18n#use-a-custom-id-with-a-description
+            context.report({
+              messageId: 'i18nId',
+              loc,
+            });
+          }
+        }
+      } else {
+        // No i18n attribute here!
+
+        if (checkText) {
+          // Attempted to check for child nodes that also include i18n
+          // however these throw a template parser error before the linter
+          // is allowed to run, so no need!
+
+          // Need to check the children
+          if (
+            node.children &&
+            node.children.some((child: any) =>
+              TEXT_TYPE_NAMES.includes(child.type),
+            )
+          ) {
+            // If at least one child is a text node then we probably need i18n
+            context.report({
+              messageId: 'i18nText',
+              loc,
+              fix: fixer =>
+                fixer.replaceTextRange(
+                  [insertIndex, insertIndex],
+                  ' ' + ATTRIB_I18N,
+                ),
+            });
+          }
+        }
+      }
+    }
+
+    return parserServices.defineTemplateBodyVisitor({
+      Element(node: any) {
+        checkNode(node, node.name);
+      },
+      Template(node: any) {
+        checkNode(node, node.tagName);
+      },
+    });
+  },
+});

--- a/packages/eslint-plugin-template/src/rules/i18n.ts
+++ b/packages/eslint-plugin-template/src/rules/i18n.ts
@@ -185,7 +185,9 @@ export default createESLintRule<Options, MessageIds>({
                   data: {
                     attribName: attrib.name,
                   },
-                  fix: () => null,
+                  // Little bit of a hack,
+                  // but VS code ignores suggestions with no fix!?
+                  fix: fixer => fixer.insertTextBeforeRange([0, 0], ''),
                 },
               ],
             });

--- a/packages/eslint-plugin-template/tests/rules/i18n.test.ts
+++ b/packages/eslint-plugin-template/tests/rules/i18n.test.ts
@@ -73,7 +73,13 @@ ruleTester.run(RULE_NAME, rule, {
           placeholder="More translation, please"
           class="red"
         >
-          <span i18n>Some text to translate</span>
+          <div
+            *ngIf="true"
+            width="100px"
+            label="Templates need translation too."
+          >
+            <span i18n>Some text to translate</span>
+          </div>
         </div>`,
       errors: [
         {
@@ -87,9 +93,19 @@ ruleTester.run(RULE_NAME, rule, {
           column: 9,
         },
         {
-          messageId: i18nId,
+          messageId: i18nAttrib,
           line: 8,
           column: 11,
+        },
+        {
+          messageId: i18nAttrib,
+          line: 8,
+          column: 11,
+        },
+        {
+          messageId: i18nId,
+          line: 13,
+          column: 13,
         },
       ],
       output: `
@@ -99,7 +115,13 @@ ruleTester.run(RULE_NAME, rule, {
           placeholder="More translation, please"
           class="red"
         >
-          <span i18n>Some text to translate</span>
+          <div i18n-label
+            *ngIf="true"
+            width="100px"
+            label="Templates need translation too."
+          >
+            <span i18n>Some text to translate</span>
+          </div>
         </div>`,
     },
   ],

--- a/packages/eslint-plugin-template/tests/rules/i18n.test.ts
+++ b/packages/eslint-plugin-template/tests/rules/i18n.test.ts
@@ -1,0 +1,106 @@
+import {
+  convertAnnotatedSourceToFailureCase,
+  RuleTester,
+} from '@angular-eslint/utils';
+import rule, { MessageIds, RULE_NAME } from '../../src/rules/i18n';
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+const ruleTester = new RuleTester({
+  parser: '@angular-eslint/template-parser',
+});
+
+const i18nId: MessageIds = 'i18nId';
+const i18nText: MessageIds = 'i18nText';
+const i18nAttrib: MessageIds = 'i18nAttrib';
+const i18nIdOnAttrib: MessageIds = 'i18nIdOnAttrib';
+
+ruleTester.run(RULE_NAME, rule, {
+  valid: [
+    {
+      filename: 'test.component.html',
+      code: `
+        <div>
+          <span i18n="@@my-custom-id">Some text to translate</span>
+        </div>`,
+    },
+    {
+      filename: 'test.component.html',
+      code: `
+      <div
+        i18n-tooltip="@@my-custom-id"
+        tooltip="This also requires translation"
+      >
+        <span i18n="@@my-custom-id">Some text to translate</span>
+      </div>`,
+    },
+    {
+      filename: 'test.component.html',
+      code: `
+        <div>
+          <span
+            class="red"
+            i18n="@@my-custom-id"
+          >
+            Some text to translate
+          </span>
+        </div>`,
+    },
+  ],
+  invalid: [
+    convertAnnotatedSourceToFailureCase({
+      description: 'it should fail if i18n is missing',
+      annotatedSource: `
+        <div>
+          <span>Some text to translate</span>
+          ~~~~~~
+        </div>`,
+      messageId: i18nText,
+      annotatedOutput: `
+        <div>
+          <span i18n>Some text to translate</span>
+          ~~~~~~~~~~~
+        </div>`,
+    }),
+    {
+      filename: 'test.component.html',
+      code: `
+        <div
+          tooltip="This also requires translation"
+          i18n-placeholder
+          placeholder="More translation, please"
+          class="red"
+        >
+          <span i18n>Some text to translate</span>
+        </div>`,
+      errors: [
+        {
+          messageId: i18nAttrib,
+          line: 2,
+          column: 9,
+        },
+        {
+          messageId: i18nIdOnAttrib,
+          line: 2,
+          column: 9,
+        },
+        {
+          messageId: i18nId,
+          line: 8,
+          column: 11,
+        },
+      ],
+      output: `
+        <div i18n-tooltip
+          tooltip="This also requires translation"
+          i18n-placeholder
+          placeholder="More translation, please"
+          class="red"
+        >
+          <span i18n>Some text to translate</span>
+        </div>`,
+    },
+  ],
+});

--- a/packages/eslint-plugin/src/configs/all.json
+++ b/packages/eslint-plugin/src/configs/all.json
@@ -39,6 +39,7 @@
       "rules": {
         "@angular-eslint/template/banana-in-a-box": "error",
         "@angular-eslint/template/cyclomatic-complexity": "error",
+        "@angular-eslint/template/i18n": "error",
         "@angular-eslint/template/no-call-expression": "error",
         "@angular-eslint/template/no-negated-async": "error"
       }


### PR DESCRIPTION
inspiration from Codelyzer, re-written for es-lint

Have done my best to follow your banana-in-a-box template rule and created an i18n rule, which I quite liked from Codelyzer.  Have made a few tweaks (dare I say improvements?).

Let me know if you want anything changed. (I'm not very experienced at writing tests, but these do pass and the rule functions nicely on my own codebase)

Cheers