### PR TITLE
fix(*): export no-any rule, fix & improve config tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -404,30 +404,30 @@ If you are still having problems after you have done some digging into these, fe
 
 #### Functionality
 
-| Codelyzer rule                                  |       Status       |
-| ----------------------------------------------- | :----------------: |
-| [`contextual-decorator`]                        |                    |
-| [`contextual-lifecycle`]                        | :white_check_mark: |
-| [`no-attribute-decorator`]                      | :white_check_mark: |
-| [`no-lifecycle-call`]                           | :white_check_mark: |
-| [`no-output-native`]                            | :white_check_mark: |
-| [`no-pipe-impure`]                              | :white_check_mark: |
-| [`prefer-on-push-component-change-detection`]   | :white_check_mark: |
-| [`template-accessibility-alt-text`]             | :white_check_mark: |
-| [`template-accessibility-elements-content`]     | :white_check_mark: |
-| [`template-accessibility-label-for`]            |                    |
-| [`template-accessibility-tabindex-no-positive`] | :white_check_mark: |
-| [`template-accessibility-table-scope`]          | :white_check_mark: |
-| [`template-accessibility-valid-aria`]           | :white_check_mark: |
-| [`template-banana-in-box`]                      | :white_check_mark: |
-| [`template-click-events-have-key-events`]       |                    |
-| [`template-mouse-events-have-key-events`]       | :white_check_mark: |
-| [`template-no-any`]                             | :white_check_mark: |
-| [`template-no-autofocus`]                       | :white_check_mark: |
-| [`template-no-distracting-elements`]            | :white_check_mark: |
-| [`template-no-negated-async`]                   | :white_check_mark: |
-| [`use-injectable-provided-in`]                  | :white_check_mark: |
-| [`use-lifecycle-interface`]                     | :white_check_mark: |
+| Codelyzer rule                                  |          Status           |
+| ----------------------------------------------- | :-----------------------: |
+| [`contextual-decorator`]                        | [:construction:][`pr233`] |
+| [`contextual-lifecycle`]                        |    :white_check_mark:     |
+| [`no-attribute-decorator`]                      |    :white_check_mark:     |
+| [`no-lifecycle-call`]                           |    :white_check_mark:     |
+| [`no-output-native`]                            |    :white_check_mark:     |
+| [`no-pipe-impure`]                              |    :white_check_mark:     |
+| [`prefer-on-push-component-change-detection`]   |    :white_check_mark:     |
+| [`template-accessibility-alt-text`]             |    :white_check_mark:     |
+| [`template-accessibility-elements-content`]     |    :white_check_mark:     |
+| [`template-accessibility-label-for`]            |                           |
+| [`template-accessibility-tabindex-no-positive`] |    :white_check_mark:     |
+| [`template-accessibility-table-scope`]          |    :white_check_mark:     |
+| [`template-accessibility-valid-aria`]           |    :white_check_mark:     |
+| [`template-banana-in-box`]                      |    :white_check_mark:     |
+| [`template-click-events-have-key-events`]       |                           |
+| [`template-mouse-events-have-key-events`]       |    :white_check_mark:     |
+| [`template-no-any`]                             |    :white_check_mark:     |
+| [`template-no-autofocus`]                       |    :white_check_mark:     |
+| [`template-no-distracting-elements`]            |    :white_check_mark:     |
+| [`template-no-negated-async`]                   |    :white_check_mark:     |
+| [`use-injectable-provided-in`]                  |    :white_check_mark:     |
+| [`use-lifecycle-interface`]                     |    :white_check_mark:     |
 
 #### Maintainability
 
@@ -527,5 +527,7 @@ If you are still having problems after you have done some digging into these, fe
 [`use-pipe-transform-interface`]: https://codelyzer.com/rules/use-pipe-transform-interface
 
 <!-- PR Links -->
+
+[`pr233`]: https://api.github.com/repos/angular-eslint/angular-eslint/pulls/233
 
 <!-- end rule list -->

--- a/README.md
+++ b/README.md
@@ -404,30 +404,30 @@ If you are still having problems after you have done some digging into these, fe
 
 #### Functionality
 
