### PR TITLE
fix(eslint-plugin): no-lifecycle-call invalid super calls not being reported

### DIFF
--- a/packages/eslint-plugin/src/utils/utils.ts
+++ b/packages/eslint-plugin/src/utils/utils.ts
@@ -223,6 +223,10 @@ function isProperty(node: TSESTree.Node): node is TSESTree.Property {
   return node.type === 'Property';
 }
 
+function isProgram(node: TSESTree.Node): node is TSESTree.Program {
+  return node.type === 'Program';
+}
+
 export function isLiteral(node: TSESTree.Node): node is TSESTree.Literal {
   return node.type === 'Literal';
 }
@@ -260,16 +264,35 @@ export function isLiteralWithStringValue(
   return node.type === 'Literal' && typeof node.value === 'string';
 }
 
-function isMethodDefinition(
+export function isMethodDefinition(
   node: TSESTree.Node,
 ): node is TSESTree.MethodDefinition {
   return node.type === 'MethodDefinition';
+}
+
+export function isSuper(node: TSESTree.Node): node is TSESTree.Super {
+  return node.type === 'Super';
 }
 
 /**
  * SECTION END:
  * Equivalents of utils exported by TypeScript itself for its own AST
  */
+
+export function getNearestNodeFrom<T extends TSESTree.Node>(
+  { parent }: TSESTree.Node,
+  predicate: (parent: TSESTree.Node) => parent is T,
+): T | null {
+  while (parent && !isProgram(parent)) {
+    if (predicate(parent)) {
+      return (parent as unknown) as T;
+    }
+
+    parent = parent.parent as TSESTree.Node | undefined;
+  }
+
+  return null;
+}
 
 export const getClassName = (node: TSESTree.Node): string | undefined => {
   if (isClassDeclaration(node)) {

--- a/packages/eslint-plugin/tests/rules/no-lifecycle-call.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-lifecycle-call.test.ts
@@ -15,7 +15,7 @@ ruleTester.run(RULE_NAME, rule, {
     `
     @Component()
     class Test {
-      test(): void { 
+      ngAfterContentChecked(): void { 
         super.ngAfterContentChecked(); 
       }
     }
@@ -158,6 +158,20 @@ ruleTester.run(RULE_NAME, rule, {
           test(): void {
             this.ngOnInit();
             ~~~~~~~~~~~~~~~
+          }
+        }
+      `,
+      messageId,
+    }),
+    convertAnnotatedSourceToFailureCase({
+      description:
+        'should fail if super.<lifecycle method>() is called in a incorrect context',
+      annotatedSource: `
+        @Component({ template: '' })
+        class Test extends ParentComponent {
+          test(): void {
+            super.ngOnChanges();
+            ~~~~~~~~~~~~~~~~~~~
           }
         }
       `,

--- a/packages/eslint-plugin/tests/rules/no-lifecycle-call.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-lifecycle-call.test.ts
@@ -12,306 +12,16 @@ const messageId: MessageIds = 'noLifecycleCall';
 
 ruleTester.run(RULE_NAME, rule, {
   valid: [
-    // #region Components
-    `@Component({
-      selector: 'test'
-    })
+    `
+    @Component()
     class Test {
-      test() {
-        super.ngAfterContentChecked();
-      }
-    }`,
-
-    `@Component({
-      selector: 'test'
-    })
-    class Test {
-      test() {
-        super.ngAfterContentInit();
-      }
-    }`,
-
-    `@Component({
-      selector: 'test'
-    })
-    class Test {
-      test() {
-        super.ngAfterViewChecked();
-      }
-    }`,
-
-    `@Component({
-      selector: 'test'
-    })
-    class Test {
-      test() {
-        super.ngAfterViewInit();
-      }
-    }`,
-
-    `@Component({
-      selector: 'test'
-    })
-    class Test {
-      test() {
-        super.ngDoBootstrap();
-      }
-    }`,
-
-    `@Component({
-      selector: 'test'
-    })
-    class Test {
-      test() {
-        super.ngDoCheck();
-      }
-    }`,
-
-    `@Component({
-      selector: 'test'
-    })
-    class Test {
-      test() {
-        super.ngOnChanges();
-      }
-    }`,
-
-    `@Component({
-      selector: 'test'
-    })
-    class Test {
-      test() {
-        super.ngOnInit();
-      }
-    }`,
-    // #endregion Components
-
-    // #region Directives
-    `@Directive({
-      selector: 'test'
-    })
-    class Test {
-      test() {
-        super.ngAfterContentChecked();
-      }
-    }`,
-
-    `@Directive({
-      selector: 'test'
-    })
-    class Test {
-      test() {
-        super.ngAfterContentInit();
-      }
-    }`,
-
-    `@Directive({
-      selector: 'test'
-    })
-    class Test {
-      test() {
-        super.ngAfterViewChecked();
-      }
-    }`,
-
-    `@Directive({
-      selector: 'test'
-    })
-    class Test {
-      test() {
-        super.ngAfterViewInit();
-      }
-    }`,
-
-    `@Directive({
-      selector: 'test'
-    })
-    class Test {
-      test() {
-        super.ngDoBootstrap();
-      }
-    }`,
-
-    `@Directive({
-      selector: 'test'
-    })
-    class Test {
-      test() {
-        super.ngDoCheck();
-      }
-    }`,
-
-    `@Directive({
-      selector: 'test'
-    })
-    class Test {
-      test() {
-        super.ngOnChanges();
-      }
-    }`,
-
-    `@Directive({
-      selector: 'test'
-    })
-    class Test {
-      test() {
-        super.ngOnInit();
-      }
-    }`,
-    // #endregion Directives
-
-    // #region Injectables
-    `@Injectable()
-    class Test {
-      test() {
-        super.ngAfterContentChecked();
-      }
-    }`,
-
-    `@Injectable()
-    class Test {
-      test() {
-        super.ngAfterContentInit();
-      }
-    }`,
-
-    `@Injectable()
-    class Test {
-      test() {
-        super.ngAfterViewChecked();
-      }
-    }`,
-
-    `@Injectable()
-    class Test {
-      test() {
-        super.ngAfterViewInit();
-      }
-    }`,
-
-    `@Injectable()
-    class Test {
-      test() {
-        super.ngDoBootstrap();
-      }
-    }`,
-
-    `@Injectable()
-    class Test {
-      test() {
-        super.ngDoCheck();
-      }
-    }`,
-
-    `@Injectable()
-    class Test {
-      test() {
-        super.ngOnChanges();
-      }
-    }`,
-
-    `@Injectable()
-    class Test {
-      test() {
-        super.ngOnInit();
-      }
-    }`,
-    // #endregion Injectables
-
-    // #region Pipes
-    `@Pipe({
-      name: 'test'
-    })
-    class Test {
-      test() {
-        super.ngAfterContentChecked();
-      }
-    }`,
-
-    `@Pipe({
-      name: 'test'
-    })
-    class Test {
-      test() {
-        super.ngAfterContentInit();
-      }
-    }`,
-
-    `@Pipe({
-      name: 'test'
-    })
-    class Test {
-      test() {
-        super.ngAfterViewChecked();
-      }
-    }`,
-
-    `@Pipe({
-      name: 'test'
-    })
-    class Test {
-      test() {
-        super.ngAfterViewInit();
-      }
-    }`,
-
-    `@Pipe({
-      name: 'test'
-    })
-    class Test {
-      test() {
-        super.ngDoBootstrap();
-      }
-    }`,
-
-    `@Pipe({
-      name: 'test'
-    })
-    class Test {
-      test() {
-        super.ngDoCheck();
-      }
-    }`,
-
-    `@Pipe({
-      name: 'test'
-    })
-    class Test {
-      test() {
-        super.ngOnChanges();
-      }
-    }`,
-
-    `@Pipe({
-      name: 'test'
-    })
-    class Test {
-      test() {
-        super.ngOnInit();
-      }
-    }`,
-    // #endregion Pipes
-
-    // should succeed if explicitly calling multiple non lifecycle methods
-    `@Component({
-      selector: 'test'
-    })
-    class Test {
-      test(): void {
-        this.ngAfterContentChecked1();
-        this.angAfterContentInit();
-        this.ngAfterViewChecked2();
-        this.ngAfterViewInit3();
-        this.ngOnChange$();
-        this.ngOnDestroyx();
-        this.ngOnInitialize();
-        this.ngDoChecking();
+      test(): void { 
+        super.ngAfterContentChecked(); 
       }
     }
-    @Directive({
-      selector: 'test'
-    })
-    class TestDirective {
+
+    @Directive()
+    class Test {
       test(): void {
         this.ngAfterContentChecked1();
         this.angAfterContentInit();
@@ -321,451 +31,137 @@ ruleTester.run(RULE_NAME, rule, {
         this.ngOnDestroyx();
         this.ngOnInitialize();
         this.ngDoChecking();
+        ngOnInit();
       }
-    }`,
+    }
+
+    @MyDecorator()
+    class Test {
+      test(): void {
+        ngDoCheck();
+      }
+    }
+
+    ngOnDestroy();
+    `,
   ],
   invalid: [
-    // #region Components
     convertAnnotatedSourceToFailureCase({
-      description: 'it should fail if explicitly calling ngAfterContentChecked',
-      annotatedSource: `@Component({
-        selector: 'test'
-      })
-      class Test {
-        test() {
-          this.ngAfterContentChecked();
-          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      description: 'should fail if ngAfterContentChecked() method is called',
+      annotatedSource: `
+        @Component()
+        class Test {
+          test(): void {
+            this.ngAfterContentChecked();
+            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+          }
         }
-      }`,
+      `,
       messageId,
     }),
-
     convertAnnotatedSourceToFailureCase({
-      description: 'it should fail if explicitly calling ngAfterContentInit()',
-      annotatedSource: `@Component({
-        selector: 'test'
-      })
-      class Test {
-        test() {
-          this.ngAfterContentInit();
-          ~~~~~~~~~~~~~~~~~~~~~~~~~
+      description: 'should fail if ngAfterContentInit() method is called',
+      annotatedSource: `
+        @Directive()
+        class Test {
+          test(): void {
+            this.ngAfterContentInit();
+            ~~~~~~~~~~~~~~~~~~~~~~~~~
+          }
         }
-      }`,
+      `,
       messageId,
     }),
-
     convertAnnotatedSourceToFailureCase({
-      description: 'it should fail if explicitly calling ngAfterViewChecked()',
-      annotatedSource: `@Component({
-        selector: 'test'
-      })
-      class Test {
-        test() {
-          this.ngAfterViewChecked();
-          ~~~~~~~~~~~~~~~~~~~~~~~~~
+      description: 'should fail if ngAfterViewChecked() method is called',
+      annotatedSource: `
+        @Injectable()
+        class Test {
+          test(): void {
+            this.ngAfterViewChecked();
+            ~~~~~~~~~~~~~~~~~~~~~~~~~
+          }
         }
-      }`,
+      `,
       messageId,
     }),
-
     convertAnnotatedSourceToFailureCase({
-      description: 'it should fail if explicitly calling ngAfterViewInit()',
-      annotatedSource: `@Component({
-        selector: 'test'
-      })
-      class Test {
-        test() {
-          this.ngAfterViewInit();
-          ~~~~~~~~~~~~~~~~~~~~~~
+      description: 'should fail if ngAfterViewInit() method is called',
+      annotatedSource: `
+        @NgModule()
+        class Test {
+          test(): void {
+            this.ngAfterViewInit();
+            ~~~~~~~~~~~~~~~~~~~~~~
+          }
         }
-      }`,
+      `,
       messageId,
     }),
-
     convertAnnotatedSourceToFailureCase({
-      description: 'it should fail if explicitly calling ngDoBootstrap()',
-      annotatedSource: `@Component({
-        selector: 'test'
-      })
-      class Test {
-        test() {
-          this.ngDoBootstrap();
-          ~~~~~~~~~~~~~~~~~~~~
+      description: 'should fail if ngDoBootstrap() method is called',
+      annotatedSource: `
+        @Pipe()
+        class Test {
+          test(): void {
+            this.ngDoBootstrap();
+            ~~~~~~~~~~~~~~~~~~~~
+          }
         }
-      }`,
+      `,
       messageId,
     }),
-
     convertAnnotatedSourceToFailureCase({
-      description: 'it should fail if explicitly calling ngDoCheck()',
-      annotatedSource: `@Component({
-        selector: 'test'
-      })
-      class Test {
-        test() {
-          this.ngDoCheck();
-          ~~~~~~~~~~~~~~~~
+      description: 'should fail if ngDoCheck() method is called',
+      annotatedSource: `
+        @Component()
+        class Test {
+          test(): void {
+            this.ngDoCheck();
+            ~~~~~~~~~~~~~~~~
+          }
         }
-      }`,
+      `,
       messageId,
     }),
-
     convertAnnotatedSourceToFailureCase({
-      description: 'it should fail if explicitly calling ngOnChanges()',
-      annotatedSource: `@Component({
-        selector: 'test'
-      })
-      class Test {
-        test() {
-          this.ngOnChanges();
-          ~~~~~~~~~~~~~~~~~~
+      description: 'should fail if ngOnChanges() method is called',
+      annotatedSource: `
+        @Directive()
+        class Test {
+          test(): void {
+            this.ngOnChanges();
+            ~~~~~~~~~~~~~~~~~~
+          }
         }
-      }`,
+      `,
       messageId,
     }),
-
     convertAnnotatedSourceToFailureCase({
-      description: 'it should fail if explicitly calling ngOnInit()',
-      annotatedSource: `@Component({
-        selector: 'test'
-      })
-      class Test {
-        test() {
-          this.ngOnInit();
-          ~~~~~~~~~~~~~~~
+      description: 'should fail if ngOnDestroy() method is called',
+      annotatedSource: `
+        @Injectable()
+        class Test {
+          test(): void {
+            this.ngOnDestroy();
+            ~~~~~~~~~~~~~~~~~~
+          }
         }
-      }`,
+      `,
       messageId,
     }),
-    // #endregion
-
-    // #region Directives
     convertAnnotatedSourceToFailureCase({
-      description:
-        'it should fail if explicitly calling ngAfterContentChecked()',
-      annotatedSource: `@Directive({
-        selector: 'test'
-      })
-      class Test {
-        test() {
-          this.ngAfterContentChecked();
-          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      description: 'should fail if ngOnInit() method is called',
+      annotatedSource: `
+        @NgModule()
+        class Test {
+          test(): void {
+            this.ngOnInit();
+            ~~~~~~~~~~~~~~~
+          }
         }
-      }`,
+      `,
       messageId,
     }),
-
-    convertAnnotatedSourceToFailureCase({
-      description: 'it should fail if explicitly calling ngAfterContentInit()',
-      annotatedSource: `@Directive({
-        selector: 'test'
-      })
-      class Test {
-        test() {
-          this.ngAfterContentInit();
-          ~~~~~~~~~~~~~~~~~~~~~~~~~
-        }
-      }`,
-      messageId,
-    }),
-
-    convertAnnotatedSourceToFailureCase({
-      description: 'it should fail if explicitly calling ngAfterViewChecked()',
-      annotatedSource: `@Directive({
-        selector: 'test'
-      })
-      class Test {
-        test() {
-          this.ngAfterViewChecked();
-          ~~~~~~~~~~~~~~~~~~~~~~~~~
-        }
-      }`,
-      messageId,
-    }),
-
-    convertAnnotatedSourceToFailureCase({
-      description: 'it should fail if explicitly calling ngAfterViewInit()',
-      annotatedSource: `@Directive({
-        selector: 'test'
-      })
-      class Test {
-        test() {
-          this.ngAfterViewInit();
-          ~~~~~~~~~~~~~~~~~~~~~~
-        }
-      }`,
-      messageId,
-    }),
-
-    convertAnnotatedSourceToFailureCase({
-      description: 'it should fail if explicitly calling ngDoBootstrap()',
-      annotatedSource: `@Directive({
-        selector: 'test'
-      })
-      class Test {
-        test() {
-          this.ngDoBootstrap();
-          ~~~~~~~~~~~~~~~~~~~~
-        }
-      }`,
-      messageId,
-    }),
-
-    convertAnnotatedSourceToFailureCase({
-      description: 'it should fail if explicitly calling ngDoCheck()',
-      annotatedSource: `@Directive({
-        selector: 'test'
-      })
-      class Test {
-        test() {
-          this.ngDoCheck();
-          ~~~~~~~~~~~~~~~~
-        }
-      }`,
-      messageId,
-    }),
-
-    convertAnnotatedSourceToFailureCase({
-      description: 'it should fail if explicitly calling ngOnChanges()',
-      annotatedSource: `@Directive({
-        selector: 'test'
-      })
-      class Test {
-        test() {
-          this.ngOnChanges();
-          ~~~~~~~~~~~~~~~~~~
-        }
-      }`,
-      messageId,
-    }),
-
-    convertAnnotatedSourceToFailureCase({
-      description: 'it should fail if explicitly calling ngOnInit()',
-      annotatedSource: `@Directive({
-        selector: 'test'
-      })
-      class Test {
-        test() {
-          this.ngOnInit();
-          ~~~~~~~~~~~~~~~
-        }
-      }`,
-      messageId,
-    }),
-    // #endregion Directives
-
-    // #region Injectables
-    convertAnnotatedSourceToFailureCase({
-      description:
-        'it should fail if explicitly calling ngAfterContentChecked()',
-      annotatedSource: `@Injectable()
-      class Test {
-        test() {
-          this.ngAfterContentChecked();
-          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-        }
-      }`,
-      messageId,
-    }),
-
-    convertAnnotatedSourceToFailureCase({
-      description: 'it should fail if explicitly calling ngAfterContentInit()',
-      annotatedSource: `@Injectable()
-      class Test {
-        test() {
-          this.ngAfterContentInit();
-          ~~~~~~~~~~~~~~~~~~~~~~~~~
-        }
-      }`,
-      messageId,
-    }),
-
-    convertAnnotatedSourceToFailureCase({
-      description: 'it should fail if explicitly calling ngAfterViewChecked()',
-      annotatedSource: `@Injectable()
-      class Test {
-        test() {
-          this.ngAfterViewChecked();
-          ~~~~~~~~~~~~~~~~~~~~~~~~~
-        }
-      }`,
-      messageId,
-    }),
-
-    convertAnnotatedSourceToFailureCase({
-      description: 'it should fail if explicitly calling ngAfterViewInit()',
-      annotatedSource: `@Injectable()
-      class Test {
-        test() {
-          this.ngAfterViewInit();
-          ~~~~~~~~~~~~~~~~~~~~~~
-        }
-      }`,
-      messageId,
-    }),
-
-    convertAnnotatedSourceToFailureCase({
-      description: 'it should fail if explicitly calling ngDoBootstrap()',
-      annotatedSource: `@Injectable()
-      class Test {
-        test() {
-          this.ngDoBootstrap();
-          ~~~~~~~~~~~~~~~~~~~~
-        }
-      }`,
-      messageId,
-    }),
-
-    convertAnnotatedSourceToFailureCase({
-      description: 'it should fail if explicitly calling ngDoCheck()',
-      annotatedSource: `@Injectable()
-      class Test {
-        test() {
-          this.ngDoCheck();
-          ~~~~~~~~~~~~~~~~
-        }
-      }`,
-      messageId,
-    }),
-
-    convertAnnotatedSourceToFailureCase({
-      description: 'it should fail if explicitly calling ngOnChanges()',
-      annotatedSource: `@Injectable()
-      class Test {
-        test() {
-          this.ngOnChanges();
-          ~~~~~~~~~~~~~~~~~~
-        }
-      }`,
-      messageId,
-    }),
-
-    convertAnnotatedSourceToFailureCase({
-      description: 'it should fail if explicitly calling ngOnInit()',
-      annotatedSource: `@Injectable()
-      class Test {
-        test() {
-          this.ngOnInit();
-          ~~~~~~~~~~~~~~~
-        }
-      }`,
-      messageId,
-    }),
-    // #endregion Injectables
-
-    // #region Pipes
-    convertAnnotatedSourceToFailureCase({
-      description:
-        'it should fail if explicitly calling ngAfterContentChecked()',
-      annotatedSource: `@Pipe({
-        name: 'test'
-      })
-      class Test {
-        test() {
-          this.ngAfterContentChecked();
-          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-        }
-      }`,
-      messageId,
-    }),
-
-    convertAnnotatedSourceToFailureCase({
-      description: 'it should fail if explicitly calling ngAfterContentInit()',
-      annotatedSource: `@Pipe({
-        name: 'test'
-      })
-      class Test {
-        test() {
-          this.ngAfterContentInit();
-          ~~~~~~~~~~~~~~~~~~~~~~~~~
-        }
-      }`,
-      messageId,
-    }),
-
-    convertAnnotatedSourceToFailureCase({
-      description: 'it should fail if explicitly calling ngAfterViewChecked()',
-      annotatedSource: `@Pipe({
-        name: 'test'
-      })
-      class Test {
-        test() {
-          this.ngAfterViewChecked();
-          ~~~~~~~~~~~~~~~~~~~~~~~~~
-        }
-      }`,
-      messageId,
-    }),
-
-    convertAnnotatedSourceToFailureCase({
-      description: 'it should fail if explicitly calling ngAfterViewInit()',
-      annotatedSource: `@Pipe({
-        name: 'test'
-      })
-      class Test {
-        test() {
-          this.ngAfterViewInit();
-          ~~~~~~~~~~~~~~~~~~~~~~
-        }
-      }`,
-      messageId,
-    }),
-
-    convertAnnotatedSourceToFailureCase({
-      description: 'it should fail if explicitly calling ngDoBootstrap()',
-      annotatedSource: `@Pipe({
-        name: 'test'
-      })
-      class Test {
-        test() {
-          this.ngDoBootstrap();
-          ~~~~~~~~~~~~~~~~~~~~
-        }
-      }`,
-      messageId,
-    }),
-
-    convertAnnotatedSourceToFailureCase({
-      description: 'it should fail if explicitly calling ngDoCheck()',
-      annotatedSource: `@Pipe({
-        name: 'test'
-      })
-      class Test {
-        test() {
-          this.ngDoCheck();
-          ~~~~~~~~~~~~~~~~
-        }
-      }`,
-      messageId,
-    }),
-
-    convertAnnotatedSourceToFailureCase({
-      description: 'it should fail if explicitly calling ngOnChanges()',
-      annotatedSource: `@Pipe({
-        name: 'test'
-      })
-      class Test {
-        test() {
-          this.ngOnChanges();
-          ~~~~~~~~~~~~~~~~~~
-        }
-      }`,
-      messageId,
-    }),
-
-    convertAnnotatedSourceToFailureCase({
-      description: 'it should fail if explicitly calling ngOnInit()',
-      annotatedSource: `@Pipe({
-        name: 'test'
-      })
-      class Test {
-        test() {
-          this.ngOnInit();
-          ~~~~~~~~~~~~~~~
-        }
-      }`,
-      messageId,
-    }),
-    // #endregion Pipes
   ],
 });


### PR DESCRIPTION
**First commit**: Adds a method to find the nearest node based on the received node.

**Second commit**: This clean up the huge amount of tests I noticed in https://github.com/angular-eslint/angular-eslint/pull/243#issuecomment-749695110 (most of them copied from `contextual-lifecycle`).

**Third commit**: Fixes #246, before this commit this rule didn't report any `super <lifecycle method>()`, regardless of the context and also reports any class, even if the class isn't decorated by Angular decorators. Now it may be fixed.