### PR TITLE
fix(eslint-plugin-template): rename banana-in-a-box to banana-in-box

### DIFF
--- a/packages/eslint-plugin-template/src/configs/all.json
+++ b/packages/eslint-plugin-template/src/configs/all.json
@@ -1,7 +1,7 @@
 {
   "extends": "./configs/base.json",
   "rules": {
-    "@angular-eslint/template/banana-in-a-box": "error",
+    "@angular-eslint/template/banana-in-box": "error",
     "@angular-eslint/template/cyclomatic-complexity": "error",
     "@angular-eslint/template/no-call-expression": "error",
     "@angular-eslint/template/no-negated-async": "error"

--- a/packages/eslint-plugin-template/src/configs/recommended.json
+++ b/packages/eslint-plugin-template/src/configs/recommended.json
@@ -1,7 +1,7 @@
 {
   "extends": "./configs/base.json",
   "rules": {
-    "@angular-eslint/template/banana-in-a-box": "error",
+    "@angular-eslint/template/banana-in-box": "error",
     "@angular-eslint/template/no-negated-async": "error"
   }
 }

--- a/packages/eslint-plugin-template/src/index.ts
+++ b/packages/eslint-plugin-template/src/index.ts
@@ -3,9 +3,9 @@ import base from './configs/base.json';
 import recommended from './configs/recommended.json';
 import processInlineTemplates from './configs/process-inline-templates.json';
 import processors from './processors';
-import bananaInABox, {
-  RULE_NAME as bananaInABoxRuleName,
-} from './rules/banana-in-a-box';
+import bananaInBox, {
+  RULE_NAME as bananaInBoxRuleName,
+} from './rules/banana-in-box';
 import cyclomaticComplexity, {
   RULE_NAME as cyclomaticComplexityRuleName,
 } from './rules/cyclomatic-complexity';
@@ -25,7 +25,7 @@ export default {
   },
   processors,
   rules: {
-    [bananaInABoxRuleName]: bananaInABox,
+    [bananaInBoxRuleName]: bananaInBox,
     [cyclomaticComplexityRuleName]: cyclomaticComplexity,
     [noCallExpressionRule]: noCallExpression,
     [noNegatedAsyncRuleName]: noNegatedAsync,

--- a/packages/eslint-plugin-template/src/rules/banana-in-box.ts
+++ b/packages/eslint-plugin-template/src/rules/banana-in-box.ts
@@ -4,8 +4,8 @@ import {
 } from '../utils/create-eslint-rule';
 
 type Options = [];
-export type MessageIds = 'bananaInABox';
-export const RULE_NAME = 'banana-in-a-box';
+export type MessageIds = 'bananaInBox';
+export const RULE_NAME = 'banana-in-box';
 
 const INVALID_PATTERN = /\[(.*)\]/;
 const VALID_CLOSE_BOX = ')]';
@@ -23,7 +23,7 @@ export default createESLintRule<Options, MessageIds>({
     fixable: 'code',
     schema: [],
     messages: {
-      bananaInABox: 'Invalid binding syntax. Use [(expr)] instead',
+      bananaInBox: 'Invalid binding syntax. Use [(expr)] instead',
     },
   },
   defaultOptions: [],
@@ -45,7 +45,7 @@ export default createESLintRule<Options, MessageIds>({
         const startIndex = sourceCode.getIndexFromLoc(loc.start);
 
         context.report({
-          messageId: 'bananaInABox',
+          messageId: 'bananaInBox',
           loc,
           fix: (fixer) =>
             fixer.replaceTextRange(

--- a/packages/eslint-plugin-template/tests/rules/banana-in-box.test.ts
+++ b/packages/eslint-plugin-template/tests/rules/banana-in-box.test.ts
@@ -2,7 +2,7 @@ import {
   convertAnnotatedSourceToFailureCase,
   RuleTester,
 } from '@angular-eslint/utils';
-import rule, { MessageIds, RULE_NAME } from '../../src/rules/banana-in-a-box';
+import rule, { MessageIds, RULE_NAME } from '../../src/rules/banana-in-box';
 
 //------------------------------------------------------------------------------
 // Tests
@@ -12,7 +12,7 @@ const ruleTester = new RuleTester({
   parser: '@angular-eslint/template-parser',
 });
 
-const messageId: MessageIds = 'bananaInABox';
+const messageId: MessageIds = 'bananaInBox';
 
 ruleTester.run(RULE_NAME, rule, {
   valid: [

--- a/packages/integration-tests/tests/__snapshots__/integration.ts.snap
+++ b/packages/integration-tests/tests/__snapshots__/integration.ts.snap
@@ -25,10 +25,10 @@ __ROOT__/angular-cli-workspace/src/app/example.component.ts
   13:3   error  Use @Output rather than the \`outputs\` metadata property (https://angular.io/styleguide#style-05-12)  @angular-eslint/no-outputs-metadata-property
   14:3   error  Use @Output rather than the \`host\` metadata property (https://angular.io/styleguide#style-05-12)     @angular-eslint/no-host-metadata-property
   18:3   error  In the class \\"ExampleComponent\\", the output property \\"onFoo\\" should not be prefixed with on          @angular-eslint/no-output-on-prefix
-   6:35  error  Invalid binding syntax. Use [(expr)] instead                                                         @angular-eslint/template/banana-in-a-box
-   8:15  error  Invalid binding syntax. Use [(expr)] instead                                                         @angular-eslint/template/banana-in-a-box
-   8:29  error  Invalid binding syntax. Use [(expr)] instead                                                         @angular-eslint/template/banana-in-a-box
-   9:48  error  Invalid binding syntax. Use [(expr)] instead                                                         @angular-eslint/template/banana-in-a-box
+   6:35  error  Invalid binding syntax. Use [(expr)] instead                                                         @angular-eslint/template/banana-in-box
+   8:15  error  Invalid binding syntax. Use [(expr)] instead                                                         @angular-eslint/template/banana-in-box
+   8:29  error  Invalid binding syntax. Use [(expr)] instead                                                         @angular-eslint/template/banana-in-box
+   9:48  error  Invalid binding syntax. Use [(expr)] instead                                                         @angular-eslint/template/banana-in-box
 
 ✖ 9 problems (9 errors, 0 warnings)
   5 errors and 0 warnings potentially fixable with the \`--fix\` option.
@@ -41,7 +41,7 @@ __ROOT__/angular-cli-workspace/src/app/example.pipe.ts
 
 
 __ROOT__/angular-cli-workspace/src/app/app.component.html
-  1:31  error  Invalid binding syntax. Use [(expr)] instead  @angular-eslint/template/banana-in-a-box
+  1:31  error  Invalid binding syntax. Use [(expr)] instead  @angular-eslint/template/banana-in-box
 
 ✖ 1 problem (1 error, 0 warnings)
   1 error and 0 warnings potentially fixable with the \`--fix\` option.

--- a/tools/scripts/generate-rules-list/generate-rules-list.ts
+++ b/tools/scripts/generate-rules-list/generate-rules-list.ts
@@ -10,7 +10,7 @@ import { CodelyzerRule, PRDetails, RuleDetails } from './interfaces';
  * Stores a mapping from codelyzer rules to eslint rules that have changed name.
  */
 const RULE_MAP = {
-  'template-banana-in-box': 'banana-in-a-box',
+  'template-banana-in-box': 'banana-in-box',
 };
 
 /**


### PR DESCRIPTION
As stated in #134: Rename `banana-in-a-box` to `banana-in-box` to conform with:

1. [Codelyzer rule](http://codelyzer.com/rules/template-banana-in-box/) name
1. Rule [generated by `tslint-to-eslint-config`](https://github.com/typescript-eslint/tslint-to-eslint-config#usage)