-| Codelyzer rule                                  |          Status           |
-| ----------------------------------------------- | :-----------------------: |
-| [`contextual-decorator`]                        | [:construction:][`pr233`] |
-| [`contextual-lifecycle`]                        |    :white_check_mark:     |
-| [`no-attribute-decorator`]                      |    :white_check_mark:     |
-| [`no-lifecycle-call`]                           |    :white_check_mark:     |
-| [`no-output-native`]                            |    :white_check_mark:     |
-| [`no-pipe-impure`]                              |    :white_check_mark:     |
-| [`prefer-on-push-component-change-detection`]   |    :white_check_mark:     |
-| [`template-accessibility-alt-text`]             |    :white_check_mark:     |
-| [`template-accessibility-elements-content`]     |    :white_check_mark:     |
-| [`template-accessibility-label-for`]            |                           |
-| [`template-accessibility-tabindex-no-positive`] |    :white_check_mark:     |
-| [`template-accessibility-table-scope`]          |    :white_check_mark:     |
-| [`template-accessibility-valid-aria`]           |    :white_check_mark:     |
-| [`template-banana-in-box`]                      |    :white_check_mark:     |
-| [`template-click-events-have-key-events`]       |                           |
-| [`template-mouse-events-have-key-events`]       |    :white_check_mark:     |
-| [`template-no-any`]                             |    :white_check_mark:     |
-| [`template-no-autofocus`]                       |    :white_check_mark:     |
-| [`template-no-distracting-elements`]            |    :white_check_mark:     |
-| [`template-no-negated-async`]                   |    :white_check_mark:     |
-| [`use-injectable-provided-in`]                  |    :white_check_mark:     |
-| [`use-lifecycle-interface`]                     |    :white_check_mark:     |
+| Codelyzer rule                                  |       Status       |
+| ----------------------------------------------- | :----------------: |
+| [`contextual-decorator`]                        |                    |
+| [`contextual-lifecycle`]                        | :white_check_mark: |
+| [`no-attribute-decorator`]                      | :white_check_mark: |
+| [`no-lifecycle-call`]                           | :white_check_mark: |
+| [`no-output-native`]                            | :white_check_mark: |
+| [`no-pipe-impure`]                              | :white_check_mark: |
+| [`prefer-on-push-component-change-detection`]   | :white_check_mark: |
+| [`template-accessibility-alt-text`]             | :white_check_mark: |
+| [`template-accessibility-elements-content`]     | :white_check_mark: |
+| [`template-accessibility-label-for`]            |                    |
+| [`template-accessibility-tabindex-no-positive`] | :white_check_mark: |
+| [`template-accessibility-table-scope`]          | :white_check_mark: |
+| [`template-accessibility-valid-aria`]           | :white_check_mark: |
+| [`template-banana-in-box`]                      | :white_check_mark: |
+| [`template-click-events-have-key-events`]       |                    |
+| [`template-mouse-events-have-key-events`]       | :white_check_mark: |
+| [`template-no-any`]                             | :white_check_mark: |
+| [`template-no-autofocus`]                       | :white_check_mark: |
+| [`template-no-distracting-elements`]            | :white_check_mark: |
+| [`template-no-negated-async`]                   | :white_check_mark: |
+| [`use-injectable-provided-in`]                  | :white_check_mark: |
+| [`use-lifecycle-interface`]                     | :white_check_mark: |
 
 #### Maintainability
 
@@ -527,7 +527,5 @@ If you are still having problems after you have done some digging into these, fe
 [`use-pipe-transform-interface`]: https://codelyzer.com/rules/use-pipe-transform-interface
 
 <!-- PR Links -->
-
-[`pr233`]: https://api.github.com/repos/angular-eslint/angular-eslint/pulls/233
 
 <!-- end rule list -->

--- a/packages/eslint-plugin-template/src/configs/all.json
+++ b/packages/eslint-plugin-template/src/configs/all.json
@@ -1,20 +1,21 @@
 {
   "extends": "./configs/base.json",
   "rules": {
+    "@angular-eslint/template/accessibility-alt-text": "error",
+    "@angular-eslint/template/accessibility-elements-content": "error",
+    "@angular-eslint/template/accessibility-table-scope": "error",
+    "@angular-eslint/template/accessibility-valid-aria": "error",
     "@angular-eslint/template/banana-in-box": "error",
+    "@angular-eslint/template/conditional-complexity": "error",
     "@angular-eslint/template/cyclomatic-complexity": "error",
+    "@angular-eslint/template/i18n": "error",
+    "@angular-eslint/template/mouse-events-have-key-events": "error",
     "@angular-eslint/template/no-any": "error",
     "@angular-eslint/template/no-autofocus": "error",
     "@angular-eslint/template/no-call-expression": "error",
+    "@angular-eslint/template/no-distracting-elements": "error",
     "@angular-eslint/template/no-negated-async": "error",
     "@angular-eslint/template/no-positive-tabindex": "error",
-    "@angular-eslint/template/accessibility-elements-content": "error",
-    "@angular-eslint/template/accessibility-alt-text": "error",
-    "@angular-eslint/template/accessibility-valid-aria": "error",
-    "@angular-eslint/template/accessibility-table-scope": "error",
-    "@angular-eslint/template/no-distracting-elements": "error",
-    "@angular-eslint/template/i18n": "error",
-    "@angular-eslint/template/mouse-events-have-key-events": "error",
-    "@angular-eslint/template/conditional-complexity": "error"
+    "@angular-eslint/template/use-track-by-function": "error"
   }
 }

