### PR TITLE
fix(eslint-plugin): component-max-inline-declarations animations not being checked properly 

### DIFF
--- a/packages/eslint-plugin/src/rules/component-max-inline-declarations.ts
+++ b/packages/eslint-plugin/src/rules/component-max-inline-declarations.ts
@@ -1,24 +1,22 @@
 import { TSESTree } from '@typescript-eslint/experimental-utils';
 import { createESLintRule } from '../utils/create-eslint-rule';
+import { COMPONENT_CLASS_DECORATOR } from '../utils/selectors';
 import {
-  getDecoratorPropertyValue,
+  isArrayExpression,
   isLiteral,
   isTemplateLiteral,
-  isArrayExpression,
 } from '../utils/utils';
-import { COMPONENT_CLASS_DECORATOR } from '../utils/selectors';
 
 type Options = [
   {
-    template?: number;
-    styles?: number;
-    animations?: number;
+    readonly template?: number;
+    readonly styles?: number;
+    readonly animations?: number;
   },
 ];
-export const messageId = 'componentMaxInlineDeclarations';
-export type MessageIds = typeof messageId;
+export type MessageIds = 'componentMaxInlineDeclarations';
 export const RULE_NAME = 'component-max-inline-declarations';
-const STYLE_GUIDE_LINK = 'https://angular.io/guide/styleguide#style-05-04.';
+const STYLE_GUIDE_LINK = 'https://angular.io/guide/styleguide#style-05-04';
 const NEW_LINE_REGEXP = /\r\n|\r|\n/;
 const DEFAULT_TEMPLATE_LIMIT = 3;
 const DEFAULT_STYLES_LIMIT = 3;
@@ -27,9 +25,12 @@ const DEFAULT_ANIMATIONS_LIMIT = 15;
 function getLinesCount(node: TSESTree.Node): number {
   if (isTemplateLiteral(node)) {
     return node.quasis[0].value.raw.trim().split(NEW_LINE_REGEXP).length;
-  } else if (isLiteral(node)) {
+  }
+
+  if (isLiteral(node)) {
     return node.raw.trim().split(NEW_LINE_REGEXP).length;
   }
+
   return 0;
 }
 
