### PR TITLE
fix(eslint-plugin): handle DoBootstrap correctly in lifecycle rules

### DIFF
--- a/packages/eslint-plugin/src/rules/contextual-decorator.ts
+++ b/packages/eslint-plugin/src/rules/contextual-decorator.ts
@@ -1,12 +1,11 @@
 import { TSESLint, TSESTree } from '@typescript-eslint/experimental-utils';
 
 import {
-  getDecoratorName,
-  isAngularClassDecorator,
   isAngularInnerClassDecorator,
-  isNotNullOrUndefined,
   AngularClassDecoratorKeys,
   ANGULAR_CLASS_DECORATOR_MAPPER,
+  getAngularClassDecorator,
+  getDecoratorName,
 } from '../utils/utils';
 import { createESLintRule } from '../utils/create-eslint-rule';
 
@@ -62,7 +61,7 @@ function validateNode(
     return;
   }
 
-  const classDecoratorName = getClassDecoratorName(classDeclaration);
+  const classDecoratorName = getAngularClassDecorator(classDeclaration);
 
   if (!classDecoratorName) {
     return;
@@ -85,15 +84,6 @@ function lookupTheClassDeclaration(
   }
 
   return null;
-}
-
-function getClassDecoratorName(
-  classDeclaration: TSESTree.ClassDeclaration,
-): AngularClassDecoratorKeys | undefined {
-  return (classDeclaration.decorators || [])
-    .map(getDecoratorName)
-    .filter(isNotNullOrUndefined)
-    .find(isAngularClassDecorator);
 }
 
 function validateDecorator(

--- a/packages/eslint-plugin/src/rules/no-empty-lifecycle-method.ts
+++ b/packages/eslint-plugin/src/rules/no-empty-lifecycle-method.ts
@@ -40,7 +40,7 @@ export default createESLintRule<Options, MessageIds>({
         if (!getAngularClassDecorator(classDeclaration)) return;
 
         context.report({
-          node,
+          node: node.key,
           messageId: 'noEmptyLifecycleMethod',
         });
       },

--- a/packages/eslint-plugin/src/rules/no-empty-lifecycle-method.ts
+++ b/packages/eslint-plugin/src/rules/no-empty-lifecycle-method.ts
@@ -1,11 +1,9 @@
 import { TSESTree } from '@typescript-eslint/experimental-utils';
 import { createESLintRule } from '../utils/create-eslint-rule';
-import { COMPONENT_OR_DIRECTIVE_CLASS_DECORATOR } from '../utils/selectors';
-
 import {
-  getDeclaredMethods,
-  getMethodName,
-  isAngularLifecycleMethod,
+  ANGULAR_LIFECYCLE_METHODS,
+  getAngularClassDecorator,
+  toPattern,
 } from '../utils/utils';
 
 type Options = [];
@@ -17,39 +15,34 @@ export default createESLintRule<Options, MessageIds>({
   meta: {
     type: 'suggestion',
     docs: {
-      description: 'Disallows declaring empty lifecycle hook methods',
+      description: 'Disallows declaring empty lifecycle methods',
       category: 'Best Practices',
       recommended: 'error',
     },
     schema: [],
     messages: {
-      noEmptyLifecycleMethod: `Lifecycle method {{methodName}} should not be empty`,
+      noEmptyLifecycleMethod: 'Lifecycle methods should not be empty',
     },
   },
   defaultOptions: [],
   create(context) {
-    const isMethodEmpty = (node: TSESTree.MethodDefinition): boolean => {
-      return !node.value.body || node.value.body.body.length === 0;
-    };
+    const angularLifecycleMethodsPattern = toPattern([
+      ...ANGULAR_LIFECYCLE_METHODS,
+    ]);
 
     return {
-      [COMPONENT_OR_DIRECTIVE_CLASS_DECORATOR](node: TSESTree.Decorator) {
-        const classParent = node.parent as TSESTree.ClassDeclaration;
-        const declaredMethods = getDeclaredMethods(classParent);
+      [`MethodDefinition[key.name=${angularLifecycleMethodsPattern}][value.body.body.length=0]`](
+        node: TSESTree.MethodDefinition,
+      ) {
+        const classDeclaration = node.parent!
+          .parent as TSESTree.ClassDeclaration;
 
-        for (const method of declaredMethods) {
-          const methodName = getMethodName(method);
-          if (!isAngularLifecycleMethod(methodName) || !isMethodEmpty(method))
-            continue;
+        if (!getAngularClassDecorator(classDeclaration)) return;
 
-          context.report({
-            node: method.key,
-            messageId: 'noEmptyLifecycleMethod',
-            data: {
-              methodName,
-            },
-          });
-        }
+        context.report({
+          node,
+          messageId: 'noEmptyLifecycleMethod',
+        });
       },
     };
   },

--- a/packages/eslint-plugin/src/rules/no-lifecycle-call.ts
+++ b/packages/eslint-plugin/src/rules/no-lifecycle-call.ts
@@ -22,12 +22,11 @@ export default createESLintRule<Options, MessageIds>({
   defaultOptions: [],
   create(context) {
     return {
-      MemberExpression: (node) => {
-        const {
-          object: { type: nodeObjectType },
-          parent,
-          property,
-        } = node;
+      MemberExpression: ({
+        object: { type: nodeObjectType },
+        parent,
+        property,
+      }) => {
         const isSuperCall = nodeObjectType === 'Super';
 
         if (

--- a/packages/eslint-plugin/src/rules/use-lifecycle-interface.ts
+++ b/packages/eslint-plugin/src/rules/use-lifecycle-interface.ts
@@ -27,7 +27,7 @@ export default createESLintRule<Options, MessageIds>({
     },
     schema: [],
     messages: {
-      useLifecycleInterface: `Lifecycle interface "{{interfaceName}}" should be implemented for method "{{methodName}}" (${STYLE_GUIDE_LINK})`,
+      useLifecycleInterface: `Lifecycle interface '{{interfaceName}}' should be implemented for method '{{methodName}}'. (${STYLE_GUIDE_LINK})`,
     },
   },
   defaultOptions: [],

--- a/packages/eslint-plugin/src/utils/utils.ts
+++ b/packages/eslint-plugin/src/utils/utils.ts
@@ -297,6 +297,15 @@ export const getDecorator = (
   );
 };
 
+export const getAngularClassDecorator = ({
+  decorators,
+}: TSESTree.ClassDeclaration): AngularClassDecoratorKeys | undefined => {
+  return decorators
+    ?.map(getDecoratorName)
+    .filter(isNotNullOrUndefined)
+    .find(isAngularClassDecorator);
+};
+
 export const getDecoratorArgument = (
   decorator: TSESTree.Decorator,
 ): TSESTree.ObjectExpression | undefined => {

--- a/packages/eslint-plugin/src/utils/utils.ts
+++ b/packages/eslint-plugin/src/utils/utils.ts
@@ -46,10 +46,11 @@ export enum AngularLifecycleInterfaces {
   AfterContentInit = 'AfterContentInit',
   AfterViewChecked = 'AfterViewChecked',
   AfterViewInit = 'AfterViewInit',
+  DoBootstrap = 'DoBootstrap',
+  DoCheck = 'DoCheck',
   OnChanges = 'OnChanges',
   OnDestroy = 'OnDestroy',
   OnInit = 'OnInit',
-  DoCheck = 'DoCheck',
 }
 
 export enum AngularLifecycleMethods {
@@ -57,10 +58,11 @@ export enum AngularLifecycleMethods {
   ngAfterContentInit = 'ngAfterContentInit',
   ngAfterViewChecked = 'ngAfterViewChecked',
   ngAfterViewInit = 'ngAfterViewInit',
+  ngDoBootstrap = 'ngDoBootstrap',
+  ngDoCheck = 'ngDoCheck',
   ngOnChanges = 'ngOnChanges',
   ngOnDestroy = 'ngOnDestroy',
   ngOnInit = 'ngOnInit',
-  ngDoCheck = 'ngDoCheck',
 }
 
 export const OPTION_STYLE_CAMEL_CASE = 'camelCase';
@@ -90,13 +92,42 @@ export const ANGULAR_CLASS_DECORATOR_LIFECYCLE_METHOD_MAPPER: ReadonlyMap<
   AngularClassDecoratorKeys,
   ReadonlySet<AngularLifecycleMethodKeys>
 > = new Map([
-  [AngularClassDecorators.Component, new Set(angularLifecycleMethodKeys)],
-  [AngularClassDecorators.Directive, new Set(angularLifecycleMethodKeys)],
+  [
+    AngularClassDecorators.Component,
+    new Set([
+      AngularLifecycleMethods.ngAfterContentChecked,
+      AngularLifecycleMethods.ngAfterContentInit,
+      AngularLifecycleMethods.ngAfterViewChecked,
+      AngularLifecycleMethods.ngAfterViewInit,
+      AngularLifecycleMethods.ngOnChanges,
+      AngularLifecycleMethods.ngOnDestroy,
+      AngularLifecycleMethods.ngOnInit,
+      AngularLifecycleMethods.ngDoCheck,
+    ]),
+  ],
+  [
+    AngularClassDecorators.Directive,
+    new Set([
+      AngularLifecycleMethods.ngAfterContentChecked,
+      AngularLifecycleMethods.ngAfterContentInit,
+      AngularLifecycleMethods.ngAfterViewChecked,
+      AngularLifecycleMethods.ngAfterViewInit,
+      AngularLifecycleMethods.ngOnChanges,
+      AngularLifecycleMethods.ngOnDestroy,
+      AngularLifecycleMethods.ngOnInit,
+      AngularLifecycleMethods.ngDoCheck,
+    ]),
+  ],
   [
     AngularClassDecorators.Injectable,
     new Set<AngularLifecycleMethodKeys>([AngularLifecycleMethods.ngOnDestroy]),
   ],
-  [AngularClassDecorators.NgModule, new Set<AngularLifecycleMethodKeys>([])],
+  [
+    AngularClassDecorators.NgModule,
+    new Set<AngularLifecycleMethodKeys>([
+      AngularLifecycleMethods.ngDoBootstrap,
+    ]),
+  ],
   [
     AngularClassDecorators.Pipe,
     new Set<AngularLifecycleMethodKeys>([AngularLifecycleMethods.ngOnDestroy]),

--- a/packages/eslint-plugin/src/utils/utils.ts
+++ b/packages/eslint-plugin/src/utils/utils.ts
@@ -579,3 +579,6 @@ export const getReadablePrefixes = (prefixes: string[]): string => {
     .slice(0, prefixesLength - 1)
     .join(', ')} or "${[...prefixes].pop()}"`;
 };
+
+export const toPattern = (value: readonly unknown[]) =>
+  RegExp(`^(${value.join('|')})$`);

--- a/packages/eslint-plugin/tests/rules/contextual-lifecycle.test.ts
+++ b/packages/eslint-plugin/tests/rules/contextual-lifecycle.test.ts
@@ -20,10 +20,10 @@ const messageId: MessageIds = 'contextuaLifecycle';
 ruleTester.run(RULE_NAME, rule, {
   valid: [
     `
-     @Injectable()
-     class Test {
+    @Injectable()
+    class Test {
       ngOnDestroy() { console.log('OnDestroy'); }
-     }
+    }
     `,
     `
     @Component()
@@ -127,6 +127,12 @@ ruleTester.run(RULE_NAME, rule, {
     }
     `,
     `
+    @NgModule()
+    class Test {
+      ngDoBootstrap() {}
+    }
+    `,
+    `
     @Pipe()
     class Test {
       ngOnDestroy() { console.log('OnDestroy'); }
@@ -134,6 +140,30 @@ ruleTester.run(RULE_NAME, rule, {
     `,
   ],
   invalid: [
+    convertAnnotatedSourceToFailureCase({
+      description:
+        'Class with @Component should fail if ngDoBootstrap() method is present',
+      annotatedSource: `
+        @Component()
+        class Test {
+          ngDoBootstrap() {}
+          ~~~~~~~~~~~~~
+        }
+      `,
+      messageId,
+    }),
+    convertAnnotatedSourceToFailureCase({
+      description:
+        'Class with @Directive should fail if ngDoBootstrap() method is present',
+      annotatedSource: `
+        @Directive()
+        class Test {
+          ngDoBootstrap() {}
+          ~~~~~~~~~~~~~
+        }
+      `,
+      messageId,
+    }),
     convertAnnotatedSourceToFailureCase({
       description:
         'Class with @Injectable should fail if ngAfterContentChecked() method is present',
@@ -166,6 +196,18 @@ ruleTester.run(RULE_NAME, rule, {
         class Test {
           ngAfterViewInit() { console.log('ngAfterViewInit'); }
           ~~~~~~~~~~~~~~~
+        }
+      `,
+      messageId,
+    }),
+    convertAnnotatedSourceToFailureCase({
+      description:
+        'Class with @Injectable should fail if ngDoBootstrap() method is present',
+      annotatedSource: `
+        @Injectable()
+        class Test {
+          ngDoBootstrap() {}
+          ~~~~~~~~~~~~~
         }
       `,
       messageId,
@@ -352,6 +394,18 @@ ruleTester.run(RULE_NAME, rule, {
     }),
     convertAnnotatedSourceToFailureCase({
       description:
+        'Class with @Pipe should fail if ngDoBootstrap() method is present',
+      annotatedSource: `
+        @Pipe()
+        class Test {
+          ngDoBootstrap() {}
+          ~~~~~~~~~~~~~
+        }
+      `,
+      messageId,
+    }),
+    convertAnnotatedSourceToFailureCase({
+      description:
         'Class with @Pipe should fail if ngDoCheck() method is present',
       annotatedSource: `
         @Pipe()
@@ -390,18 +444,20 @@ ruleTester.run(RULE_NAME, rule, {
       description:
         'It should fail if @Directive and @Pipe decorators are present on the same file and the @Pipe contains a non allowed method',
       annotatedSource: `
-      @Pipe()
-      class Test implements DoCheck {
-        constructor() {}
+        @Pipe()
+        class Test implements DoCheck {
+          constructor() {}
+          
           ngDoCheck() {}
           ~~~~~~~~~
-      }
-      @Directive()
-      class TestDirective implements OnInit {
-        ngOnInit() {
-          console.log('Initialized');
         }
-      }
+        
+        @Directive()
+        class TestDirective implements OnInit {
+          ngOnInit() {
+            console.log('Initialized');
+          }
+        }
       `,
       messageId,
     }),

--- a/packages/eslint-plugin/tests/rules/no-empty-lifecycle-method.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-empty-lifecycle-method.test.ts
@@ -120,9 +120,15 @@ ruleTester.run(RULE_NAME, rule, {
     }
     `,
     `
-    @Pipe
+    @NgModule()
     class Test {
-      ngOnInit() { }
+      ngOnInit() { console.log('ngOnInit') }
+    }
+    `,
+    `
+    @Pipe()
+    class Test {
+      ngDoBootstrap() { console.log('ngDoBootstrap') }
     }
     `,
   ],
@@ -134,7 +140,7 @@ ruleTester.run(RULE_NAME, rule, {
         @Component()
         class Test {
           ngAfterContentChecked() { }
-          ~~~~~~~~~~~~~~~~~~~~~
+          ~~~~~~~~~~~~~~~~~~~~~~~~~~~
         }
       `,
       messageId,
@@ -146,7 +152,7 @@ ruleTester.run(RULE_NAME, rule, {
         @Component()
         class Test {
           ngAfterContentInit() { }
-          ~~~~~~~~~~~~~~~~~~
+          ~~~~~~~~~~~~~~~~~~~~~~~~
         }
       `,
       messageId,
@@ -158,7 +164,7 @@ ruleTester.run(RULE_NAME, rule, {
         @Component()
         class Test {
           ngAfterViewChecked() { }
-          ~~~~~~~~~~~~~~~~~~
+          ~~~~~~~~~~~~~~~~~~~~~~~~
         }
       `,
       messageId,
@@ -170,7 +176,19 @@ ruleTester.run(RULE_NAME, rule, {
         @Component()
         class Test {
           ngAfterViewInit() { }
-          ~~~~~~~~~~~~~~~
+          ~~~~~~~~~~~~~~~~~~~~~
+        }
+      `,
+      messageId,
+    }),
+    convertAnnotatedSourceToFailureCase({
+      description:
+        'Class with @Component should fail if ngDoBootstrap() method is empty',
+      annotatedSource: `
+        @Component()
+        class Test {
+          ngDoBootstrap() { }
+          ~~~~~~~~~~~~~~~~~~~
         }
       `,
       messageId,
@@ -182,7 +200,7 @@ ruleTester.run(RULE_NAME, rule, {
         @Component()
         class Test {
           ngDoCheck() { }
-          ~~~~~~~~~
+          ~~~~~~~~~~~~~~~
         }
       `,
       messageId,
@@ -194,7 +212,7 @@ ruleTester.run(RULE_NAME, rule, {
         @Component()
         class Test {
           ngOnChanges() { }
-          ~~~~~~~~~~~
+          ~~~~~~~~~~~~~~~~~
         }
       `,
       messageId,
@@ -206,7 +224,7 @@ ruleTester.run(RULE_NAME, rule, {
         @Component()
         class Test {
           ngOnDestroy() { }
-          ~~~~~~~~~~~
+          ~~~~~~~~~~~~~~~~~
         }
       `,
       messageId,
@@ -218,7 +236,7 @@ ruleTester.run(RULE_NAME, rule, {
         @Component()
         class Test {
           ngOnInit() { }
-          ~~~~~~~~
+          ~~~~~~~~~~~~~~
         }
       `,
       messageId,
@@ -230,7 +248,7 @@ ruleTester.run(RULE_NAME, rule, {
         @Directive()
         class Test {
           ngAfterContentChecked() { }
-          ~~~~~~~~~~~~~~~~~~~~~
+          ~~~~~~~~~~~~~~~~~~~~~~~~~~~
         }
       `,
       messageId,
@@ -242,7 +260,7 @@ ruleTester.run(RULE_NAME, rule, {
         @Directive()
         class Test {
           ngAfterContentInit() { }
-          ~~~~~~~~~~~~~~~~~~
+          ~~~~~~~~~~~~~~~~~~~~~~~~
         }
       `,
       messageId,
@@ -254,7 +272,7 @@ ruleTester.run(RULE_NAME, rule, {
         @Directive()
         class Test {
           ngAfterViewChecked() { }
-          ~~~~~~~~~~~~~~~~~~
+          ~~~~~~~~~~~~~~~~~~~~~~~~
         }
       `,
       messageId,
@@ -266,7 +284,19 @@ ruleTester.run(RULE_NAME, rule, {
         @Directive()
         class Test {
           ngAfterViewInit() { }
-          ~~~~~~~~~~~~~~~
+          ~~~~~~~~~~~~~~~~~~~~~
+        }
+      `,
+      messageId,
+    }),
+    convertAnnotatedSourceToFailureCase({
+      description:
+        'Class with @Directive should fail if ngDoBootstrap() method is empty',
+      annotatedSource: `
+        @Directive()
+        class Test {
+          ngDoBootstrap() { }
+          ~~~~~~~~~~~~~~~~~~~
         }
       `,
       messageId,
@@ -278,7 +308,7 @@ ruleTester.run(RULE_NAME, rule, {
         @Directive()
         class Test {
           ngDoCheck() { }
-          ~~~~~~~~~
+          ~~~~~~~~~~~~~~~
         }
       `,
       messageId,
@@ -290,7 +320,7 @@ ruleTester.run(RULE_NAME, rule, {
         @Directive()
         class Test {
           ngOnChanges() { }
-          ~~~~~~~~~~~
+          ~~~~~~~~~~~~~~~~~
         }
       `,
       messageId,
@@ -302,7 +332,7 @@ ruleTester.run(RULE_NAME, rule, {
         @Directive()
         class Test {
           ngOnDestroy() { }
-          ~~~~~~~~~~~
+          ~~~~~~~~~~~~~~~~~
         }
       `,
       messageId,
@@ -314,7 +344,7 @@ ruleTester.run(RULE_NAME, rule, {
         @Directive()
         class Test {
           ngOnInit() { }
-          ~~~~~~~~
+          ~~~~~~~~~~~~~~
         }
       `,
       messageId,

--- a/packages/eslint-plugin/tests/rules/no-empty-lifecycle-method.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-empty-lifecycle-method.test.ts
@@ -140,7 +140,7 @@ ruleTester.run(RULE_NAME, rule, {
         @Component()
         class Test {
           ngAfterContentChecked() { }
-          ~~~~~~~~~~~~~~~~~~~~~~~~~~~
+          ~~~~~~~~~~~~~~~~~~~~~
         }
       `,
       messageId,
@@ -152,7 +152,7 @@ ruleTester.run(RULE_NAME, rule, {
         @Component()
         class Test {
           ngAfterContentInit() { }
-          ~~~~~~~~~~~~~~~~~~~~~~~~
+          ~~~~~~~~~~~~~~~~~~
         }
       `,
       messageId,
@@ -164,7 +164,7 @@ ruleTester.run(RULE_NAME, rule, {
         @Component()
         class Test {
           ngAfterViewChecked() { }
-          ~~~~~~~~~~~~~~~~~~~~~~~~
+          ~~~~~~~~~~~~~~~~~~
         }
       `,
       messageId,
@@ -176,7 +176,7 @@ ruleTester.run(RULE_NAME, rule, {
         @Component()
         class Test {
           ngAfterViewInit() { }
-          ~~~~~~~~~~~~~~~~~~~~~
+          ~~~~~~~~~~~~~~~
         }
       `,
       messageId,
@@ -188,7 +188,7 @@ ruleTester.run(RULE_NAME, rule, {
         @Component()
         class Test {
           ngDoBootstrap() { }
-          ~~~~~~~~~~~~~~~~~~~
+          ~~~~~~~~~~~~~
         }
       `,
       messageId,
@@ -200,7 +200,7 @@ ruleTester.run(RULE_NAME, rule, {
         @Component()
         class Test {
           ngDoCheck() { }
-          ~~~~~~~~~~~~~~~
+          ~~~~~~~~~
         }
       `,
       messageId,
@@ -212,7 +212,7 @@ ruleTester.run(RULE_NAME, rule, {
         @Component()
         class Test {
           ngOnChanges() { }
-          ~~~~~~~~~~~~~~~~~
+          ~~~~~~~~~~~
         }
       `,
       messageId,
@@ -224,7 +224,7 @@ ruleTester.run(RULE_NAME, rule, {
         @Component()
         class Test {
           ngOnDestroy() { }
-          ~~~~~~~~~~~~~~~~~
+          ~~~~~~~~~~~
         }
       `,
       messageId,
@@ -236,7 +236,7 @@ ruleTester.run(RULE_NAME, rule, {
         @Component()
         class Test {
           ngOnInit() { }
-          ~~~~~~~~~~~~~~
+          ~~~~~~~~
         }
       `,
       messageId,
@@ -248,7 +248,7 @@ ruleTester.run(RULE_NAME, rule, {
         @Directive()
         class Test {
           ngAfterContentChecked() { }
-          ~~~~~~~~~~~~~~~~~~~~~~~~~~~
+          ~~~~~~~~~~~~~~~~~~~~~
         }
       `,
       messageId,
@@ -260,7 +260,7 @@ ruleTester.run(RULE_NAME, rule, {
         @Directive()
         class Test {
           ngAfterContentInit() { }
-          ~~~~~~~~~~~~~~~~~~~~~~~~
+          ~~~~~~~~~~~~~~~~~~
         }
       `,
       messageId,
@@ -272,7 +272,7 @@ ruleTester.run(RULE_NAME, rule, {
         @Directive()
         class Test {
           ngAfterViewChecked() { }
-          ~~~~~~~~~~~~~~~~~~~~~~~~
+          ~~~~~~~~~~~~~~~~~~
         }
       `,
       messageId,
@@ -284,7 +284,7 @@ ruleTester.run(RULE_NAME, rule, {
         @Directive()
         class Test {
           ngAfterViewInit() { }
-          ~~~~~~~~~~~~~~~~~~~~~
+          ~~~~~~~~~~~~~~~
         }
       `,
       messageId,
@@ -296,7 +296,7 @@ ruleTester.run(RULE_NAME, rule, {
         @Directive()
         class Test {
           ngDoBootstrap() { }
-          ~~~~~~~~~~~~~~~~~~~
+          ~~~~~~~~~~~~~
         }
       `,
       messageId,
@@ -308,7 +308,7 @@ ruleTester.run(RULE_NAME, rule, {
         @Directive()
         class Test {
           ngDoCheck() { }
-          ~~~~~~~~~~~~~~~
+          ~~~~~~~~~
         }
       `,
       messageId,
@@ -320,7 +320,7 @@ ruleTester.run(RULE_NAME, rule, {
         @Directive()
         class Test {
           ngOnChanges() { }
-          ~~~~~~~~~~~~~~~~~
+          ~~~~~~~~~~~
         }
       `,
       messageId,
@@ -332,7 +332,7 @@ ruleTester.run(RULE_NAME, rule, {
         @Directive()
         class Test {
           ngOnDestroy() { }
-          ~~~~~~~~~~~~~~~~~
+          ~~~~~~~~~~~
         }
       `,
       messageId,
@@ -344,7 +344,7 @@ ruleTester.run(RULE_NAME, rule, {
         @Directive()
         class Test {
           ngOnInit() { }
-          ~~~~~~~~~~~~~~
+          ~~~~~~~~
         }
       `,
       messageId,

--- a/packages/eslint-plugin/tests/rules/no-lifecycle-call.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-lifecycle-call.test.ts
@@ -54,6 +54,15 @@ ruleTester.run(RULE_NAME, rule, {
     })
     class Test {
       test() {
+        super.ngDoBootstrap();
+      }
+    }`,
+
+    `@Component({
+      selector: 'test'
+    })
+    class Test {
+      test() {
         super.ngDoCheck();
       }
     }`,
@@ -119,6 +128,15 @@ ruleTester.run(RULE_NAME, rule, {
     })
     class Test {
       test() {
+        super.ngDoBootstrap();
+      }
+    }`,
+
+    `@Directive({
+      selector: 'test'
+    })
+    class Test {
+      test() {
         super.ngDoCheck();
       }
     }`,
@@ -168,6 +186,13 @@ ruleTester.run(RULE_NAME, rule, {
     class Test {
       test() {
         super.ngAfterViewInit();
+      }
+    }`,
+
+    `@Injectable()
+    class Test {
+      test() {
+        super.ngDoBootstrap();
       }
     }`,
 
@@ -227,6 +252,15 @@ ruleTester.run(RULE_NAME, rule, {
     class Test {
       test() {
         super.ngAfterViewInit();
+      }
+    }`,
+
+    `@Pipe({
+      name: 'test'
+    })
+    class Test {
+      test() {
+        super.ngDoBootstrap();
       }
     }`,
 
@@ -349,6 +383,20 @@ ruleTester.run(RULE_NAME, rule, {
     }),
 
     convertAnnotatedSourceToFailureCase({
+      description: 'it should fail if explicitly calling ngDoBootstrap()',
+      annotatedSource: `@Component({
+        selector: 'test'
+      })
+      class Test {
+        test() {
+          this.ngDoBootstrap();
+          ~~~~~~~~~~~~~~~~~~~~
+        }
+      }`,
+      messageId,
+    }),
+
+    convertAnnotatedSourceToFailureCase({
       description: 'it should fail if explicitly calling ngDoCheck()',
       annotatedSource: `@Component({
         selector: 'test'
@@ -450,6 +498,20 @@ ruleTester.run(RULE_NAME, rule, {
     }),
 
     convertAnnotatedSourceToFailureCase({
+      description: 'it should fail if explicitly calling ngDoBootstrap()',
+      annotatedSource: `@Directive({
+        selector: 'test'
+      })
+      class Test {
+        test() {
+          this.ngDoBootstrap();
+          ~~~~~~~~~~~~~~~~~~~~
+        }
+      }`,
+      messageId,
+    }),
+
+    convertAnnotatedSourceToFailureCase({
       description: 'it should fail if explicitly calling ngDoCheck()',
       annotatedSource: `@Directive({
         selector: 'test'
@@ -537,6 +599,18 @@ ruleTester.run(RULE_NAME, rule, {
         test() {
           this.ngAfterViewInit();
           ~~~~~~~~~~~~~~~~~~~~~~
+        }
+      }`,
+      messageId,
+    }),
+
+    convertAnnotatedSourceToFailureCase({
+      description: 'it should fail if explicitly calling ngDoBootstrap()',
+      annotatedSource: `@Injectable()
+      class Test {
+        test() {
+          this.ngDoBootstrap();
+          ~~~~~~~~~~~~~~~~~~~~
         }
       }`,
       messageId,
@@ -632,6 +706,20 @@ ruleTester.run(RULE_NAME, rule, {
         test() {
           this.ngAfterViewInit();
           ~~~~~~~~~~~~~~~~~~~~~~
+        }
+      }`,
+      messageId,
+    }),
+
+    convertAnnotatedSourceToFailureCase({
+      description: 'it should fail if explicitly calling ngDoBootstrap()',
+      annotatedSource: `@Pipe({
+        name: 'test'
+      })
+      class Test {
+        test() {
+          this.ngDoBootstrap();
+          ~~~~~~~~~~~~~~~~~~~~
         }
       }`,
       messageId,

--- a/packages/eslint-plugin/tests/rules/use-lifecycle-interface.test.ts
+++ b/packages/eslint-plugin/tests/rules/use-lifecycle-interface.test.ts
@@ -27,7 +27,11 @@ ruleTester.run(RULE_NAME, rule, {
     class Test implements OnInit {
       ngOnInit() {}
     }
- `,
+    `,
+    `class Test implements DoBootstrap {
+      ngDoBootstrap() {}
+    }
+    `,
     `
     class Test extends Component implements OnInit, OnDestroy  {
       ngOnInit() {}
@@ -38,7 +42,7 @@ ruleTester.run(RULE_NAME, rule, {
 
       ngOnSmth() {}
     }
-`,
+    `,
     `
     class Test extends Component implements ng.OnInit, ng.OnDestroy  {
       ngOnInit() {}
@@ -49,16 +53,15 @@ ruleTester.run(RULE_NAME, rule, {
 
       ngOnSmth() {}
     }
-`,
-    `
-    class Test {}
-`,
+    `,
+    'class Test {}',
   ],
   invalid: [
     convertAnnotatedSourceToFailureCase({
       description:
         'it should fail if lifecycle method is declared without implementing its interface',
       annotatedSource: `
+        @Component()
         class Test {
           ngOnInit() {
           ~~~~~~~~
@@ -75,6 +78,7 @@ ruleTester.run(RULE_NAME, rule, {
       description:
         'it should fail if one of the lifecycle methods is declared without implementing its interface',
       annotatedSource: `
+        @Directive()
         class Test extends Component implements OnInit {
           ngOnInit() {}
 
@@ -89,40 +93,33 @@ ruleTester.run(RULE_NAME, rule, {
         methodName: AngularLifecycleMethods.ngOnDestroy,
       },
     }),
-    {
-      // it should fail if lifecycle methods are declared without implementing their interfaces
-      code: `
-      class Test {
-        ngOnInit() {}
+    convertAnnotatedSourceToFailureCase({
+      description:
+        'it should fail if lifecycle methods are declared without implementing their interfaces',
+      annotatedSource: `
+        @Injectable()
+        class Test {
+          ngDoBootstrap() {}
+          ~~~~~~~~~~~~~
 
-        ngOnDestroy() {}
-      }
-`,
-      errors: [
-        {
-          messageId: 'useLifecycleInterface',
-          data: {
-            interfaceName: AngularLifecycleInterfaces.OnInit,
-            methodName: AngularLifecycleMethods.ngOnInit,
-          },
-          line: 3,
-          column: 9,
-        },
-        {
-          messageId: 'useLifecycleInterface',
-          data: {
-            interfaceName: AngularLifecycleInterfaces.OnDestroy,
-            methodName: AngularLifecycleMethods.ngOnDestroy,
-          },
-          line: 5,
-          column: 9,
-        },
+          ngOnInit() {}
+          ^^^^^^^^
+
+          ngOnDestroy() {}
+          ###########
+        }
+      `,
+      messages: [
+        { char: '~', messageId },
+        { char: '^', messageId },
+        { char: '#', messageId },
       ],
-    },
+    }),
     convertAnnotatedSourceToFailureCase({
       description:
         'it should fail if lifecycle methods are declared without implementing their interfaces, using namespace',
       annotatedSource: `
+        @NgModule()
         class Test extends Component implements ng.OnInit {
           ngOnInit() {}
 

--- a/packages/integration-tests/tests/__snapshots__/v1014-multi-project-manual-config.test.ts.snap
+++ b/packages/integration-tests/tests/__snapshots__/v1014-multi-project-manual-config.test.ts.snap
@@ -14,7 +14,7 @@ __ROOT__/v1014-multi-project-manual-config/src/app/app.component.spec.ts
 __ROOT__/v1014-multi-project-manual-config/src/app/app.component.ts
    2:1  error  'rxjs/Rx' import is restricted from being used. Please import directly from 'rxjs' instead                             no-restricted-imports
    5:1  error  Unexpected console statement                                                                                           no-console
-  15:3  error  Lifecycle interface "OnInit" should be implemented for method "ngOnInit" (https://angular.io/styleguide#style-09-01)  @angular-eslint/use-lifecycle-interface
+  15:3  error  Lifecycle interface 'OnInit' should be implemented for method 'ngOnInit'. (https://angular.io/styleguide#style-09-01)  @angular-eslint/use-lifecycle-interface
 
 ✖ 3 problems (3 errors, 0 warnings)
 

--- a/packages/integration-tests/tests/__snapshots__/v1014-multi-project-manual-config.test.ts.snap
+++ b/packages/integration-tests/tests/__snapshots__/v1014-multi-project-manual-config.test.ts.snap
@@ -14,7 +14,7 @@ __ROOT__/v1014-multi-project-manual-config/src/app/app.component.spec.ts
 __ROOT__/v1014-multi-project-manual-config/src/app/app.component.ts
    2:1  error  'rxjs/Rx' import is restricted from being used. Please import directly from 'rxjs' instead                             no-restricted-imports
    5:1  error  Unexpected console statement                                                                                           no-console
-  15:3  error  Lifecycle interface "OnInit" should be implemented for method "ngOnInit". (https://angular.io/styleguide#style-09-01)  @angular-eslint/use-lifecycle-interface
+  15:3  error  Lifecycle interface "OnInit" should be implemented for method "ngOnInit" (https://angular.io/styleguide#style-09-01)  @angular-eslint/use-lifecycle-interface
 
 ✖ 3 problems (3 errors, 0 warnings)
 

--- a/packages/integration-tests/tests/__snapshots__/v1014-multi-project-manual-config.test.ts.snap
+++ b/packages/integration-tests/tests/__snapshots__/v1014-multi-project-manual-config.test.ts.snap
@@ -14,7 +14,7 @@ __ROOT__/v1014-multi-project-manual-config/src/app/app.component.spec.ts
 __ROOT__/v1014-multi-project-manual-config/src/app/app.component.ts
    2:1  error  'rxjs/Rx' import is restricted from being used. Please import directly from 'rxjs' instead                             no-restricted-imports
    5:1  error  Unexpected console statement                                                                                           no-console
-  15:3  error  Lifecycle interface 'OnInit' should be implemented for method 'ngOnInit'. (https://angular.io/styleguide#style-09-01)  @angular-eslint/use-lifecycle-interface
+  15:3  error  Lifecycle interface "OnInit" should be implemented for method "ngOnInit". (https://angular.io/styleguide#style-09-01)  @angular-eslint/use-lifecycle-interface
 
 ✖ 3 problems (3 errors, 0 warnings)
 

--- a/packages/integration-tests/tests/__snapshots__/v11-new-workspace.test.ts.snap
+++ b/packages/integration-tests/tests/__snapshots__/v11-new-workspace.test.ts.snap
@@ -230,7 +230,7 @@ All files pass linting.
 Linting \\"another-lib\\"...
 
 __ROOT__/v11-new-workspace/projects/another-lib/src/lib/another-lib.component.ts
-  17:3  error  Lifecycle method ngOnInit should not be empty  @angular-eslint/no-empty-lifecycle-method
+  17:3  error  Lifecycle methods should not be empty  @angular-eslint/no-empty-lifecycle-method
 
 ✖ 1 problem (1 error, 0 warnings)
 "


### PR DESCRIPTION
This:

- Handles `DoBootstrap`/`ngDoBootstrap` for all 4 lifecycle rules correctly now;
- `no-empty-lifecycle-method` handles all decorators. Before it was caring only about `Component` and `Directive`;
- `no-empty-lifecycle -method` now ignores non-angular classes;
- `use-lifecycle-interface` now ignores non-angular classes.