### PR TITLE
docs: Created docs for rule 'component-class-suffix'

### DIFF
--- a/packages/eslint-plugin/docs/rules/component-class-suffix.md
+++ b/packages/eslint-plugin/docs/rules/component-class-suffix.md
@@ -1,0 +1,74 @@
+# Enforces components to have a specified suffix (`component-class-suffix`)
+
+This rule enforces that classes decorated with @Component must have suffix "Component" (or custom) in their name.
+
+## Rule Details
+
+This rule follows the recommendation from the [Angular styleguide](https://angular.io/guide/styleguide#style-02-03).
+
+Examples of **incorrect** code for this rule (with default configuration):
+
+```javascript
+@Component({
+	selector: "app-root",
+	templateUrl: "./app.component.html",
+	styleUrls: ["./app.component.css"]
+})
+class App {}
+```
+
+Example of **correct** code for this rule:
+```javascript
+@Component({
+	selector: "app-root",
+	templateUrl: "./app.component.html",
+	styleUrls: ["./app.component.css"]
+})
+class AppComponent {}
+```
+
+## Options
+
+By default, the suffix will be `Component`. You may pass an array of suffixes, for example:
+```json
+{
+    "@angular-eslint/component-class-suffix": ["error", {
+        "suffixes": ["Component", "Comp"]
+    }]
+}
+```
+
+Examples of **incorrect** code with the above options:
+
+```javascript
+@Component({
+	selector: "app-root",
+	templateUrl: "./app.component.html",
+	styleUrls: ["./app.component.css"]
+})
+export class AppCompe {}
+
+@Component({
+	selector: "app-root",
+	templateUrl: "./app.component.html",
+	styleUrls: ["./app.component.css"]
+})
+export class App {}
+```
+
+Example of **correct** code with the above options:
+```javascript
+@Component({
+	selector: "app-root",
+	templateUrl: "./app.component.html",
+	styleUrls: ["./app.component.css"]
+})
+export class AppComp {}
+
+@Component({
+	selector: "app-root",
+	templateUrl: "./app.component.html",
+	styleUrls: ["./app.component.css"]
+})
+export class AppComponent {}
+```

--- a/packages/eslint-plugin/docs/rules/component-class-suffix.md
+++ b/packages/eslint-plugin/docs/rules/component-class-suffix.md
@@ -8,7 +8,7 @@ This rule follows the recommendation from the [Angular styleguide](https://angul
 
 Examples of **incorrect** code for this rule (with default configuration):
 
-```javascript
+```ts
 @Component({
   selector: 'app-root',
   templateUrl: './app.component.html',
@@ -19,7 +19,7 @@ class App {}
 
 Example of **correct** code for this rule:
 
-```javascript
+```ts
 @Component({
   selector: 'app-root',
   templateUrl: './app.component.html',
@@ -45,7 +45,7 @@ By default, the suffix will be `Component`. You may pass an array of suffixes, f
 
 Examples of **incorrect** code with the above options:
 
-```javascript
+```ts
 @Component({
   selector: 'app-root',
   templateUrl: './app.component.html',
@@ -63,7 +63,7 @@ export class App {}
 
 Example of **correct** code with the above options:
 
-```javascript
+```ts
 @Component({
   selector: 'app-root',
   templateUrl: './app.component.html',

--- a/packages/eslint-plugin/docs/rules/component-class-suffix.md
+++ b/packages/eslint-plugin/docs/rules/component-class-suffix.md
@@ -10,19 +10,20 @@ Examples of **incorrect** code for this rule (with default configuration):
 
 ```javascript
 @Component({
-	selector: "app-root",
-	templateUrl: "./app.component.html",
-	styleUrls: ["./app.component.css"]
+  selector: 'app-root',
+  templateUrl: './app.component.html',
+  styleUrls: ['./app.component.css'],
 })
 class App {}
 ```
 
 Example of **correct** code for this rule:
+
 ```javascript
 @Component({
-	selector: "app-root",
-	templateUrl: "./app.component.html",
-	styleUrls: ["./app.component.css"]
+  selector: 'app-root',
+  templateUrl: './app.component.html',
+  styleUrls: ['./app.component.css'],
 })
 class AppComponent {}
 ```
@@ -30,11 +31,15 @@ class AppComponent {}
 ## Options
 
 By default, the suffix will be `Component`. You may pass an array of suffixes, for example:
+
 ```json
 {
-    "@angular-eslint/component-class-suffix": ["error", {
-        "suffixes": ["Component", "Comp"]
-    }]
+  "@angular-eslint/component-class-suffix": [
+    "error",
+    {
+      "suffixes": ["Component", "Comp"]
+    }
+  ]
 }
 ```
 
@@ -42,33 +47,34 @@ Examples of **incorrect** code with the above options:
 
 ```javascript
 @Component({
-	selector: "app-root",
-	templateUrl: "./app.component.html",
-	styleUrls: ["./app.component.css"]
+  selector: 'app-root',
+  templateUrl: './app.component.html',
+  styleUrls: ['./app.component.css'],
 })
 export class AppCompe {}
 
 @Component({
-	selector: "app-root",
-	templateUrl: "./app.component.html",
-	styleUrls: ["./app.component.css"]
+  selector: 'app-root',
+  templateUrl: './app.component.html',
+  styleUrls: ['./app.component.css'],
 })
 export class App {}
 ```
 
 Example of **correct** code with the above options:
+
 ```javascript
 @Component({
-	selector: "app-root",
-	templateUrl: "./app.component.html",
-	styleUrls: ["./app.component.css"]
+  selector: 'app-root',
+  templateUrl: './app.component.html',
+  styleUrls: ['./app.component.css'],
 })
 export class AppComp {}
 
 @Component({
-	selector: "app-root",
-	templateUrl: "./app.component.html",
-	styleUrls: ["./app.component.css"]
+  selector: 'app-root',
+  templateUrl: './app.component.html',
+  styleUrls: ['./app.component.css'],
 })
 export class AppComponent {}
 ```


### PR DESCRIPTION
Docs for rule [component-class-sufix](https://github.com/angular-eslint/angular-eslint/blob/master/packages/eslint-plugin/src/rules/component-class-suffix.ts), in accordance to the effort for documentation #197