### PR TITLE
fix(template-parser): add BindingPipe exp to VisitorKeys (#337)

### DIFF
--- a/packages/template-parser/src/index.ts
+++ b/packages/template-parser/src/index.ts
@@ -44,6 +44,7 @@ const KEYS: VisitorKeys = {
   Program: ['templateNodes'],
   PropertyRead: ['receiver'],
   Template: ['templateAttrs', 'children', 'inputs'],
+  BindingPipe: ['exp'],
 };
 
 function fallbackKeysFilter(this: Node, key: string) {


### PR DESCRIPTION
Added `BindingPipe: ['exp']` to `template-parser` for (#337)