### PR TITLE
Suggest removal of codelyzer in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ npx ng lint {{YOUR_PROJECT_NAME_GOES_HERE}}
 
 ### Step 3 - Remove root TSLint configuration and use only ESLint
 
-Once you are happy with your ESLint setup, you simply need to remove the root-level `tslint.json` and potentially uninstall TSLint and any TSLint-related plugins/dependencies if your Angular CLI workspace is now no longer using TSLint at all.
+Once you are happy with your ESLint setup, you simply need to remove the root-level `tslint.json` and potentially uninstall TSLint and any TSLint-related plugins/dependencies like `codelyzer`, if your Angular CLI workspace is now no longer using TSLint at all.
 
 <br>
 


### PR DESCRIPTION
Codelyzer is added by default to every Angular project. Some people who migrate their Angular project to ESLint might not know that `codelyzer` can be removed after removing TSLint. So I thought it would be better to suggest removing it in the README.