### PR TITLE
chore: update verdaccio version and config

### DIFF
--- a/README.md
+++ b/README.md
@@ -404,30 +404,30 @@ If you are still having problems after you have done some digging into these, fe
 
 #### Functionality
 
-| Codelyzer rule                                  |       Status       |
-| ----------------------------------------------- | :----------------: |
-| [`contextual-decorator`]                        |                    |
-| [`contextual-lifecycle`]                        | :white_check_mark: |
-| [`no-attribute-decorator`]                      | :white_check_mark: |
-| [`no-lifecycle-call`]                           | :white_check_mark: |
-| [`no-output-native`]                            | :white_check_mark: |
-| [`no-pipe-impure`]                              | :white_check_mark: |
-| [`prefer-on-push-component-change-detection`]   | :white_check_mark: |
-| [`template-accessibility-alt-text`]             | :white_check_mark: |
-| [`template-accessibility-elements-content`]     | :white_check_mark: |
-| [`template-accessibility-label-for`]            |                    |
-| [`template-accessibility-tabindex-no-positive`] | :white_check_mark: |
-| [`template-accessibility-table-scope`]          | :white_check_mark: |
-| [`template-accessibility-valid-aria`]           | :white_check_mark: |
-| [`template-banana-in-box`]                      | :white_check_mark: |
-| [`template-click-events-have-key-events`]       | :white_check_mark: |
-| [`template-mouse-events-have-key-events`]       | :white_check_mark: |
-| [`template-no-any`]                             | :white_check_mark: |
-| [`template-no-autofocus`]                       | :white_check_mark: |
-| [`template-no-distracting-elements`]            | :white_check_mark: |
-| [`template-no-negated-async`]                   | :white_check_mark: |
-| [`use-injectable-provided-in`]                  | :white_check_mark: |
-| [`use-lifecycle-interface`]                     | :white_check_mark: |
+| Codelyzer rule                                  |          Status           |
+| ----------------------------------------------- | :-----------------------: |
+| [`contextual-decorator`]                        | [:construction:][`pr233`] |
+| [`contextual-lifecycle`]                        |    :white_check_mark:     |
+| [`no-attribute-decorator`]                      |    :white_check_mark:     |
+| [`no-lifecycle-call`]                           |    :white_check_mark:     |
+| [`no-output-native`]                            |    :white_check_mark:     |
+| [`no-pipe-impure`]                              |    :white_check_mark:     |
+| [`prefer-on-push-component-change-detection`]   |    :white_check_mark:     |
+| [`template-accessibility-alt-text`]             |    :white_check_mark:     |
+| [`template-accessibility-elements-content`]     |    :white_check_mark:     |
+| [`template-accessibility-label-for`]            |                           |
+| [`template-accessibility-tabindex-no-positive`] |    :white_check_mark:     |
+| [`template-accessibility-table-scope`]          |    :white_check_mark:     |
+| [`template-accessibility-valid-aria`]           |    :white_check_mark:     |
+| [`template-banana-in-box`]                      |    :white_check_mark:     |
+| [`template-click-events-have-key-events`]       |    :white_check_mark:     |
+| [`template-mouse-events-have-key-events`]       |    :white_check_mark:     |
+| [`template-no-any`]                             |    :white_check_mark:     |
+| [`template-no-autofocus`]                       |    :white_check_mark:     |
+| [`template-no-distracting-elements`]            |    :white_check_mark:     |
+| [`template-no-negated-async`]                   |    :white_check_mark:     |
+| [`use-injectable-provided-in`]                  |    :white_check_mark:     |
+| [`use-lifecycle-interface`]                     |    :white_check_mark:     |
 
 #### Maintainability
 
@@ -527,5 +527,8 @@ If you are still having problems after you have done some digging into these, fe
 [`use-pipe-transform-interface`]: https://codelyzer.com/rules/use-pipe-transform-interface
 
 <!-- PR Links -->
+
+[`pr233`]: https://api.github.com/repos/angular-eslint/angular-eslint/pulls/233
+[`pr260`]: https://api.github.com/repos/angular-eslint/angular-eslint/pulls/260
 
 <!-- end rule list -->

--- a/packages/integration-tests/local-registry/config.yml
+++ b/packages/integration-tests/local-registry/config.yml
@@ -51,4 +51,5 @@ packages:
 
 # log settings
 logs:
