### PR TITLE
fix(eslint-plugin-template): handle 'innerHtml' input properly

### DIFF
--- a/packages/eslint-plugin-template/src/rules/accessibility-elements-content.ts
+++ b/packages/eslint-plugin-template/src/rules/accessibility-elements-content.ts
@@ -42,7 +42,9 @@ export default createESLintRule<Options, MessageIds>({
 
         const hasInnerContent = node.inputs.some(
           (input: any) =>
-            input.name === 'innerHTML' || input.name === 'innerText',
+            input.name === 'innerHTML' ||
+            input.name === 'innerHtml' ||
+            input.name === 'innerText',
         );
 
         if (hasInnerContent) {

--- a/packages/eslint-plugin-template/src/rules/accessibility-elements-content.ts
+++ b/packages/eslint-plugin-template/src/rules/accessibility-elements-content.ts
@@ -1,3 +1,4 @@
+import { TmplAstElement } from '@angular/compiler';
 import {
   createESLintRule,
   getTemplateParserServices,
@@ -6,8 +7,11 @@ import {
 type Options = [];
 export type MessageIds = 'accessibilityElementsContent';
 export const RULE_NAME = 'accessibility-elements-content';
-
-const elements = ['h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'a', 'button'];
+const innerContentInputs: ReadonlySet<string> = new Set([
+  'innerHtml',
+  'innerHTML',
+  'innerText',
+]);
 
 export default createESLintRule<Options, MessageIds>({
   name: RULE_NAME,
@@ -29,36 +33,23 @@ export default createESLintRule<Options, MessageIds>({
     const parserServices = getTemplateParserServices(context);
 
     return {
-      Element(node: any) {
-        if (elements.indexOf(node.name) === -1) {
-          return;
-        }
-
-        const hasContent = node.children.length > 0;
-
-        if (hasContent) {
-          return;
-        }
-
-        const hasInnerContent = node.inputs.some(
-          (input: any) =>
-            input.name === 'innerHTML' ||
-            input.name === 'innerHtml' ||
-            input.name === 'innerText',
+      'Element[name=/^(a|button|h1|h2|h3|h4|h5|h6)$/][children.length=0]'({
+        inputs,
+        name: element,
+        sourceSpan,
+      }: TmplAstElement) {
+        const hasInnerContent = inputs.some(({ name }) =>
+          innerContentInputs.has(name),
         );
 
-        if (hasInnerContent) {
-          return;
-        }
+        if (hasInnerContent) return;
 
-        const loc = parserServices.convertNodeSourceSpanToLoc(node.sourceSpan);
+        const loc = parserServices.convertNodeSourceSpanToLoc(sourceSpan);
 
         context.report({
           loc,
           messageId: 'accessibilityElementsContent',
-          data: {
-            element: node.name,
-          },
+          data: { element },
         });
       },
     };

--- a/packages/eslint-plugin-template/tests/rules/accessibility-elements-content.test.ts
+++ b/packages/eslint-plugin-template/tests/rules/accessibility-elements-content.test.ts
@@ -21,7 +21,7 @@ ruleTester.run(RULE_NAME, rule, {
   valid: [
     '<h1>Heading Content!</h1>',
     '<h2><app-content></app-content></h2>',
-    '<h3 [innerHTML]="dangerouslySetHTML"></h3>',
+    '<h3 [innerHtml]="dangerouslySetHTML"></h3>',
     '<h4 [innerText]="text"></h4>',
     '<a>Anchor Content!</a>',
     '<a><app-content></app-content></a>',


### PR DESCRIPTION
**Current behavior**:

We can pass html content by using `innerHTML` and `innerHtml`. The later isn't currently ignored by the rule.

```html
<h3 [innerHtml]="dangerouslySetHTML"></h3>
~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

**Expected behavior**:

```html
<h3 [innerHtml]="dangerouslySetHTML"></h3> // Pass
```

<hr>

I also replaced conditionals by selectors to make it more readable and shorter.