--- a/packages/eslint-plugin-template/src/index.ts
+++ b/packages/eslint-plugin-template/src/index.ts
@@ -3,18 +3,41 @@ import base from './configs/base.json';
 import recommended from './configs/recommended.json';
 import processInlineTemplates from './configs/process-inline-templates.json';
 import processors from './processors';
+import accessibilityAltText, {
+  RULE_NAME as accessibilityAltTextRuleName,
+} from './rules/accessibility-alt-text';
+import accessibilityElementsContent, {
+  RULE_NAME as accessibilityElementsContentRuleName,
+} from './rules/accessibility-elements-content';
+import accessibilityTableScope, {
+  RULE_NAME as accessibilityTableScopeRuleName,
+} from './rules/accessibility-table-scope';
+import accessibilityValidAria, {
+  RULE_NAME as accessibilityValidAriaRuleName,
+} from './rules/accessibility-valid-aria';
 import bananaInBox, {
   RULE_NAME as bananaInBoxRuleName,
 } from './rules/banana-in-box';
+import conditionalСomplexity, {
+  RULE_NAME as conditionalСomplexityRuleName,
+} from './rules/conditional-complexity';
 import cyclomaticComplexity, {
   RULE_NAME as cyclomaticComplexityRuleName,
 } from './rules/cyclomatic-complexity';
+import i18n, { RULE_NAME as i18nRuleName } from './rules/i18n';
+import mouseEventsHaveKeyEvents, {
+  RULE_NAME as mouseEventsHaveKeyEventsRuleName,
+} from './rules/mouse-events-have-key-events-rule';
+import noAny, { RULE_NAME as noAnyRuleName } from './rules/no-any';
 import noAutofocus, {
   RULE_NAME as noAutofocusRuleName,
 } from './rules/no-autofocus';
 import noCallExpression, {
   RULE_NAME as noCallExpressionRuleName,
 } from './rules/no-call-expression';
+import noDistractingElements, {
+  RULE_NAME as noDistractingElementsRuleName,
+} from './rules/no-distracting-elements';
 import noNegatedAsync, {
   RULE_NAME as noNegatedAsyncRuleName,
 } from './rules/no-negated-async';
