### PR TITLE
feat(builder): add maxWarnings option

### DIFF
--- a/packages/builder/src/index.ts
+++ b/packages/builder/src/index.ts
@@ -98,7 +98,7 @@ async function run(
   const tooManyWarnings = maxWarnings >= 0 && totalWarnings > maxWarnings;
   if (tooManyWarnings && printInfo) {
     context.logger.error(
-      `Found too many warnings (maximum: ${options.maxWarnings}).`,
+      `Found ${totalWarnings} warnings, which exceeds your configured limit (${options.maxWarnings}). Either fix some of them or increase the value of the maxWarnings option.`,
     );
   }
 

--- a/packages/builder/src/index.ts
+++ b/packages/builder/src/index.ts
@@ -18,6 +18,7 @@ async function run(
   const projectName = context.target?.project || '<???>';
   const printInfo = options.format && !options.silent;
   const reportOnlyErrors = options.quiet;
+  const maxWarnings = options.maxWarnings;
 
   context.reportStatus(`Linting ${JSON.stringify(projectName)}...`);
   if (printInfo) {
@@ -94,8 +95,15 @@ async function run(
     context.logger.info('All files pass linting.\n');
   }
 
+  const tooManyWarnings = maxWarnings >= 0 && totalWarnings > maxWarnings;
+  if (tooManyWarnings && printInfo) {
+    context.logger.error(
+      `Found too many warnings (maximum: ${options.maxWarnings}).`,
+    );
+  }
+
   return {
-    success: options.force || totalErrors === 0,
+    success: options.force || (totalErrors === 0 && !tooManyWarnings),
   };
 }
 

--- a/packages/builder/src/index.ts
+++ b/packages/builder/src/index.ts
@@ -98,7 +98,7 @@ async function run(
   const tooManyWarnings = maxWarnings >= 0 && totalWarnings > maxWarnings;
   if (tooManyWarnings && printInfo) {
     context.logger.error(
-      `Found ${totalWarnings} warnings, which exceeds your configured limit (${options.maxWarnings}). Either fix some of them or increase the value of the maxWarnings option.`,
+      `Found ${totalWarnings} warnings, which exceeds your configured limit (${options.maxWarnings}). Either increase your maxWarnings limit or fix some of the lint warnings.`,
     );
   }
 

--- a/packages/builder/src/schema.d.ts
+++ b/packages/builder/src/schema.d.ts
@@ -5,6 +5,7 @@ export interface Schema extends JsonObject {
   lintFilePatterns: string[];
   force: boolean;
   quiet: boolean;
+  maxWarnings: number;
   silent: boolean;
   fix: boolean;
   cache: boolean;

--- a/packages/builder/src/schema.json
+++ b/packages/builder/src/schema.json
@@ -32,6 +32,11 @@
       "description": "Report errors only.",
       "default": false
     },
+    "maxWarnings": {
+      "type": "integer",
+      "description": "Number of warnings to trigger nonzero exit code.",
+      "default": -1
+    },
     "silent": {
       "type": "boolean",
       "description": "Hide output text.",

--- a/packages/builder/tests/index.test.ts
+++ b/packages/builder/tests/index.test.ts
@@ -549,7 +549,7 @@ describe('Linter Builder', () => {
     mockReports = [
       {
         errorCount: 0,
-        warningCount: 0,
+        warningCount: 1,
         results: [],
         messages: [],
         usedDeprecatedRules: [],
@@ -568,7 +568,7 @@ describe('Linter Builder', () => {
     const flattenedCalls = loggerSpy.mock.calls.reduce((logs, call) => {
       return [...logs, call[0]];
     }, []);
-    expect(flattenedCalls).not.toContainEqual(
+    expect(flattenedCalls).toContainEqual(
       expect.objectContaining({
         message: expect.stringContaining(
           'Found too many warnings (maximum: 0).',

--- a/packages/builder/tests/index.test.ts
+++ b/packages/builder/tests/index.test.ts
@@ -571,7 +571,7 @@ describe('Linter Builder', () => {
     expect(flattenedCalls).toContainEqual(
       expect.objectContaining({
         message: expect.stringContaining(
-          'Found too many warnings (maximum: 0).',
+          'Found 1 warnings, which exceeds your configured limit (0).',
         ),
       }),
     );

--- a/packages/builder/tests/index.test.ts
+++ b/packages/builder/tests/index.test.ts
@@ -63,6 +63,7 @@ function createValidRunBuilderOptions(
     format: 'stylish',
     force: false,
     quiet: false,
+    maxWarnings: -1,
     silent: false,
     ignorePath: null,
     ...additionalOptions,
@@ -148,6 +149,7 @@ describe('Linter Builder', () => {
         format: 'stylish',
         force: false,
         silent: false,
+        maxWarnings: -1,
         ignorePath: null,
       }),
     );
@@ -162,6 +164,7 @@ describe('Linter Builder', () => {
       format: 'stylish',
       force: false,
       silent: false,
+      maxWarnings: -1,
       ignorePath: null,
     });
   });
@@ -331,6 +334,7 @@ describe('Linter Builder', () => {
           eslintConfig: './.eslintrc',
           lintFilePatterns: ['includedFile1'],
           format: 'json',
+          maxWarnings: 1,
           silent: true,
         }),
       );
@@ -510,5 +514,66 @@ describe('Linter Builder', () => {
       }),
     );
     expect(output.success).toBeFalsy();
+  });
+
+  it('should be a failure if the the amount of warnings exceeds the maxWarnings option', async () => {
+    mockReports = [
+      {
+        errorCount: 0,
+        warningCount: 4,
+        results: [],
+        messages: [],
+        usedDeprecatedRules: [],
+      },
+      {
+        errorCount: 0,
+        warningCount: 6,
+        results: [],
+        messages: [],
+        usedDeprecatedRules: [],
+      },
+    ];
+    setupMocks();
+    const output = await runBuilder(
+      createValidRunBuilderOptions({
+        eslintConfig: './.eslintrc',
+        lintFilePatterns: ['includedFile1'],
+        format: 'json',
+        maxWarnings: 5,
+      }),
+    );
+    expect(output.success).toBeFalsy();
+  });
+
+  it('should log too many warnings even if quiet flag was passed', async () => {
+    mockReports = [
+      {
+        errorCount: 0,
+        warningCount: 0,
+        results: [],
+        messages: [],
+        usedDeprecatedRules: [],
+      },
+    ];
+    setupMocks();
+    await runBuilder(
+      createValidRunBuilderOptions({
+        eslintConfig: './.eslintrc',
+        lintFilePatterns: ['includedFile1'],
+        format: 'json',
+        quiet: true,
+        maxWarnings: 0,
+      }),
+    );
+    const flattenedCalls = loggerSpy.mock.calls.reduce((logs, call) => {
+      return [...logs, call[0]];
+    }, []);
+    expect(flattenedCalls).not.toContainEqual(
+      expect.objectContaining({
+        message: expect.stringContaining(
+          'Found too many warnings (maximum: 0).',
+        ),
+      }),
+    );
   });
 });


### PR DESCRIPTION
Implements [ESLint's max-warnings CLI option](https://eslint.org/docs/user-guide/command-line-interface#:~:text=quiet%20file.js-,%2D%2Dmax%2Dwarnings,with%20a%20success%20exit%20status.).

When migrating from TSLint to ESLint recently, we wanted to show linting errors only as warnings during development in vscode (as the TSLint extension does), but at the same time we also use the ng lint command in our CI and want to fail on these warnings.
At first, I thought about a `--strict` flag, but after reading [this ESLint thread](https://github.com/eslint/eslint/issues/2309), it looked best to just implement the max-warnings flag.

