### PR TITLE
chore: temporarily pin node 15 to 15.4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,10 @@ jobs:
     - name: Setup Node.js for use with actions
       uses: actions/setup-node@v1
       with:
-        version: 15
+        # Temporarily pinning to 15.4 for the v15 installation because there is some change in NPM
+        # that causes a ENEEDAUTH error in the publishing step of the integration-tests that needs
+        # to be figured out
+        version: 15.4
 
     - name: Get yarn cache directory path
       id: yarn-cache-dir-path

--- a/README.md
+++ b/README.md
@@ -528,7 +528,6 @@ If you are still having problems after you have done some digging into these, fe
 
 <!-- PR Links -->
 
-[`pr233`]: https://api.github.com/repos/angular-eslint/angular-eslint/pulls/233
 [`pr260`]: https://api.github.com/repos/angular-eslint/angular-eslint/pulls/260
 
 <!-- end rule list -->


### PR DESCRIPTION
Temporarily pinning to 15.4 for the v15 installation because there is some change in NPM that causes a ENEEDAUTH error in the publishing step of the integration-tests that needs to be figured out.

It could be caused by: https://github.com/npm/cli/issues/2411, but needs more investigation, I want to unblock us for now as the priority