### PR TITLE
fix: components with inline templates and CRLF

### DIFF
--- a/packages/eslint-plugin-template/src/processors.ts
+++ b/packages/eslint-plugin-template/src/processors.ts
@@ -1,6 +1,7 @@
 import ts from 'typescript';
 
 function quickGetRangeForTemplate(text: string, template: string) {
+  text = text.replace(/\r\n/g, '\n');
   const start = text.indexOf(template);
   return [start, start + template.length];
 }

--- a/packages/eslint-plugin-template/tests/processors.test.ts
+++ b/packages/eslint-plugin-template/tests/processors.test.ts
@@ -259,6 +259,49 @@ describe('extract-inline-html', () => {
       });
     });
 
+    describe('components with inline templates and CRLF', () => {
+      let inlineTemplate = `\r\n
+        <div [style.height]="aBool ? '100px' : '200px'"></div>\r\n
+        <div [style]="{height: this.aBool ? '100px' : '200px'}"></div>\r\n
+        <div [style]="{height: '100px'}"></div>\r\n
+      `;
+
+      const testCases = [
+        {
+          input: `
+            import {Component} from '@angular/core';\r\n
+\r\n
+            @Component({\r\n
+              selector: 'app-root',\r\n
+              template: \`${inlineTemplate}\`,\r\n
+              styleUrls: ['./app.component.scss']\r\n
+            })\r\n
+            export class AppComponent {\r\n
+              public aBool = false;\r\n
+              public aStyle = {height: this.aBool ? '100px' : '200px'};\r\n
+            }\r\n
+        `,
+        },
+      ];
+
+      testCases.forEach((tc, i) => {
+        it(`should extract the inline HTML of components with inline templates, CASE: ${i}`, () => {
+          expect(
+            processors['extract-inline-html'].preprocess(
+              tc.input,
+              'test.component.ts',
+            ),
+          ).toEqual([
+            tc.input,
+            {
+              filename: 'inline-template-1.component.html',
+              text: inlineTemplate.replace(/\r\n/g, '\n'),
+            },
+          ]);
+        });
+      });
+    });
+
     /**
      * Currently explicitly unsupported...
      */


### PR DESCRIPTION
Fixes https://github.com/angular-eslint/angular-eslint/issues/185

> > I haven't been able to compile the full source yet
> 
> I'm not sure what you mean by this

I couldn't get `npm run build` in `/packages/eslint-plugin-template` working the other week for some reason... Today it worked and I manually verified that the compiled/build package with the fix works in my other project. 