### PR TITLE
fix(eslint-plugin-template): accessibility-valid-aria reporting non a…

### DIFF
--- a/packages/eslint-plugin-template/src/rules/accessibility-valid-aria.ts
+++ b/packages/eslint-plugin-template/src/rules/accessibility-valid-aria.ts
@@ -9,20 +9,21 @@ import {
 type Options = [];
 export type MessageIds = 'accessibilityValidAria';
 export const RULE_NAME = 'accessibility-valid-aria';
+const ARIA_PATTERN = /^aria-.*/;
 
 export default createESLintRule<Options, MessageIds>({
   name: RULE_NAME,
   meta: {
     type: 'suggestion',
     docs: {
-      description: 'Ensures that the correct ARIA attributes are used.',
+      description: 'Ensures that correct ARIA attributes are used',
       category: 'Best Practices',
       recommended: false,
     },
     schema: [],
     messages: {
       accessibilityValidAria:
-        '{{attribute}}: This attribute is an invalid ARIA attribute.',
+        'The `{{attribute}}` is an invalid ARIA attribute',
     },
   },
   defaultOptions: [],
@@ -30,27 +31,25 @@ export default createESLintRule<Options, MessageIds>({
     const parserServices = getTemplateParserServices(context);
 
     return {
-      'TextAttribute[name=/aria-*/], BoundAttribute[name=/aria-*/]'({
-        name,
+      [`BoundAttribute[name=${ARIA_PATTERN}], TextAttribute[name=${ARIA_PATTERN}]`]({
+        name: attribute,
         sourceSpan,
-      }: TmplAstTextAttribute | TmplAstBoundAttribute) {
-        if (getAriaAttributes().has(name)) {
-          return;
-        }
+      }: TmplAstBoundAttribute | TmplAstTextAttribute) {
+        if (getAriaAttributes().has(attribute)) return;
 
         const loc = parserServices.convertNodeSourceSpanToLoc(sourceSpan);
 
         context.report({
           loc,
           messageId: 'accessibilityValidAria',
-          data: { attribute: name },
+          data: { attribute },
         });
       },
     };
   },
 });
 
-let ariaAttributes: Set<string> | null = null;
-function getAriaAttributes(): Set<string> {
+let ariaAttributes: ReadonlySet<string> | null = null;
+function getAriaAttributes(): ReadonlySet<string> {
   return ariaAttributes || (ariaAttributes = new Set<string>(aria.keys()));
 }

--- a/packages/eslint-plugin-template/tests/rules/accessibility-valid-aria.test.ts
+++ b/packages/eslint-plugin-template/tests/rules/accessibility-valid-aria.test.ts
@@ -14,31 +14,31 @@ import rule, {
 const ruleTester = new RuleTester({
   parser: '@angular-eslint/template-parser',
 });
-
 const messageId: MessageIds = 'accessibilityValidAria';
 
 ruleTester.run(RULE_NAME, rule, {
   valid: [
     '<input aria-labelledby="Text">',
-    '<input [attr.aria-labelledby]="text">',
+    '<div ariaselected="0"></div>',
+    '<textarea [attr.aria-readonly]="readonly"></textarea>',
+    '<button [variant]="variant">Text</button>',
   ],
   invalid: [
     convertAnnotatedSourceToFailureCase({
-      messageId,
-      description:
-        'should fail when aria attributes are misspelled or if they does not exist',
+      description: 'should fail if the attribute is an invalid ARIA attribute',
       annotatedSource: `
-        <input aria-labelby="text">
-               ~~~~~~~~~~~~~~~~~~~
+        <div aria-roledescriptio="text">Text</div>
+             ~~~~~~~~~~~~~~~~~~~~~~~~~~
+        <input [aria-labelby]="label">
+               ^^^^^^^^^^^^^^^^^^^^^^               
+        <input [attr.aria-requiredIf]="required">
+               #################################
       `,
-    }),
-    convertAnnotatedSourceToFailureCase({
-      messageId,
-      description: 'should fail when using wrong aria attributes with inputs',
-      annotatedSource: `
-        <input [aria-labelby]="text">
-               ~~~~~~~~~~~~~~~~~~~~~
-      `,
+      messages: [
+        { char: '~', messageId },
+        { char: '^', messageId },
+        { char: '#', messageId },
+      ],
     }),
   ],
 });


### PR DESCRIPTION
…ria attributes

Currently the rule `accessibility-valid-aria` reports any word that **contain** the word "aria", like "variant", "arial", "ariaAnother", etc., while it should only report words that **start** with "aria-".

Fixes #271.

