### PR TITLE
fix(eslint-plugin-template): no-call-expression not reporting failures for safe method c…

### DIFF
--- a/packages/eslint-plugin-template/src/rules/no-call-expression.ts
+++ b/packages/eslint-plugin-template/src/rules/no-call-expression.ts
@@ -29,7 +29,7 @@ export default createESLintRule<Options, MessageIds>({
     const sourceCode = context.getSourceCode();
 
     return {
-      ':not(BoundEvent) > * > MethodCall[name!="$any"]'({
+      ':not(BoundEvent) > * > :matches(MethodCall[name!="$any"], SafeMethodCall)'({
         sourceSpan: { end, start },
       }: MethodCall) {
         const loc = {

--- a/packages/eslint-plugin-template/tests/rules/no-call-expression.test.ts
+++ b/packages/eslint-plugin-template/tests/rules/no-call-expression.test.ts
@@ -21,17 +21,15 @@ ruleTester.run(RULE_NAME, rule, {
   valid: [
     `
       {{ info }}
-    `,
-    `
       <button type="button" (click)="handleClick()">Click Here</button>
-    `,
-    `
       {{ $any(info) }}
+      <input (change)="obj?.changeHandler()">
     `,
   ],
   invalid: [
     convertAnnotatedSourceToFailureCase({
-      description: 'it should fail with call expression in expression binding',
+      description:
+        'it should fail for call expression in an expression binding',
       annotatedSource: `
         <div>{{ getInfo() }}</div>
                 ~~~~~~~~~
@@ -39,16 +37,8 @@ ruleTester.run(RULE_NAME, rule, {
       messageId,
     }),
     convertAnnotatedSourceToFailureCase({
-      description: 'it should fail with call expression in expression binding',
-      annotatedSource: `
-        <a href="http://example.com">{{ getInfo() }}</a>
-                                        ~~~~~~~~~
-      `,
-      messageId,
-    }),
-    convertAnnotatedSourceToFailureCase({
       description:
-        'it should fail when using a property resulted from a call expression in expression binding',
+        'it should fail when using a property resulted from a call expression in an expression binding',
       annotatedSource: `
         <a href="http://example.com">{{ getInfo().name }}</a>
                                         ~~~~~~~~~
@@ -56,7 +46,7 @@ ruleTester.run(RULE_NAME, rule, {
       messageId,
     }),
     convertAnnotatedSourceToFailureCase({
-      description: 'it should fail with call expression in property binding',
+      description: 'it should fail for call expression in a property binding',
       annotatedSource: `
         <a [href]="getUrl()">info</a>
                    ~~~~~~~~
@@ -64,12 +54,21 @@ ruleTester.run(RULE_NAME, rule, {
       messageId,
     }),
     convertAnnotatedSourceToFailureCase({
-      description: 'it should fail with a property access call expression',
+      description: 'it should fail for safe/unsafe method calls',
       annotatedSource: `
-        <a [href]="helper.getUrl()">info</a>
-                   ~~~~~~~~~~~~~~~
+        {{ obj?.nested1() }} {{ obj!.nested1() }}
+            ~~~~~~~~~~~~~~       ^^^^^^^^^^^^^^      
+        <button [type]="obj!.$any(b)!.getType()">info</button>
+                        #######################
+        <a [href]="obj.propertyA?.href()">info</a>
+                   %%%%%%%%%%%%%%%%%%%%%
       `,
-      messageId,
+      messages: [
+        { char: '~', messageId },
+        { char: '^', messageId },
+        { char: '#', messageId },
+        { char: '%', messageId },
+      ],
     }),
   ],
 });


### PR DESCRIPTION
…alls

As reported in https://github.com/mgechev/codelyzer/issues/757, `no-call-expression` doesn't report failures for safe method calls, e.g.:

```html
{{ a?.b() }}
```

About https://github.com/mgechev/codelyzer/issues/757#issuecomment-620679346, I don't know if we would be able to perform this check without turn the `requiresTypeChecking` on...