@@ -24,28 +47,6 @@ import noPositiveTabindex, {
 import useTrackByFunction, {
   RULE_NAME as useTrackByFunctionRuleName,
 } from './rules/use-track-by-function';
-import accessibilityElementsContent, {
-  RULE_NAME as accessibilityElementsContentRuleName,
-} from './rules/accessibility-elements-content';
-import noDistractingElements, {
-  RULE_NAME as noDistractingElementsRuleName,
-} from './rules/no-distracting-elements';
-import i18n, { RULE_NAME as i18nRuleName } from './rules/i18n';
-import mouseEventsHaveKeyEvents, {
-  RULE_NAME as mouseEventsHaveKeyEventsRuleName,
-} from './rules/mouse-events-have-key-events-rule';
-import accessibilityAltText, {
-  RULE_NAME as accessibilityAltTextRuleName,
-} from './rules/accessibility-alt-text';
-import accessibilityValidAria, {
-  RULE_NAME as accessibilityValidAriaRuleName,
-} from './rules/accessibility-valid-aria';
-import accessibilityTableScope, {
-  RULE_NAME as accessibilityTableScopeRuleName,
-} from './rules/accessibility-table-scope';
-import conditionalСomplexity, {
-  RULE_NAME as conditionalСomplexityRuleName,
-} from './rules/conditional-complexity';
 
 export default {
   configs: {
@@ -56,20 +57,21 @@ export default {
   },
   processors,
   rules: {
+    [accessibilityAltTextRuleName]: accessibilityAltText,
+    [accessibilityElementsContentRuleName]: accessibilityElementsContent,
+    [accessibilityTableScopeRuleName]: accessibilityTableScope,
+    [accessibilityValidAriaRuleName]: accessibilityValidAria,
     [bananaInBoxRuleName]: bananaInBox,
+    [conditionalСomplexityRuleName]: conditionalСomplexity,
     [cyclomaticComplexityRuleName]: cyclomaticComplexity,
+    [i18nRuleName]: i18n,
+    [mouseEventsHaveKeyEventsRuleName]: mouseEventsHaveKeyEvents,
+    [noAnyRuleName]: noAny,
     [noAutofocusRuleName]: noAutofocus,
     [noCallExpressionRuleName]: noCallExpression,
+    [noDistractingElementsRuleName]: noDistractingElements,
     [noNegatedAsyncRuleName]: noNegatedAsync,
     [noPositiveTabindexRuleName]: noPositiveTabindex,
     [useTrackByFunctionRuleName]: useTrackByFunction,
-    [accessibilityElementsContentRuleName]: accessibilityElementsContent,
-    [noDistractingElementsRuleName]: noDistractingElements,
-    [i18nRuleName]: i18n,
-    [mouseEventsHaveKeyEventsRuleName]: mouseEventsHaveKeyEvents,
-    [accessibilityAltTextRuleName]: accessibilityAltText,
-    [accessibilityValidAriaRuleName]: accessibilityValidAria,
-    [accessibilityTableScopeRuleName]: accessibilityTableScope,
-    [conditionalСomplexityRuleName]: conditionalСomplexity,
   },
 };

--- a/packages/eslint-plugin-template/tests/configs.test.ts
+++ b/packages/eslint-plugin-template/tests/configs.test.ts
@@ -1,5 +1,7 @@
 import eslintPluginTemplate from '../src';
 
+const ESLINT_PLUGIN_PREFFIX = '@angular-eslint/template/';
+
 interface Config {
   extends?: string | string[];
   rules?: { [ruleName: string]: string | object };
@@ -7,9 +9,10 @@ interface Config {
 }
 
 function containsRule(config: any, ruleName: string): boolean {
+  const prefixedRuleName = `${ESLINT_PLUGIN_PREFFIX}${ruleName}`;
   return (
-    Boolean(config.rules?.[ruleName]) ||
-    config.overrides?.some((config: Config) => config.rules?.[ruleName])
+    Boolean(config.rules?.[prefixedRuleName]) ||
+    config.overrides?.some((config: Config) => config.rules?.[prefixedRuleName])
   );
 }
 
@@ -26,7 +29,21 @@ describe('configs', () => {
         Object.keys(eslintPluginTemplate.rules).every((ruleName) =>
           containsRule(eslintPluginTemplate.configs.all, ruleName),
         ),
-      );
+      ).toBe(true);
+    });
+
+    it('should only contain valid rules', () => {
+      expect(
+        Object.keys(eslintPluginTemplate.configs.all.rules)
+          .filter((ruleName) => ruleName.startsWith(ESLINT_PLUGIN_PREFFIX))
+          .every((ruleName) =>
+            Boolean(
+              (eslintPluginTemplate.rules as any)[
+                ruleName.slice(ESLINT_PLUGIN_PREFFIX.length)
+              ],
+            ),
+          ),
+      ).toBe(true);
     });
   });
 
@@ -38,7 +55,21 @@ describe('configs', () => {
           .every((entry) =>
             containsRule(eslintPluginTemplate.configs.recommended, entry[0]),
           ),
-      );
+      ).toBe(true);
+    });
+
+    it('should only contain valid rules', () => {
+      expect(
+        Object.keys(eslintPluginTemplate.configs.recommended.rules)
+          .filter((ruleName) => ruleName.startsWith(ESLINT_PLUGIN_PREFFIX))
+          .every((ruleName) =>
+            Boolean(
+              (eslintPluginTemplate.rules as any)[
+                ruleName.slice(ESLINT_PLUGIN_PREFFIX.length)
+              ],
+            ),
+          ),
+      ).toBe(true);
     });
   });
 });

--- a/packages/eslint-plugin-template/tests/configs.test.ts
+++ b/packages/eslint-plugin-template/tests/configs.test.ts
@@ -1,6 +1,6 @@
 import eslintPluginTemplate from '../src';
 
