### PR TITLE
fix: Add missing colon

### DIFF
--- a/README.md
+++ b/README.md
@@ -464,7 +464,8 @@ For example, it may look like:
 ```jsonc
 {
   "extends": "./tsconfig.json",
-  "include": [ // adjust "includes" to what makes sense for you and your project
+  "include": [ 
+    // adjust "includes" to what makes sense for you and your project
     "src/**/*.ts",
     "e2e/**/*.ts"
   ]

--- a/README.md
+++ b/README.md
@@ -464,7 +464,7 @@ For example, it may look like:
 ```jsonc
 {
   "extends": "./tsconfig.json",
-  "include" [ // adjust "includes" to what makes sense for you and your project
+  "include": [ // adjust "includes" to what makes sense for you and your project
     "src/**/*.ts",
     "e2e/**/*.ts"
   ]

--- a/README.md
+++ b/README.md
@@ -464,7 +464,7 @@ For example, it may look like:
 ```jsonc
 {
   "extends": "./tsconfig.json",
-  "include": [ 
+  "include": [
     // adjust "includes" to what makes sense for you and your project
     "src/**/*.ts",
     "e2e/**/*.ts"


### PR DESCRIPTION
Add missing colon so it does not error when you copy the example. 