-  - { type: stdout, format: pretty, level: http }
+  # Change level to http to get more verbose output when working locally if needed
+  - { type: stdout, format: pretty, level: warn }

--- a/packages/integration-tests/local-registry/config.yml
+++ b/packages/integration-tests/local-registry/config.yml
@@ -13,6 +13,10 @@ uplinks:
     timeout: 60s
     cache: false
     maxage: 30m
+    agent_options:
+      keepAlive: true
+      maxSockets: 40
+      maxFreeSockets: 10
   yarn:
     url: https://registry.yarnpkg.com
     max_fails: 30
@@ -20,6 +24,10 @@ uplinks:
     timeout: 60s
     cache: false
     maxage: 30m
+    agent_options:
+      keepAlive: true
+      maxSockets: 40
+      maxFreeSockets: 10
 
 packages:
   '@*/*':

--- a/packages/integration-tests/local-registry/config.yml
+++ b/packages/integration-tests/local-registry/config.yml
@@ -8,12 +8,18 @@ auth:
 uplinks:
   npmjs:
     url: https://registry.npmjs.org/
-    max_fails: 20
+    max_fails: 30
     fail_timeout: 10m
+    timeout: 60s
+    cache: false
+    maxage: 30m
   yarn:
     url: https://registry.yarnpkg.com
-    max_fails: 20
+    max_fails: 30
     fail_timeout: 10m
+    timeout: 60s
+    cache: false
+    maxage: 30m
 
 packages:
   '@*/*':

