### PR TITLE
feat: Add rule 'ngmodule-array-sorted' to enforce array sorting of identifi…

### DIFF
--- a/README.md
+++ b/README.md
@@ -563,6 +563,18 @@ If you are not sure what `"createDefaultProgram"` does, please reread the sectio
 
 <br>
 
+---
+
+## Non-Codelyzer Rules
+
+| Rule Name             | Rule Description                                                                    |
+| --------------------- | ----------------------------------------------------------------------------------- |
+| ngmodule-array-sorted | Rule enforces a sorted array in NgModule decorator properties for class identifiers |
+
+<br>
+
+---
+
 ## Status of Codelyzer Rules Conversion
 
 The table below shows the status of each Codelyzer Rule in terms of whether or not an equivalent for it has been created within `@angular-eslint`.

--- a/packages/eslint-plugin/src/rules/ngmodule-array-sorted.ts
+++ b/packages/eslint-plugin/src/rules/ngmodule-array-sorted.ts
@@ -1,0 +1,80 @@
+import { TSESTree } from '@typescript-eslint/experimental-utils';
+import { createESLintRule } from '../utils/create-eslint-rule';
+import { MODULE_CLASS_DECORATOR } from '../utils/selectors';
+import {
+  getDecoratorPropertyValue,
+  isArrayExpression,
+  isIdentifier,
+} from '../utils/utils';
+
+import { Options } from '../utils/property-selector';
+import { NgModule } from '@angular/compiler/src/core';
+
+export const RULE_NAME = 'ngmodule-array-sorted';
+export type MessageIds = 'sortedFailure';
+const validProperties: (keyof NgModule)[] = [
+  'bootstrap',
+  'declarations',
+  'entryComponents',
+  'exports',
+  'imports',
+  'providers',
+];
+
+export default createESLintRule<Options, MessageIds>({
+  name: RULE_NAME,
+  meta: {
+    type: 'suggestion',
+    docs: {
+      description:
+        'NgModule property arrays should be alphabetized for easy visual scanning.',
+      category: 'Best Practices',
+      recommended: false,
+    },
+    schema: [],
+    messages: {
+      sortedFailure:
+        'NgModule property arrays should be sorted in ASC alphabetical order.',
+    },
+  },
+  defaultOptions: [
+    {
+      type: '',
+      prefix: '',
+      style: '',
+    },
+  ],
+  create(context) {
+    return {
+      [MODULE_CLASS_DECORATOR](node: TSESTree.Decorator) {
+        validProperties.forEach((prop: keyof NgModule) => {
+          const initializer = getDecoratorPropertyValue(node, prop);
+          if (
+            !initializer ||
+            !isArrayExpression(initializer) ||
+            initializer.elements.length <= 1
+          ) {
+            return;
+          }
+          const elements = initializer.elements.filter(
+            (e: TSESTree.Expression) => isIdentifier(e),
+          );
+          elements.forEach((e, i, list) => {
+            if (i > 0 && isIdentifier(e)) {
+              const previous = list[i - 1];
+              if (
+                isIdentifier(previous) &&
+                e.name.localeCompare(previous.name) === -1
+              ) {
+                context.report({
+                  node: previous,
+                  messageId: 'sortedFailure',
+                });
+              }
+            }
+          });
+        });
+      },
+    };
+  },
+});

--- a/packages/eslint-plugin/tests/rules/ngmodule-array-sorted.test.ts
+++ b/packages/eslint-plugin/tests/rules/ngmodule-array-sorted.test.ts
@@ -1,0 +1,150 @@
+import {
+  convertAnnotatedSourceToFailureCase,
+  RuleTester,
+} from '@angular-eslint/utils';
+import rule, {
+  MessageIds,
+  RULE_NAME,
+} from '../../src/rules/ngmodule-array-sorted';
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+const ruleTester = new RuleTester({
+  parser: '@typescript-eslint/parser',
+});
+
+const messageIdSortFailure: MessageIds = 'sortedFailure';
+
+ruleTester.run(RULE_NAME, rule, {
+  valid: [
+    {
+      code: `
+      @NgModule({
+        imports: [
+            _foo,
+            AModule,
+            bModule,
+            cModule,
+            DModule,
+        ],
+        bootstrap: [
+            AppModule1,
+            AppModule2,
+            AppModule3,
+        ],
+        declarations: [
+            AComponent,
+            bDirective,
+            cPipe,
+            DComponent
+        ],
+        providers: [
+            AProvider,
+            {
+              provide : 'myprovider',
+              useClass : MyProvider,
+            },
+            bProvider,
+            cProvider,
+            DProvider,
+        ],
+      })
+      class Test {}
+      `,
+      options: [],
+    },
+  ],
+  invalid: [
+    convertAnnotatedSourceToFailureCase({
+      description: 'it should fail if imports array is not sorted ASC',
+      annotatedSource: `
+      @NgModule({
+        imports: [
+            aModule,
+            bModule,
+            DModule,
+            ~~~~~~~
+            cModule,
+        ]
+      })
+      class Test {}
+      `,
+      messageId: messageIdSortFailure,
+      options: [],
+    }),
+    convertAnnotatedSourceToFailureCase({
+      description: 'it should fail if declarations array is not sorted ASC',
+      annotatedSource: `
+      @NgModule({
+        declarations: [
+            AComponent,
+            cPipe,
+            ~~~~~
+            bDirective,
+            DComponent
+        ],
+      })
+      class Test {}
+      `,
+      messageId: messageIdSortFailure,
+      options: [],
+    }),
+    convertAnnotatedSourceToFailureCase({
+      description: 'it should fail if exports array is not sorted ASC',
+      annotatedSource: `
+      @NgModule({
+        exports: [
+            AComponent,
+            cPipe,
+            ~~~~~
+            bDirective,
+            DComponent
+        ],
+      })
+      class Test {}
+      `,
+      messageId: messageIdSortFailure,
+      options: [],
+    }),
+    convertAnnotatedSourceToFailureCase({
+      description: 'it should fail if bootstrap array is not sorted ASC',
+      annotatedSource: `
+      @NgModule({
+        bootstrap: [
+            AppModule2,
+            ~~~~~~~~~~
+            AppModule1,
+            AppModule3,
+        ]
+      })
+      class Test {}
+      `,
+      messageId: messageIdSortFailure,
+      options: [],
+    }),
+    convertAnnotatedSourceToFailureCase({
+      description:
+        'it should fail if providers array is not sorted ASC, but ignore objects',
+      annotatedSource: `
+      @NgModule({
+        imports: [
+            AProvider,
+            {
+              provide : 'myprovider',
+              useClass : MyProvider,
+            },
+            cProvider,
+            ~~~~~~~~~
+            bProvider,
+            DProvider,
+        ]
+      })
+      class Test {}
+      `,
+      messageId: messageIdSortFailure,
+      options: [],
+    }),
+  ],
+});


### PR DESCRIPTION
…ers in @NgModule decorator. Currently this ignores objects and only determines sort order based on Identifier names. Future options could determine how objects like provider objects could be handled.

I am not sure if this package intends to only implement rules that already exist in codelyzer or if adding in additional rules like this would be allowed.

This rule is one we use that simply enforces alphabetical order of identifiers in NgModule decorator as part of a code style best practice. If you are interested in this it would be great to get this into the main 