-const ESLINT_PLUGIN_PREFFIX = '@angular-eslint/template/';
+const ESLINT_PLUGIN_TEMPLATE_PREFIX = '@angular-eslint/template/';
 
 interface Config {
   extends?: string | string[];
@@ -8,11 +8,11 @@ interface Config {
   overrides?: Config[];
 }
 
-function containsRule(config: any, ruleName: string): boolean {
-  const prefixedRuleName = `${ESLINT_PLUGIN_PREFFIX}${ruleName}`;
-  return (
-    Boolean(config.rules?.[prefixedRuleName]) ||
-    config.overrides?.some((config: Config) => config.rules?.[prefixedRuleName])
+function containsRule(config: Config, ruleName: string): boolean {
+  const prefixedRuleName = `${ESLINT_PLUGIN_TEMPLATE_PREFIX}${ruleName}`;
+  return Boolean(
+    config.rules?.[prefixedRuleName] ||
+      config.overrides?.some(({ rules }) => rules?.[prefixedRuleName]),
   );
 }
 
@@ -35,11 +35,15 @@ describe('configs', () => {
     it('should only contain valid rules', () => {
       expect(
         Object.keys(eslintPluginTemplate.configs.all.rules)
-          .filter((ruleName) => ruleName.startsWith(ESLINT_PLUGIN_PREFFIX))
+          .filter((ruleName) =>
+            ruleName.startsWith(ESLINT_PLUGIN_TEMPLATE_PREFIX),
+          )
           .every((ruleName) =>
             Boolean(
-              (eslintPluginTemplate.rules as any)[
-                ruleName.slice(ESLINT_PLUGIN_PREFFIX.length)
+              eslintPluginTemplate.rules[
+                ruleName.slice(
+                  ESLINT_PLUGIN_TEMPLATE_PREFIX.length,
+                ) as keyof typeof eslintPluginTemplate.rules
               ],
             ),
           ),
@@ -61,11 +65,15 @@ describe('configs', () => {
     it('should only contain valid rules', () => {
       expect(
         Object.keys(eslintPluginTemplate.configs.recommended.rules)
-          .filter((ruleName) => ruleName.startsWith(ESLINT_PLUGIN_PREFFIX))
+          .filter((ruleName) =>
+            ruleName.startsWith(ESLINT_PLUGIN_TEMPLATE_PREFIX),
+          )
           .every((ruleName) =>
             Boolean(
-              (eslintPluginTemplate.rules as any)[
-                ruleName.slice(ESLINT_PLUGIN_PREFFIX.length)
+              eslintPluginTemplate.rules[
+                ruleName.slice(
+                  ESLINT_PLUGIN_TEMPLATE_PREFIX.length,
+                ) as keyof typeof eslintPluginTemplate.rules
               ],
             ),
           ),

--- a/packages/eslint-plugin/tests/configs.test.ts
+++ b/packages/eslint-plugin/tests/configs.test.ts
@@ -1,5 +1,7 @@
 import eslintPlugin from '../src';
 
+const ESLINT_PLUGIN_PREFFIX = '@angular-eslint/';
+
 interface Config {
   extends?: string | string[];
   rules?: { [ruleName: string]: string | object };
@@ -7,9 +9,10 @@ interface Config {
 }
 
 function containsRule(config: any, ruleName: string): boolean {
+  const prefixedRuleName = `${ESLINT_PLUGIN_PREFFIX}${ruleName}`;
   return (
-    Boolean(config.rules?.[ruleName]) ||
-    config.overrides?.some((config: Config) => config.rules?.[ruleName])
+    Boolean(config.rules?.[prefixedRuleName]) ||
+    config.overrides?.some((config: Config) => config.rules?.[prefixedRuleName])
   );
 }
 
@@ -40,7 +43,21 @@ describe('configs', () => {
         Object.keys(eslintPlugin.rules).every((ruleName) =>
           containsRule(eslintPlugin.configs.all, ruleName),
         ),
-      );
+      ).toBe(true);
+    });
+
+    it('should only contain valid rules', () => {
+      expect(
+        Object.keys(eslintPlugin.configs.all.rules)
+          .filter((ruleName) => ruleName.startsWith(ESLINT_PLUGIN_PREFFIX))
+          .every((ruleName) =>
+            Boolean(
+              (eslintPlugin.rules as any)[
+                ruleName.slice(ESLINT_PLUGIN_PREFFIX.length)
+              ],
+            ),
+          ),
+      ).toBe(true);
     });
   });
 
@@ -52,7 +69,21 @@ describe('configs', () => {
           .every((entry) =>
             containsRule(eslintPlugin.configs.recommended, entry[0]),
           ),
-      );
+      ).toBe(true);
+    });
+
+    it('should only contain valid rules', () => {
+      expect(
+        Object.keys(eslintPlugin.configs.recommended.rules)
+          .filter((ruleName) => ruleName.startsWith(ESLINT_PLUGIN_PREFFIX))
+          .every((ruleName) =>
+            Boolean(
+              (eslintPlugin.rules as any)[
+                ruleName.slice(ESLINT_PLUGIN_PREFFIX.length)
+              ],
+            ),
+          ),
+      ).toBe(true);
     });
   });
 });

--- a/packages/eslint-plugin/tests/configs.test.ts
+++ b/packages/eslint-plugin/tests/configs.test.ts
@@ -1,6 +1,6 @@
 import eslintPlugin from '../src';
 
-const ESLINT_PLUGIN_PREFFIX = '@angular-eslint/';
+const ESLINT_PLUGIN_PREFIX = '@angular-eslint/';
 
 interface Config {
   extends?: string | string[];
@@ -8,11 +8,11 @@ interface Config {
   overrides?: Config[];
 }
 
-function containsRule(config: any, ruleName: string): boolean {
-  const prefixedRuleName = `${ESLINT_PLUGIN_PREFFIX}${ruleName}`;
-  return (
-    Boolean(config.rules?.[prefixedRuleName]) ||
-    config.overrides?.some((config: Config) => config.rules?.[prefixedRuleName])
+function containsRule(config: Config, ruleName: string): boolean {
+  const prefixedRuleName = `${ESLINT_PLUGIN_PREFIX}${ruleName}`;
+  return Boolean(
+    config.rules?.[prefixedRuleName] ||
+      config.overrides?.some(({ rules }) => rules?.[prefixedRuleName]),
   );
 }
 
@@ -49,11 +49,13 @@ describe('configs', () => {
     it('should only contain valid rules', () => {
       expect(
         Object.keys(eslintPlugin.configs.all.rules)
-          .filter((ruleName) => ruleName.startsWith(ESLINT_PLUGIN_PREFFIX))
+          .filter((ruleName) => ruleName.startsWith(ESLINT_PLUGIN_PREFIX))
           .every((ruleName) =>
             Boolean(
-              (eslintPlugin.rules as any)[
-                ruleName.slice(ESLINT_PLUGIN_PREFFIX.length)
+              eslintPlugin.rules[
+                ruleName.slice(
+                  ESLINT_PLUGIN_PREFIX.length,
+                ) as keyof typeof eslintPlugin.rules
               ],
             ),
           ),
@@ -75,11 +77,13 @@ describe('configs', () => {
     it('should only contain valid rules', () => {
       expect(
         Object.keys(eslintPlugin.configs.recommended.rules)
-          .filter((ruleName) => ruleName.startsWith(ESLINT_PLUGIN_PREFFIX))
+          .filter((ruleName) => ruleName.startsWith(ESLINT_PLUGIN_PREFIX))
           .every((ruleName) =>
             Boolean(
-              (eslintPlugin.rules as any)[
-                ruleName.slice(ESLINT_PLUGIN_PREFFIX.length)
+              eslintPlugin.rules[
+                ruleName.slice(
+                  ESLINT_PLUGIN_PREFIX.length,
+                ) as keyof typeof eslintPlugin.rules
               ],
             ),
           ),


### PR DESCRIPTION
Fixes https://github.com/angular-eslint/angular-eslint/issues/247. This:
- Adds `no-any` to the exported rules, as it was missing in https://github.com/angular-eslint/angular-eslint/pull/205
- Sorts the imports & exported rules to clean things up
- Fix the `eslint-plugin` & `eslint-plugin-template` config tests as those were broken (missing `.toBeTrue(true)` assertion)
- Adds `@angular-eslint/template/use-track-by-function` to the `all` config as this was caught by the fixed tests, and sort the rules as well
- Extends the `eslint-plugin` & `eslint-plugin-template` config tests to catch similar issues to https://github.com/angular-eslint/angular-eslint/issues/247, i.e. rules added in the configs but not exported from the configs. For simplicity only the config `rules` entry is currently checked, as `overrides` is not currently used.