--- a/packages/integration-tests/package.json
+++ b/packages/integration-tests/package.json
@@ -14,6 +14,6 @@
     "typescript": "*"
   },
   "devDependencies": {
-    "verdaccio": "^4.8.1"
+    "verdaccio": "^4.10.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3342,17 +3342,17 @@
   dependencies:
     lockfile "1.0.4"
 
-"@verdaccio/local-storage@9.7.2":
-  version "9.7.2"
-  resolved "https://registry.yarnpkg.com/@verdaccio/local-storage/-/local-storage-9.7.2.tgz#af71bc39825b5592d0a761220c94d4e3f0a8b1eb"
-  integrity sha512-Lsn9TR1Jnkl0y7ndQQUi0ypvS9tHT4rqMiMebt2wsiy5mAlLrZ0sjw7erI7wE5sBi/L+uoq0HXfJwLjP8bfrBg==
+"@verdaccio/local-storage@9.7.4":
+  version "9.7.4"
+  resolved "https://registry.yarnpkg.com/@verdaccio/local-storage/-/local-storage-9.7.4.tgz#3ffaa41fc850758296c9f243d765372a2e5e4ea2"
+  integrity sha512-Wj0mJ6FTLGma+nDxpAWJkg7yY0WLh0sUm94juqY9eyWSqOWdv1QvduE9lvl0vh890/QbrlqzxPqxTxeZwsndTA==
   dependencies:
     "@verdaccio/commons-api" "^9.7.1"
     "@verdaccio/file-locking" "^9.7.2"
     "@verdaccio/streams" "^9.7.2"
     async "3.2.0"
     level "5.0.1"
-    lodash "4.17.19"
+    lodash "4.17.20"
     mkdirp "0.5.5"
 
 "@verdaccio/readme@9.7.3":
@@ -3369,10 +3369,10 @@
   resolved "https://registry.yarnpkg.com/@verdaccio/streams/-/streams-9.7.2.tgz#cd5448470d725e221629adb84c74af7dfd8c9678"
   integrity sha512-SoCG1btVFPxOcrs8w9wLJCfe8nfE6EaEXCXyRwGbh+Sr3NLEG0R8JOugGJbuSE+zIRuUs5JaUKjzSec+JKLvZw==
 
-"@verdaccio/ui-theme@1.12.1":
-  version "1.12.1"
-  resolved "https://registry.yarnpkg.com/@verdaccio/ui-theme/-/ui-theme-1.12.1.tgz#5bfc6ed1a222cec0b8d92ac933c3c976dbce2f3e"
-  integrity sha512-J9UEf6MkKugeq5sFhDfqPPGNy4dTSf3fVYK3Q2hGFQiKXvOw7hqovjz6PVOJRNMymBXb2fJuMPIXx1Br3kwD2Q==
+"@verdaccio/ui-theme@1.14.0":
+  version "1.14.0"
+  resolved "https://registry.yarnpkg.com/@verdaccio/ui-theme/-/ui-theme-1.14.0.tgz#22b397f399bf1dfcc8e471d1895c3f74bd340691"
+  integrity sha512-vTzZYnC+HpeeW6pGFBa51rwbqwjqYkgJE1DEF5fSK5V2QbHi+XPIPucm6hrnaZjMlSYbe+4DaMN1XOKLqOJlzg==
 
 "@webassemblyjs/ast@1.9.0":
   version "1.9.0"
@@ -5734,10 +5734,10 @@ dateformat@^3.0.0:
   resolved "https://registry.yarnpkg.com/dateformat/-/dateformat-3.0.3.tgz#a6e37499a4d9a9cf85ef5872044d62901c9889ae"
   integrity sha512-jyCETtSl3VMZMWeRo7iY1FL19ges1t55hMo5yaam4Jrsm5EPL89UQkoQRyiI+Yf4k8r2ZpdngkV8hr1lIdjb3Q==
 
-dayjs@1.8.28:
-  version "1.8.28"
-  resolved "https://registry.yarnpkg.com/dayjs/-/dayjs-1.8.28.tgz#37aa6201df483d089645cb6c8f6cef6f0c4dbc07"
-  integrity sha512-ccnYgKC0/hPSGXxj7Ju6AV/BP4HUkXC2u15mikXT5mX9YorEaoi1bEKOmAqdkJHN4EEkmAf97SpH66Try5Mbeg==
+dayjs@1.9.6:
+  version "1.9.6"
+  resolved "https://registry.yarnpkg.com/dayjs/-/dayjs-1.9.6.tgz#6f0c77d76ac1ff63720dd1197e5cb87b67943d70"
+  integrity sha512-HngNLtPEBWRo8EFVmHFmSXAjtCX8rGNqeXQI0Gh7wCTSqwaKgPIDqu9m07wABVopNwzvOeCb+2711vQhDlcIXw==
 
 debug@2.6.9, debug@^2.2.0, debug@^2.3.3, debug@^2.6.9:
   version "2.6.9"
@@ -6271,10 +6271,10 @@ env-paths@^2.2.0:
   resolved "https://registry.yarnpkg.com/env-paths/-/env-paths-2.2.0.tgz#cdca557dc009152917d6166e2febe1f039685e43"
   integrity sha512-6u0VYSCo/OW6IoD5WCLLy9JUGARbamfSavcNXry/eu8aHVFei6CD3Sw+VGX5alea1i9pgPHW0mbu6Xj0uBh7gA==
 
-envinfo@7.5.1:
-  version "7.5.1"
-  resolved "https://registry.yarnpkg.com/envinfo/-/envinfo-7.5.1.tgz#93c26897225a00457c75e734d354ea9106a72236"
-  integrity sha512-hQBkDf2iO4Nv0CNHpCuSBeaSrveU6nThVxFGTrq/eDlV716UQk09zChaJae4mZRsos1x4YLY2TaH3LHUae3ZmQ==
+envinfo@7.7.3:
+  version "7.7.3"
+  resolved "https://registry.yarnpkg.com/envinfo/-/envinfo-7.7.3.tgz#4b2d8622e3e7366afb8091b23ed95569ea0208cc"
+  integrity sha512-46+j5QxbPWza0PB1i15nZx0xQ4I/EfQxg9J8Had3b408SV63nEtor2e+oiY63amTo9KTuh2a3XLObNwduxYwwA==
 
 envinfo@^7.3.1:
   version "7.7.2"
@@ -9197,10 +9197,10 @@ kind-of@^6.0.0, kind-of@^6.0.2, kind-of@^6.0.3:
   resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-6.0.3.tgz#07c05034a6c349fa06e24fa35aa76db4580ce4dd"
   integrity sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==
 
-kleur@4.0.2:
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/kleur/-/kleur-4.0.2.tgz#57b36cc5235601f824c33e6e45db10cd5493dbf5"
-  integrity sha512-FGCCxczbrZuF5CtMeO0xfnjhzkVZSXfcWK90IPLucDWZwskrpYN7pmRIgvd8muU0mrPrzy4A2RBGuwCjLHI+nw==
+kleur@4.1.3:
+  version "4.1.3"
+  resolved "https://registry.yarnpkg.com/kleur/-/kleur-4.1.3.tgz#8d262a56d79a137ee1b706e967c0b08a7fef4f4c"
+  integrity sha512-H1tr8QP2PxFTNwAFM74Mui2b6ovcY9FoxJefgrwxY+OCJcq01k5nvhf4M/KnizzrJvLRap5STUy7dgDV35iUBw==
 
 kleur@^3.0.3:
   version "3.0.3"
@@ -9666,11 +9666,6 @@ lodash@4.17.15:
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
   integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==
 
-lodash@4.17.19:
-  version "4.17.19"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.19.tgz#e48ddedbe30b3321783c5b4301fbd353bc1e4a4b"
-  integrity sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==
-
 lodash@4.17.20, lodash@^4.17.11, lodash@^4.17.12, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.20, lodash@^4.2.1:
   version "4.17.20"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.20.tgz#b44a9b6297bcb698f1c51a3545a2b3b368d59c52"
@@ -9858,6 +9853,11 @@ marked@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/marked/-/marked-1.1.1.tgz#e5d61b69842210d5df57b05856e0c91572703e6a"
   integrity sha512-mJzT8D2yPxoPh7h0UXkB+dBj4FykPJ2OIfxAWeIHrvoHDkFxukV/29QxoFQoPM6RLEwhIFdJpmKBlqVM3s2ZIw==
+
+marked@1.2.5:
+  version "1.2.5"
+  resolved "https://registry.yarnpkg.com/marked/-/marked-1.2.5.tgz#a44b31f2a0b8b5bfd610f00d55d1952d1ac1dfdb"
+  integrity sha512-2AlqgYnVPOc9WDyWu7S5DJaEZsfk6dNh/neatQ3IHUW4QLutM/VPSH9lG7bif+XjFWc9K9XR3QvR+fXuECmfdA==
 
 maxmin@^2.1.0:
   version "2.1.0"
@@ -14520,16 +14520,16 @@ verdaccio-htpasswd@9.7.2:
     http-errors "1.8.0"
     unix-crypt-td-js "1.1.4"
 
-verdaccio@^4.8.1:
-  version "4.8.1"
-  resolved "https://registry.yarnpkg.com/verdaccio/-/verdaccio-4.8.1.tgz#49df0549d938915633797358f94ed774e294aa97"
-  integrity sha512-6I04bBlY4NS/MtRQismmIA+l/J0MJvBPj78s0p9QMATKDTcsdZS+zXf/Y6a/JsWYqz3fNp94YjV84bLjHrm4UA==
+verdaccio@^4.10.0:
+  version "4.10.0"
+  resolved "https://registry.yarnpkg.com/verdaccio/-/verdaccio-4.10.0.tgz#ca48c4b7a5bb967f0e2b5d38bab599a39cd0aaf1"
+  integrity sha512-9nCIHM9rvgwasBJvo82MiEDzS2HGWolopID8/THU0vZfa1d6MDAiuakjwQ9Z2xDonpoOoDji6xpg2i6il+gEWQ==
   dependencies:
     "@verdaccio/commons-api" "9.7.1"
-    "@verdaccio/local-storage" "9.7.2"
+    "@verdaccio/local-storage" "9.7.4"
     "@verdaccio/readme" "9.7.3"
     "@verdaccio/streams" "9.7.2"
-    "@verdaccio/ui-theme" "1.12.1"
+    "@verdaccio/ui-theme" "1.14.0"
     JSONStream "1.3.5"
     async "3.2.0"
     body-parser "1.19.0"
@@ -14538,17 +14538,17 @@ verdaccio@^4.8.1:
     compression "1.7.4"
     cookies "0.8.0"
     cors "2.8.5"
-    dayjs "1.8.28"
-    envinfo "7.5.1"
+    dayjs "1.9.6"
+    envinfo "7.7.3"
     express "4.17.1"
     handlebars "4.7.6"
     http-errors "1.8.0"
     js-yaml "3.14.0"
     jsonwebtoken "8.5.1"
-    kleur "4.0.2"
-    lodash "4.17.19"
+    kleur "4.1.3"
+    lodash "4.17.20"
     lunr-mutable-indexes "2.3.2"
-    marked "1.1.1"
+    marked "1.2.5"
     mime "2.4.6"
     minimatch "3.0.4"
     mkdirp "0.5.5"


### PR DESCRIPTION
Trying to combat integration test install flakiness by implementing the suggestions from: https://github.com/verdaccio/verdaccio/discussions/2038

I needed to regenerate the README because there are open rule PRs