### PR TITLE
fix(eslint-plugin-template): conditional-complexity not reporting all cases

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,12 @@
+# These are supported funding model platforms
+
+github: # Replace with up to 4 GitHub Sponsors-enabled usernames e.g., [user1, user2]
+patreon: # Replace with a single Patreon username
+open_collective: # Replace with a single Open Collective username
+ko_fi: # Replace with a single Ko-fi username
+tidelift: # Replace with a single Tidelift platform-name/package-name e.g., npm/babel
+community_bridge: # Replace with a single Community Bridge project-name e.g., cloud-foundry
+liberapay: # Replace with a single Liberapay username
+issuehunt: # Replace with a single IssueHunt username
+otechie: # Replace with a single Otechie username
+custom: ['https://buymeacoffee.com/jameshenry']

--- a/packages/eslint-plugin-template/src/rules/conditional-complexity.ts
+++ b/packages/eslint-plugin-template/src/rules/conditional-complexity.ts
@@ -1,6 +1,10 @@
 import {
+  AST,
   ASTWithSource,
   Binary,
+  BindingPipe,
+  Conditional,
+  Interpolation,
   Lexer,
   Parser,
   TmplAstBoundAttribute,
@@ -8,11 +12,11 @@ import {
 
 import {
   createESLintRule,
+  ensureTemplateParser,
   getTemplateParserServices,
 } from '../utils/create-eslint-rule';
 
 type Options = [{ maxComplexity: number }];
-
 export type MessageIds = 'conditionalСomplexity';
 export const RULE_NAME = 'conditional-complexity';
 
@@ -21,37 +25,41 @@ export default createESLintRule<Options, MessageIds>({
   meta: {
     type: 'suggestion',
     docs: {
-      description: `The condition complexity shouldn't exceed a rational limit in a template.`,
+      description:
+        'The conditional complexity should not exceed a rational limit',
       category: 'Best Practices',
       recommended: false,
     },
     schema: [
       {
         type: 'object',
-        properties: {
-          maxComplexity: {
-            type: 'number',
-            minimum: 1,
-          },
-        },
+        properties: { maxComplexity: { minimum: 1, type: 'number' } },
         additionalProperties: false,
       },
     ],
     messages: {
       conditionalСomplexity:
-        'The condition complexity "{{totalComplexity}}" exceeds the defined limit "{{maxComplexity}}"',
+        'The conditional complexity "{{totalComplexity}}" exceeds the defined limit "{{maxComplexity}}"',
     },
   },
   defaultOptions: [{ maxComplexity: 5 }],
   create(context, [{ maxComplexity }]) {
+    ensureTemplateParser(context);
+    const sourceCode = context.getSourceCode();
     const parserServices = getTemplateParserServices(context);
 
     return {
-      'BoundAttribute[name="ngIf"]'({
+      BoundAttribute({
+        value: { source },
         sourceSpan,
-        value,
-      }: TmplAstBoundAttribute) {
-        const totalComplexity = getTotalComplexity(value as ASTWithSource);
+      }: TmplAstBoundAttribute & { value: ASTWithSource }) {
+        if (!source) return;
+
+        const rawSource = source.replace(/\s/g, '');
+        const possibleBinary = extractPossibleBinaryOrConditionalFrom(
+          getParser().parseBinding(rawSource, null, 0).ast,
+        );
+        const totalComplexity = getTotalComplexity(possibleBinary);
 
         if (totalComplexity <= maxComplexity) return;
 
@@ -63,9 +71,34 @@ export default createESLintRule<Options, MessageIds>({
           data: { maxComplexity, totalComplexity },
         });
       },
+      Interpolation({ expressions }: Interpolation) {
+        for (const expression of expressions) {
+          const totalComplexity = getTotalComplexity(expression);
+
+          if (totalComplexity <= maxComplexity) continue;
+
+          const {
+            sourceSpan: { end, start },
+          } = expression;
+          const loc = {
+            end: sourceCode.getLocFromIndex(end),
+            start: sourceCode.getLocFromIndex(start),
+          } as const;
+
+          context.report({
+            loc,
+            messageId: 'conditionalСomplexity',
+            data: { maxComplexity, totalComplexity },
+          });
+        }
+      },
     };
   },
 });
+
+function extractPossibleBinaryOrConditionalFrom(node: AST): AST {
+  return node instanceof BindingPipe ? node.exp : node;
+}
 
 let parser: Parser | null = null;
 // Instantiate the `Parser` class lazily only when this rule is applied.
@@ -73,36 +106,38 @@ function getParser(): Parser {
   return parser || (parser = new Parser(new Lexer()));
 }
 
-function getTotalComplexity({ source }: ASTWithSource): number {
-  const expression = source?.replace(/\s/g, '') ?? '';
-  const parser = getParser();
-  const astWithSource = parser.parseAction(expression, null, 0);
-  const conditions: Binary[] = [];
-  let totalComplexity = 0;
-  let condition = astWithSource.ast as Binary;
+function getTotalComplexity(ast: AST): number {
+  const possibleBinaryOrConditional = extractPossibleBinaryOrConditionalFrom(
+    ast,
+  );
 
-  if (condition.operation) {
-    totalComplexity++;
-    conditions.push(condition);
+  if (
+    !(
+      possibleBinaryOrConditional instanceof Binary ||
+      possibleBinaryOrConditional instanceof Conditional
+    )
+  ) {
+    return 0;
   }
 
-  while (conditions.length > 0) {
-    const condition = conditions.pop()!;
+  let total = 1;
 
-    if (!condition.operation) {
-      continue;
+  if (possibleBinaryOrConditional instanceof Binary) {
+    if (possibleBinaryOrConditional.left instanceof Binary) {
+      total += getTotalComplexity(possibleBinaryOrConditional.left);
     }
 
-    if (condition.left instanceof Binary) {
-      totalComplexity++;
-      conditions.push(condition.left);
-    }
-
-    if (condition.right instanceof Binary) {
-      totalComplexity++;
-      conditions.push(condition.right);
+    if (possibleBinaryOrConditional.right instanceof Binary) {
+      total += getTotalComplexity(possibleBinaryOrConditional.right);
     }
   }
 
-  return totalComplexity;
+  if (possibleBinaryOrConditional instanceof Conditional) {
+    total +=
+      getTotalComplexity(possibleBinaryOrConditional.condition) +
+      getTotalComplexity(possibleBinaryOrConditional.trueExp) +
+      getTotalComplexity(possibleBinaryOrConditional.falseExp);
+  }
+
+  return total;
 }

--- a/packages/eslint-plugin-template/src/rules/conditional-complexity.ts
+++ b/packages/eslint-plugin-template/src/rules/conditional-complexity.ts
@@ -12,7 +12,6 @@ import {
 
 import {
   createESLintRule,
-  ensureTemplateParser,
   getTemplateParserServices,
 } from '../utils/create-eslint-rule';
 
@@ -44,7 +43,6 @@ export default createESLintRule<Options, MessageIds>({
   },
   defaultOptions: [{ maxComplexity: 5 }],
   create(context, [{ maxComplexity }]) {
-    ensureTemplateParser(context);
     const sourceCode = context.getSourceCode();
     const parserServices = getTemplateParserServices(context);
 

--- a/packages/eslint-plugin-template/src/utils/create-eslint-rule.ts
+++ b/packages/eslint-plugin-template/src/utils/create-eslint-rule.ts
@@ -25,12 +25,13 @@ export function getTemplateParserServices(context: any): ParserServices {
  * If @angular-eslint/template-parser is not the configured parser when the function is invoked it will throw
  */
 export function ensureTemplateParser(
-  context: TSESLint.RuleContext<string, []>,
+  context: TSESLint.RuleContext<string, readonly unknown[]>,
 ) {
   if (
-    !context.parserServices ||
-    !(context.parserServices as any).convertNodeSourceSpanToLoc ||
-    (!context.parserServices as any).convertElementSourceSpanToLoc
+    !((context.parserServices as unknown) as ParserServices)
+      ?.convertNodeSourceSpanToLoc ||
+    !((context.parserServices as unknown) as ParserServices)
+      ?.convertElementSourceSpanToLoc
   ) {
     /**
      * The user needs to have configured "parser" in their eslint config and set it

--- a/packages/eslint-plugin-template/tests/rules/conditional-complexity.test.ts
+++ b/packages/eslint-plugin-template/tests/rules/conditional-complexity.test.ts
@@ -14,91 +14,100 @@ import rule, {
 const ruleTester = new RuleTester({
   parser: '@angular-eslint/template-parser',
 });
-
 const messageId: MessageIds = 'conditionalСomplexity';
 
 ruleTester.run(RULE_NAME, rule, {
   valid: [
-    {
-      code: `
-        <div *ngIf="a === '1' || b === '2' && c.d !== e">
-          Enter your card details
-        </div>
-      `,
-    },
-    {
-      code: `
-        <div *ngIf="a === '1' || (b === '2' && c.d !== e)">
-          Enter your card details
-        </div>
-      `,
-    },
+    `
+      <div *ngIf="a === '1' || b === '2' && c.d !== e">Content</div>
+      <div *ngIf="isValid; then thenTemplateRef; else elseTemplateRef">Content</div>
+      <ng-template #thenTemplateRef>thenTemplateRef</ng-template>
+      <ng-template #elseTemplateRef>elseTemplateRef</ng-template>
+      <div [class.mw-100]="test === 7"></div>
+      <div [attr.aria-label]="testing === 'ab' ? 'bc' : 'de'"></div>
+      <div [attr.custom-attr]="'test345' | appPipe"></div>
+    `,
     {
       code: `
         <div *ngIf="a === '3' || (b === '3' && c.d !== '1' && e.f !== '6' && q !== g)">
-          Enter your card details
-        </div>
-    `,
-      options: [{ maxComplexity: 9 }],
-    },
-    {
-      code: `
-        <div *ngIf="(b === '3' && c.d !== '1' && e.f !== '6' && q !== g) || a === '3'">
-          Enter your card details
+          Content
         </div>
       `,
       options: [{ maxComplexity: 9 }],
-    },
-    {
-      code: `
-        <div *ngIf="isValid; then thenBlock; else elseBlock">
-          Enter your card details
-        </div>
-        <ng-template #thenBlock>
-          thenBlock
-        </ng-template>
-        <ng-template #elseBlock>
-          elseBlock
-        </ng-template>
-      `,
     },
   ],
   invalid: [
     convertAnnotatedSourceToFailureCase({
       messageId,
-      description: 'should fail with a higher level of complexity',
+      description:
+        'should fail if the conditional complexity exceeds the maximum default',
       annotatedSource: `
         <div *ngIf="a === '3' || (b === '3' && c.d !== '1' && e.f !== '6' && q !== g)">
               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-          Enter your card details
+          Content
         </div>
       `,
+      data: { maxComplexity: 5, totalComplexity: 9 },
     }),
     convertAnnotatedSourceToFailureCase({
       messageId,
       description:
-        'should fail with a higher level of complexity and a carrier return',
+        'should fail if the conditional complexity exceeds the maximum defined',
       annotatedSource: `
-        <div *ngIf="a === '3' || (b === '3' && c.d !== '1'
-              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-                    && e.f !== '6' && q !== g)">
-                    ~~~~~~~~~~~~~~~~~~~~~~~~~~
-          Enter your card details
-        </div>
+        <ng-container *ngIf="control && control.invalid && (control.touched || (showOnDirty && control.dirty))">
+                       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+          Content
+        </ng-container>
       `,
+      data: { maxComplexity: 3, totalComplexity: 4 },
+      options: [{ maxComplexity: 3 }],
     }),
     convertAnnotatedSourceToFailureCase({
       messageId,
       description:
-        'should fail with a higher level of complexity with ng-template',
+        'should fail if the conditional complexity exceeds the maximum defined when using pipes to create a variable',
       annotatedSource: `
-        <ng-template [ngIf]="a === '3' || (b === '3' && c.d !== '1'
-                     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-                    && e.f !== '6' && q !== g && x === '1')">
-                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-          Enter details
-        </ng-template>
+        <ng-container *ngIf="control && control.invalid && (control.touched || (showOnDirty && control.dirty)) && control.errors | keys as errorKeys">
+                       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+          {{ errorKeys }}
+        </ng-container>
       `,
+      data: { maxComplexity: 2, totalComplexity: 5 },
+      options: [{ maxComplexity: 2 }],
+    }),
+    convertAnnotatedSourceToFailureCase({
+      messageId,
+      description:
+        'should fail if the conditional complexity exceeds the maximum default when using [class] binding',
+      annotatedSource: `
+        <div [class.px-4]="a <= b || (b > c && c >= d && d < e)">
+             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+          Content
+        </div>
+      `,
+      data: { maxComplexity: 5, totalComplexity: 7 },
+    }),
+    convertAnnotatedSourceToFailureCase({
+      messageId,
+      description:
+        'should fail if the conditional complexity exceeds the maximum default when using nested conditionals',
+      annotatedSource: `
+        <div [class.my-2]="a === 'x' ? v === c : b === 3 ? 0 : c > 3 && d === 9 ? 9 : 'xa'">
+             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+          Content
+        </div>
+      `,
+      data: { maxComplexity: 5, totalComplexity: 9 },
+    }),
+    convertAnnotatedSourceToFailureCase({
+      messageId,
+      description:
+        'should fail if the conditional complexity exceeds the maximum default when using conditionals within interpolation',
+      annotatedSource: `
+        {{ test.xyz }} {{ ab > 2 && cd === 9 && control?.invalid && (control.touched || (showOnDirty && control.dirty)) ? 'some value' : 'another value' }} {{ control.touched }}
+                           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~      
+      `,
+      data: { maxComplexity: 5, totalComplexity: 8 },
     }),
   ],
 });


### PR DESCRIPTION
This PR aims to fix the cases:

- report when using any other bound attribute besides `ngIf`, which is the only one currently reported;
- *report when using a `Pipe` as the last statement in a condition;
- report when using `Conditional`;
- report when using `Interpolation`;

This also removes some duplicate unit tests and include `data` to ensure the complexity is computed correctly.

*: This case was reported in #280 (**case 3**) and is partially fixed here, because it was fixed only when it appears as the last statement in a condition. To completely fix it, further investigation will be required and will take some more time and probably better to do in another PR.