### PR TITLE
fix(eslint-plugin): incorrect message for no-empty-lifecycle-method

### DIFF
--- a/packages/eslint-plugin/src/rules/no-empty-lifecycle-method.ts
+++ b/packages/eslint-plugin/src/rules/no-empty-lifecycle-method.ts
@@ -23,7 +23,7 @@ export default createESLintRule<Options, MessageIds>({
     },
     schema: [],
     messages: {
-      noEmptyLifecycleMethod: `Declaring {{methodName}} lifecycle method in a class is not recommended`,
+      noEmptyLifecycleMethod: `Lifecycle method {{methodName}} should not be empty`,
     },
   },
   defaultOptions: [],


### PR DESCRIPTION
Closes #181 
Closes #188 

Changes the message for the `no-empty-lifecycle-method` rule from
`Declaring {{methodName}} lifecycle method in a class is not recommended`
to
`Lifecycle method {{methodName}} should not be empty`