@@ -39,7 +40,7 @@ export default createESLintRule<Options, MessageIds>({
     type: 'suggestion',
     docs: {
       description:
-        'Disallows having too many lines in inline template and styles. Forces separate template or styles file creation.',
+        'Enforces a maximum number of lines in inline template, styles and animations',
       category: 'Best Practices',
       recommended: false,
     },
@@ -61,7 +62,7 @@ export default createESLintRule<Options, MessageIds>({
       },
     ],
     messages: {
-      componentMaxInlineDeclarations: `Exceeds the maximum allowed inline lines for {{propertyType}}. Defined limit: {{definedLimit}} / total lines: {{totalLines}} (${STYLE_GUIDE_LINK})`,
+      componentMaxInlineDeclarations: `\`{{propertyType}}\` has too many lines ({{lineCount}}). Maximum allowed is {{max}} (${STYLE_GUIDE_LINK})`,
     },
   },
   defaultOptions: [
@@ -75,70 +76,68 @@ export default createESLintRule<Options, MessageIds>({
     template = template > -1 ? template : DEFAULT_TEMPLATE_LIMIT;
     styles = styles > -1 ? styles : DEFAULT_STYLES_LIMIT;
     animations = animations > -1 ? animations : DEFAULT_ANIMATIONS_LIMIT;
+
     return {
-      [COMPONENT_CLASS_DECORATOR](node: TSESTree.Decorator) {
-        const templatePropertyValue = getDecoratorPropertyValue(
-          node,
-          'template',
-        );
-        if (templatePropertyValue) {
-          const totalLines = getLinesCount(templatePropertyValue);
-          if (totalLines > template) {
-            context.report({
-              node: templatePropertyValue,
-              messageId,
-              data: {
-                propertyType: 'template',
-                definedLimit: template,
-                totalLines,
-              },
-            });
-          }
-        }
+      [`${COMPONENT_CLASS_DECORATOR} Property[key.name='template']`]({
+        value,
+      }: TSESTree.Property) {
+        const lineCount = getLinesCount(value);
 
-        const stylesPropertyValue = getDecoratorPropertyValue(node, 'styles');
-        if (stylesPropertyValue && isArrayExpression(stylesPropertyValue)) {
-          const totalLines = stylesPropertyValue.elements.reduce(
-            (lines, element) => lines + getLinesCount(element),
-            0,
-          );
-          if (totalLines > styles) {
-            context.report({
-              node: stylesPropertyValue,
-              messageId,
-              data: {
-                propertyType: 'styles',
-                definedLimit: styles,
-                totalLines,
-              },
-            });
-          }
-        }
+        if (lineCount <= template) return;
 
-        const animationsPropertyValue = getDecoratorPropertyValue(
-          node,
-          'animations',
+        context.report({
+          node: value,
+          messageId: 'componentMaxInlineDeclarations',
+          data: {
+            lineCount,
+            max: template,
+            propertyType: 'template',
+          },
+        });
+      },
+      [`${COMPONENT_CLASS_DECORATOR} Property[key.name='styles']`]({
+        value,
+      }: TSESTree.Property) {
+        if (!isArrayExpression(value)) return;
+
+        const lineCount = value.elements.reduce(
+          (lines, element) => lines + getLinesCount(element),
+          0,
         );
-        if (
-          animationsPropertyValue &&
-          isArrayExpression(animationsPropertyValue)
-        ) {
-          const totalLines = animationsPropertyValue.elements.reduce(
-            (lines, element) => lines + getLinesCount(element),
-            0,
-          );
-          if (totalLines > animations) {
-            context.report({
-              node: animationsPropertyValue,
-              messageId,
-              data: {
-                propertyType: 'animations',
-                definedLimit: animations,
-                totalLines,
-              },
-            });
-          }
-        }
+
+        if (lineCount <= styles) return;
+
+        context.report({
+          node: value,
+          messageId: 'componentMaxInlineDeclarations',
+          data: {
+            lineCount,
+            max: styles,
+            propertyType: 'styles',
+          },
+        });
+      },
+      [`${COMPONENT_CLASS_DECORATOR} Property[key.name='animations']`]({
+        value,
+      }: TSESTree.Property) {
+        if (!isArrayExpression(value)) return;
+
+        const lineCount = value.elements.reduce(
+          (lines, element) => lines + getLinesCount(element),
+          0,
+        );
+
+        if (lineCount <= animations) return;
+
+        context.report({
+          node: value,
+          messageId: 'componentMaxInlineDeclarations',
+          data: {
+            lineCount,
+            max: animations,
+            propertyType: 'animations',
+          },
+        });
       },
     };
   },

--- a/packages/eslint-plugin/src/rules/component-max-inline-declarations.ts
+++ b/packages/eslint-plugin/src/rules/component-max-inline-declarations.ts
@@ -120,11 +120,12 @@ export default createESLintRule<Options, MessageIds>({
       [`${COMPONENT_CLASS_DECORATOR} Property[key.name='animations']`]({
         value,
       }: TSESTree.Property) {
-        if (!isArrayExpression(value)) return;
+        if (!isArrayExpression(value) || value.elements.length === 0) return;
 
-        const lineCount = value.elements.reduce(
-          (lines, element) => lines + getLinesCount(element),
-          0,
+        const animationsBracketsSize = 2;
+        const lineCount = Math.max(
+          value.loc.end.line - value.loc.start.line - animationsBracketsSize,
+          1,
         );
 
         if (lineCount <= animations) return;

--- a/packages/eslint-plugin/tests/rules/component-max-inline-declarations.test.ts
+++ b/packages/eslint-plugin/tests/rules/component-max-inline-declarations.test.ts
@@ -3,7 +3,7 @@ import {
   RuleTester,
 } from '@angular-eslint/utils';
 import rule, {
-  messageId,
+  MessageIds,
   RULE_NAME,
 } from '../../src/rules/component-max-inline-declarations';
 
@@ -14,10 +14,11 @@ import rule, {
 const ruleTester = new RuleTester({
   parser: '@typescript-eslint/parser',
 });
+const messageId: MessageIds = 'componentMaxInlineDeclarations';
 
 ruleTester.run(RULE_NAME, rule, {
   valid: [
-    // should succeed if the number of lines does not exceeds the default lines limit (template)
+    // should succeed if the number of the template lines does not exceeds the default lines limit
     `
     @Component({
       template: '<div>just one line template</div>'
@@ -25,20 +26,16 @@ ruleTester.run(RULE_NAME, rule, {
     class Test {}
     `,
     {
-      // should succeed if a negative limit is used and the number of lines does not exceeds the default lines limit (template)
+      // should succeed if a negative limit is used and the number of the template lines does not exceeds the default lines limit
       code: `
       @Component({
         template: '<div>first line</div>'
       })
       class Test {}
       `,
-      options: [
-        {
-          template: -5,
-        },
-      ],
+      options: [{ template: -5 }],
     },
-    // should succeed if the number of lines does not exceeds the default lines limit (styles)
+    // should succeed if the number of the styles lines does not exceeds the default lines limit
     `
     @Component({
       styles: ['div { display: none; }']
@@ -46,44 +43,45 @@ ruleTester.run(RULE_NAME, rule, {
     class Test {}
     `,
     {
-      // should succeed if a negative limit is used and the number of lines does not exceeds the default lines limit (styles)
+      // should succeed if a negative limit is used and the number of the styles lines does not exceeds the default lines limit
       code: `
       @Component({
         styles: ['div { display: none; }']
       })
       class Test {}
       `,
-      options: [
-        {
-          styles: -5,
-        },
-      ],
+      options: [{ styles: -5 }],
     },
-    // should succeed if the number of lines does not exceeds the default lines limit (animations)
+    // should succeed if the number of the animations lines does not exceeds the default lines limit
     `
     @Component({
-      animations: [\`state('void', style({opacity: 0, transform: 'scale(1, 0)'}))\`]
+      animations: [state('void', style({opacity: 0, transform: 'scale(1, 0)'}))]
     })
     class Test {}
     `,
     {
-      // should succeed if a negative limit is used and the number of lines does not exceeds the default lines limit (animations)
+      // should succeed if a negative limit is used and the number of the animations lines does not exceeds the default lines limit
       code: `
       @Component({
         animations: [\`state('void', style({opacity: 0, transform: 'scale(1, 0)'}))\`]
       })
       class Test {}
       `,
-      options: [
-        {
-          animations: -5,
-        },
-      ],
+      options: [{ animations: -5 }],
     },
-    // should succeed when none of the template, styles and animations properties are present
+    // should succeed if template, styles and animations properties are not present
     `
     @Component({
       styleUrls: ['./foobar.scss'],
+      templateUrl: './foobar.html',
+    })
+    class Test {}
+    `,
+    `
+    @Component({
+      animations: [
+        state('void', style({opacity: 0, transform: 'scale(1, 0)'}))
+      ],
       templateUrl: './foobar.html',
     })
     class Test {}
@@ -92,25 +90,22 @@ ruleTester.run(RULE_NAME, rule, {
   invalid: [
     convertAnnotatedSourceToFailureCase({
       description:
-        'should fail if the number of lines exceeds the default lines limit (template)',
+        'should fail if the number of the template lines exceeds the default lines limit',
       annotatedSource: `
       @Component({
         template: \`
                   ~
           <div>first line</div>
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
           <div>second line</div>
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
           <div>third line</div>
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
           <div>fourth line</div>
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
         \`
-~~~~~~~~~
+        ~
       })
       class Test {}
       `,
       messageId,
+      data: { lineCount: 4, max: 3, propertyType: 'template' },
     }),
     convertAnnotatedSourceToFailureCase({
       description:
@@ -123,75 +118,58 @@ ruleTester.run(RULE_NAME, rule, {
       class Test {}
       `,
       messageId,
-      options: [
-        {
-          template: 0,
-        },
-      ],
+      options: [{ template: 0 }],
+      data: { lineCount: 1, max: 0, propertyType: 'template' },
     }),
     convertAnnotatedSourceToFailureCase({
       description:
-        'should fail if the number of lines exceeds the default lines limit (styles)',
+        'should fail if the number of the styles lines exceeds the default lines limit',
       annotatedSource: `
       @Component({
         styles: [
                 ~
           \`
-~~~~~~~~~~~
             div {
-~~~~~~~~~~~~~~~~~
               display: block;
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
               height: 40px;
-~~~~~~~~~~~~~~~~~~~~~~~~~~~
             }
-~~~~~~~~~~~~~
           \`
-~~~~~~~~~~~
         ]
-~~~~~~~~~
+        ~
       })
       class Test {}
       `,
       messageId,
+      data: { lineCount: 4, max: 3, propertyType: 'styles' },
     }),
     convertAnnotatedSourceToFailureCase({
       description:
-        'should fail if the sum of lines (from separate inline styles) exceeds the default lines limit (styles)',
+        'should fail if the sum of lines (from separate styles) exceeds the default lines limit',
       annotatedSource: `
       @Component({
         styles: [
                 ~
           \`
-~~~~~~~~~~~
             div {
-~~~~~~~~~~~~~~~~~
               display: block;
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
             }
-~~~~~~~~~~~~~
           \`,
-~~~~~~~~~~~~
           \`
-~~~~~~~~~~~
             span {
-~~~~~~~~~~~~~~~~~~
               width: 30px;
-~~~~~~~~~~~~~~~~~~~~~~~~~~
             }
-~~~~~~~~~~~~~
           \`
-~~~~~~~~~~~
         ]
-~~~~~~~~~
+        ~
       })
       class Test {}
       `,
       messageId,
+      data: { lineCount: 6, max: 3, propertyType: 'styles' },
     }),
     convertAnnotatedSourceToFailureCase({
       description:
-        'should fail if the number of lines exceeds a custom lines limit (styles)',
+        'should fail if the number of the styles lines exceeds a custom lines limit',
       annotatedSource: `
       @Component({
         styles: ['div { display: none; }']
@@ -200,136 +178,91 @@ ruleTester.run(RULE_NAME, rule, {
       class Test {}
       `,
       messageId,
-      options: [
-        {
-          styles: 0,
-        },
-      ],
+      options: [{ styles: 0 }],
+      data: { lineCount: 1, max: 0, propertyType: 'styles' },
     }),
     convertAnnotatedSourceToFailureCase({
       description:
-        'should fail if the number of lines exceeds the default lines limit (animations)',
+        'should fail if the number of the animations lines exceeds the default lines limit',
       annotatedSource: `
       @Component({
-        animations: [
+        animations: [{
                     ~
-          \`
-~~~~~~~~~~~
-            transformPanel: trigger('transformPanel',
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-              [
-~~~~~~~~~~~~~~~
-                state('void', style({opacity: 0, transform: 'scale(1, 0)'})),
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-                state('enter', style({opacity: 1, transform: 'scale(1, 1)'})),
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-                transition('void => enter', group([
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-                  query('@fadeInCalendar', animateChild()),
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-                  animate('400ms cubic-bezier(0.25, 0.8, 0.25, 1)')
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-                ])),
-~~~~~~~~~~~~~~~~~~~~
-                transition('* => void', animate('100ms linear', style({opacity: 0})))
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-              ]
-~~~~~~~~~~~~~~~
-            ),
-~~~~~~~~~~~~~~
-            fadeInCalendar: trigger('fadeInCalendar', [
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-              state('void', style({opacity: 0})),
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-              state('enter', style({opacity: 1})),
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-              transition('void => *', animate('400ms 100ms cubic-bezier(0.55, 0, 0.55, 0.2)'))
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-            ]
-~~~~~~~~~~~~~
-          \`
-~~~~~~~~~~~
-        ]
-~~~~~~~~~
+          transformPanelWrap: trigger('transformPanelWrap', [
+            transition('* => void', query('@transformPanel', [animateChild()], {optional: true})),
+          ]),
+          transformPanel: trigger('transformPanel', [
+            state('void', style({
+              transform: 'scaleY(0.8)',
+              minWidth: '100%',
+              opacity: 0
+            })),
+            state('showing', style({
+              opacity: 1,
+              minWidth: 'calc(100% + 32px)',
+              transform: 'scaleY(1)'
+            })),
+            state('next', style({height: '0px', visibility: 'hidden'}))
+          ])
+        }]
+         ~
       })
       class Test {}
       `,
       messageId,
+      data: { lineCount: 16, max: 15, propertyType: 'animations' },
     }),
     convertAnnotatedSourceToFailureCase({
       description:
-        'should fail if the sum of lines exceeds the default lines limit (animations)',
+        'should fail if the sum of lines (from separate animations) exceeds the default lines limit',
       annotatedSource: `
       @Component({
         animations: [
                     ~
-          \`
-~~~~~~~~~~~
-            transformPanel: trigger('transformPanel',
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-              [
-~~~~~~~~~~~~~~~
-                state('void', style({opacity: 0, transform: 'scale(1, 0)'}))
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-              ]
-~~~~~~~~~~~~~~~
-            )
-~~~~~~~~~~~~~
-          \`,
-~~~~~~~~~~~~
-          \`
-~~~~~~~~~~~
-            transformPanel: trigger('transformPanel',
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-              [
-~~~~~~~~~~~~~~~
-                state('void', style({opacity: 0, transform: 'scale(1, 0)'}))
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-              ]
-~~~~~~~~~~~~~~~
-            )
-~~~~~~~~~~~~~
-          \`
-~~~~~~~~~~~
+          trigger('dialogContainer', [
+            transition('* => void', query('@transformPanel', [animateChild()], {optional: true}))
+          ]),
+          trigger('transformPanel', [
+            state('void', style({
+              transform: 'scaleY(0.8)',
+              minWidth: '100%',
+              opacity: 0
+            })),
+            state('showing', style({
+              opacity: 1,
+              minWidth: 'calc(100% + 32px)',
+              transform: 'scaleY(1)'
+            }))
+          ]),
+          trigger('transformPanel', [
+            state('void', style({opacity: 0, transform: 'scale(1, 0)'}))
+          ])
         ]
-~~~~~~~~~
+        ~
       })
       class Test {}
       `,
       messageId,
+      data: { lineCount: 18, max: 15, propertyType: 'animations' },
     }),
     convertAnnotatedSourceToFailureCase({
       description:
-        'should fail if the number of lines exceeds a custom lines limit (animations)',
+        'should fail if the number of the animations lines exceeds a custom lines limit',
       annotatedSource: `
       @Component({
-        animations: [
+        animations: [{
                     ~
-          \`
-~~~~~~~~~~~
-            transformPanel: trigger('transformPanel',
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-              [
-~~~~~~~~~~~~~~~
-                state('void', style({opacity: 0, transform: 'scale(1, 0)'}))
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-              ]
-~~~~~~~~~~~~~~~
-            )
-~~~~~~~~~~~~~
-          \`
-~~~~~~~~~~~
-        ]
-~~~~~~~~~
+          transformPanel: trigger('transformPanel', [
+            state('void', style({opacity: 0, transform: 'scale(1, 0)'}))
+          ])
+        }]
+         ~
       })
       class Test {}
       `,
       messageId,
-      options: [
-        {
-          animations: 2,
-        },
-      ],
+      options: [{ animations: 2 }],
+      data: { lineCount: 3, max: 2, propertyType: 'animations' },
     }),
   ],
 });


### PR DESCRIPTION
While working on a fix for #304, I noticed that we could clean up this rule/tests, and so I did. Here's the context of each commit:

**First commit**: Currently we perform some checks to verify that the received limit is > `-1`. Now, we rely on the schema that can handle it automatically.

**Second commit**: Currently we use the function `getDecoratorPropertyValue` to get the desired property. Now, we use selectors instead.

**Third commit**: The tests are a bit verbose with a lot of annotations and also we don't check if the lines are calculated properly. With this commit, we have cleaner tests with properties checking through `data`.

**Fourth commit**: Fixes #304, before this commit we were calculating animation lines as `string`, however it isn't. Now, it may be checked properly.