### PR TITLE
feat(eslint-plugin-template): accessibility-label-for

### DIFF
--- a/README.md
+++ b/README.md
@@ -463,7 +463,7 @@ If you are still having problems after you have done some digging into these, fe
 | [`prefer-on-push-component-change-detection`]   | :white_check_mark: |
 | [`template-accessibility-alt-text`]             | :white_check_mark: |
 | [`template-accessibility-elements-content`]     | :white_check_mark: |
-| [`template-accessibility-label-for`]            |                    |
+| [`template-accessibility-label-for`]            | :white_check_mark: |
 | [`template-accessibility-tabindex-no-positive`] | :white_check_mark: |
 | [`template-accessibility-table-scope`]          | :white_check_mark: |
 | [`template-accessibility-valid-aria`]           | :white_check_mark: |

--- a/packages/eslint-plugin-template/src/configs/all.json
+++ b/packages/eslint-plugin-template/src/configs/all.json
@@ -3,6 +3,7 @@
   "rules": {
     "@angular-eslint/template/accessibility-alt-text": "error",
     "@angular-eslint/template/accessibility-elements-content": "error",
+    "@angular-eslint/template/accessibility-label-for": "error",
     "@angular-eslint/template/accessibility-table-scope": "error",
     "@angular-eslint/template/accessibility-valid-aria": "error",
     "@angular-eslint/template/banana-in-box": "error",

--- a/packages/eslint-plugin-template/src/index.ts
+++ b/packages/eslint-plugin-template/src/index.ts
@@ -9,6 +9,9 @@ import accessibilityAltText, {
 import accessibilityElementsContent, {
   RULE_NAME as accessibilityElementsContentRuleName,
 } from './rules/accessibility-elements-content';
+import accessibilityLabelFor, {
+  RULE_NAME as accessibilityLabelForRuleName,
+} from './rules/accessibility-label-for';
 import accessibilityTableScope, {
   RULE_NAME as accessibilityTableScopeRuleName,
 } from './rules/accessibility-table-scope';
@@ -62,6 +65,7 @@ export default {
   rules: {
     [accessibilityAltTextRuleName]: accessibilityAltText,
     [accessibilityElementsContentRuleName]: accessibilityElementsContent,
+    [accessibilityLabelForRuleName]: accessibilityLabelFor,
     [accessibilityTableScopeRuleName]: accessibilityTableScope,
     [accessibilityValidAriaRuleName]: accessibilityValidAria,
     [bananaInBoxRuleName]: bananaInBox,

--- a/packages/eslint-plugin-template/src/rules/accessibility-label-for.ts
+++ b/packages/eslint-plugin-template/src/rules/accessibility-label-for.ts
@@ -1,0 +1,137 @@
+import { TmplAstElement } from '@angular/compiler';
+import {
+  createESLintRule,
+  getTemplateParserServices,
+} from '../utils/create-eslint-rule';
+import { isChildNodeOf } from '../utils/is-child-node-of';
+
+type Options = [
+  {
+    readonly controlComponents?: readonly string[];
+    readonly labelAttributes?: readonly string[];
+    readonly labelComponents?: readonly string[];
+  },
+];
+export type MessageIds = 'accessibilityLabelFor';
+export const RULE_NAME = 'accessibility-label-for';
+const OPTION_SCHEMA_VALUE = {
+  items: { type: 'string' },
+  type: 'array',
+  uniqueItems: true,
+} as const;
+const DEFAULT_ELEMENTS = [
+  'button',
+  'input',
+  'meter',
+  'output',
+  'progress',
+  'select',
+  'textarea',
+] as const;
+const DEFAULT_LABEL_ATTRIBUTES = ['for', 'htmlFor'] as const;
+const DEFAULT_LABEL_COMPONENTS = ['label'] as const;
+
+export default createESLintRule<Options, MessageIds>({
+  name: RULE_NAME,
+  meta: {
+    type: 'suggestion',
+    docs: {
+      description:
+        'Ensures that a label element/component is associated with a form element',
+      category: 'Best Practices',
+      recommended: false,
+    },
+    schema: [
+      {
+        additionalProperties: false,
+        properties: {
+          controlComponents: OPTION_SCHEMA_VALUE,
+          labelAttributes: OPTION_SCHEMA_VALUE,
+          labelComponents: OPTION_SCHEMA_VALUE,
+        },
+        type: 'object',
+      },
+    ],
+    messages: {
+      accessibilityLabelFor:
+        'A label element/component must be associated with a form element',
+    },
+  },
+  defaultOptions: [
+    {
+      controlComponents: DEFAULT_ELEMENTS,
+      labelAttributes: DEFAULT_LABEL_ATTRIBUTES,
+      labelComponents: DEFAULT_LABEL_COMPONENTS,
+    },
+  ],
+  create(context, [options]) {
+    const parserServices = getTemplateParserServices(context);
+    const {
+      controlComponents,
+      labelAttributes,
+      labelComponents,
+    } = getParsedOptions(options);
+    const labelComponentsPattern = toPattern([...labelComponents]);
+
+    return {
+      [`Element[name=${labelComponentsPattern}]`](node: TmplAstElement) {
+        const attributesInputs: ReadonlySet<string> = new Set(
+          [...node.attributes, ...node.inputs].map(({ name }) => name),
+        );
+        const hasLabelAttribute = [...labelAttributes].some((labelAttribute) =>
+          attributesInputs.has(labelAttribute),
+        );
+
+        if (
+          hasLabelAttribute ||
+          hasControlComponentIn(controlComponents, node)
+        ) {
+          return;
+        }
+
+        const loc = parserServices.convertNodeSourceSpanToLoc(node.sourceSpan);
+
+        context.report({
+          loc,
+          messageId: 'accessibilityLabelFor',
+        });
+      },
+    };
+  },
+});
+
+function getParsedOptions({
+  controlComponents,
+  labelAttributes,
+  labelComponents,
+}: Options[0]) {
+  return {
+    controlComponents: new Set([
+      ...DEFAULT_ELEMENTS,
+      ...(controlComponents ?? []),
+    ]) as ReadonlySet<string>,
+    labelAttributes: new Set([
+      ...DEFAULT_LABEL_ATTRIBUTES,
+      ...(labelAttributes ?? []),
+    ]) as ReadonlySet<string>,
+    labelComponents: new Set([
+      ...DEFAULT_LABEL_COMPONENTS,
+      ...(labelComponents ?? []),
+    ]) as ReadonlySet<string>,
+  } as const;
+}
+
+function hasControlComponentIn(
+  controlComponents: ReadonlySet<string>,
+  element: TmplAstElement,
+): boolean {
+  return Boolean(
+    [...controlComponents].some((controlComponent) =>
+      isChildNodeOf(element, controlComponent),
+    ),
+  );
+}
+
+function toPattern(value: readonly unknown[]): RegExp {
+  return RegExp(`^(${value.join('|')})$`);
+}

--- a/packages/eslint-plugin-template/src/utils/is-child-node-of.ts
+++ b/packages/eslint-plugin-template/src/utils/is-child-node-of.ts
@@ -1,0 +1,16 @@
+import { TmplAstElement } from '@angular/compiler';
+
+export function isChildNodeOf(
+  ast: TmplAstElement,
+  childNodeName: string,
+): boolean {
+  function traverseChildNodes({ children }: TmplAstElement): boolean {
+    return children.some(
+      (child) =>
+        child instanceof TmplAstElement &&
+        (child.name === childNodeName || traverseChildNodes(child)),
+    );
+  }
+
+  return traverseChildNodes(ast);
+}

--- a/packages/eslint-plugin-template/tests/rules/accessibility-label-for.test.ts
+++ b/packages/eslint-plugin-template/tests/rules/accessibility-label-for.test.ts
@@ -1,0 +1,89 @@
+import {
+  convertAnnotatedSourceToFailureCase,
+  RuleTester,
+} from '@angular-eslint/utils';
+import rule, {
+  MessageIds,
+  RULE_NAME,
+} from '../../src/rules/accessibility-label-for';
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+const ruleTester = new RuleTester({
+  parser: '@angular-eslint/template-parser',
+});
+
+const messageId: MessageIds = 'accessibilityLabelFor';
+
+ruleTester.run(RULE_NAME, rule, {
+  valid: [
+    `
+    <ng-container *ngFor="let item of items; index as index">
+      <label for="item-{{index}}">Label #{{index}</label>
+      <input id="item-{{index}}" [(ngModel)]="item.name">
+    </ng-container>
+    <label for="id"></label>
+    <label for="{{id}}"></label>
+    <label [attr.for]="id"></label>
+    <label [htmlFor]="id"></label>
+    `,
+    {
+      code: `
+      <app-label id="name"></app-label>
+      <app-label id="{{name}}"></app-label>
+      <app-label [id]="name"></app-label>
+      `,
+      options: [{ labelAttributes: ['id'], labelComponents: ['app-label'] }],
+    },
+    {
+      code: ` 
+      <label><button>Button</button></label>
+      <label><input type="radio"></label>
+      <label><meter></meter></label>
+      <label><output></output></label>
+      <label><progress></progress></label>
+      <label><select><option>1</option></select></label>
+      <label><textarea></textarea></label>
+      <a-label><input></a-label>
+      <label>
+        Label
+        <input>
+      </label>
+      <label>
+        Label
+        <span><input></span>
+      </label>
+      <app-label>
+        <span>
+          <app-input></app-input>
+        </span>
+      </app-label>
+      `,
+      options: [
+        { controlComponents: ['app-input'], labelComponents: ['app-label'] },
+      ],
+    },
+  ],
+  invalid: [
+    convertAnnotatedSourceToFailureCase({
+      messageId,
+      description: 'should fail if a label does not have a "for" attribute',
+      annotatedSource: `
+        <label>Label</label>
+        ~~~~~~~~~~~~~~~~~~~~
+      `,
+    }),
+    convertAnnotatedSourceToFailureCase({
+      messageId,
+      description:
+        'should fail if a label component does not have a label attribute',
+      annotatedSource: `
+        <app-label anotherAttribute="id"></app-label>
+        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      `,
+      options: [{ labelAttributes: ['id'], labelComponents: ['app-label'] }],
+    }),
+  ],
+});


### PR DESCRIPTION
As soon as I started this implementation, I noticed that [the current version in Codelyzer](https://github.com/mgechev/codelyzer/blob/master/src/templateAccessibilityLabelForRule.ts) has some problems:

1. It doesn't report labels without association, e.g.:

```html
<label for="nonExistentId">Label</label>
<!-- there's no element with `nonExistentId`, but the rule passes --> 
```

2. One could pass control component selectors through the `controlComponents` option, like this:

```json
"template-accessibility-label-for": [true, {
  "controlComponents": ["p-inputMask"],  
}]
```

```html
<app-label labelFor="username">Label<p-inputMask></p-inputMask></app-label>
```

...however one could have a component with an attribute that acts like an `id`, like [the `inputId` here, by example](https://www.primefaces.org/primeng/showcase/#/inputmask) and thus doesn't need to be wrapped by a label/custom label component. This case isn't covered by the rule, e.g.:

```html
<app-label labelFor="username">Label</app-label>
<p-inputMask formControlName="username" inputId="username" mask="(999) 999-9999? x99999"></p-inputMask>
```

3. The `labelAttributes` and `labelComponents` are stored in separated structures and it could be problematic, because a label attribute can cause conflicts depending on the label component you're using, e.g.:

```json
"template-accessibility-label-for": [true, {
  "labelAttributes": ["assoc", "elementId"],
  "labelComponents": ["app-label", "ngx-label"],  
}]
```

```html
<app-label assoc="id"></app-label> <!-- ok -->
<ngx-label assoc="id"></ngx-label > <!-- not ok, but the rule doesn't report -->
<app-label elementId="id"></app-label> <!-- not ok, but the rule doesn't report -->
```

<hr>

After thinking a little bit on how we could store the structures to meet these cases, I came up with this:

```js
"template-accessibility-label-for": [true, {
  "controlComponents": [
    { "inputs": ["id"], "selector": "input" }, // one of the defaults
    { "inputs": ["inputId"], "selector": "p-inputMask" },
    { "selector": "bs4-input" } // when it doesn't have `inputs`, it must be wrapped by a label/label component.
  ],
  "labelComponents": [
    { "inputs": ["for", "htmlFor"], "selector": "label" }, // default
    { "inputs": ["assoc"], "selector": "app-label" },
    { "inputs": ["elementId", "legacyId"], "selector": "ngx-label" },
    { "selector": "ng2-label" }, // when it doesn't have `inputs`, it must wrap a control component.
  ],
}]
```

That being said, would it be a problem for the migration tool to a migrate a rule that changes options like this?
To maintain the behavior in a migration the changes would be like this (I'm using TSLint as an example):

```diff
"template-accessibility-label-for": [true, {
- "controlComponents": ["p-inputMask", "bs4-input"],
- "labelAttributes": ["assoc", "elementId"],
- "labelComponents": ["app-label", "ngx-label"],
+ "controlComponents": [
+   { "selector": "p-inputMask" }, { "selector": "bs4-input" }
+ ],
+ "labelComponents": [
+   { "inputs": ["assoc", "elementId"], "selector": "app-label" },
+   { "inputs": ["assoc", "elementId"], "selector": "ngx-label" }
+ ],
}]
```

I would appreciate a feedback on this, thanks.

Closes #277.