### PR TITLE
fix(eslint-plugin): no-call-expression incorrect reports for conditio…

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,6 @@
       "@commitlint/config-conventional"
     ]
   },
-  "dependencies": {},
   "devDependencies": {
     "@angular-devkit/architect": "~0.1102.3",
     "@angular-devkit/build-angular": "~0.1102.3",
@@ -63,8 +62,8 @@
     "@types/jest": "^26.0.15",
     "@types/node": "^10.12.2",
     "@types/prettier": "^1.19.0",
-    "@typescript-eslint/parser": "4.16.1",
     "@typescript-eslint/eslint-plugin": "4.16.1",
+    "@typescript-eslint/parser": "4.16.1",
     "eslint": "^7.6.0",
     "eslint-config-prettier": "7.1.0",
     "eslint-plugin-import": "2.22.1",

--- a/packages/eslint-plugin-template/src/rules/no-call-expression.ts
+++ b/packages/eslint-plugin-template/src/rules/no-call-expression.ts
@@ -1,4 +1,11 @@
-import type { MethodCall } from '@angular/compiler';
+import {
+  AST,
+  Conditional,
+  MethodCall,
+  SafeMethodCall,
+  TmplAstBoundEvent,
+} from '@angular/compiler';
+import { getNearestNodeFrom } from '../utils/get-nearest-node-from';
 import {
   createESLintRule,
   ensureTemplateParser,
@@ -28,18 +35,47 @@ export default createESLintRule<Options, MessageIds>({
     ensureTemplateParser(context);
     const sourceCode = context.getSourceCode();
 
+    function report({ sourceSpan: { end, start } }: AST) {
+      context.report({
+        messageId: 'noCallExpression',
+        loc: {
+          start: sourceCode.getLocFromIndex(start),
+          end: sourceCode.getLocFromIndex(end),
+        },
+      });
+    }
+
     return {
-      ':not(BoundEvent) > * > :matches(MethodCall[name!="$any"], SafeMethodCall)'({
-        sourceSpan: { end, start },
-      }: MethodCall) {
-        context.report({
-          messageId: 'noCallExpression',
-          loc: {
-            start: sourceCode.getLocFromIndex(start),
-            end: sourceCode.getLocFromIndex(end),
-          },
-        });
+      'Conditional, MethodCall[name!="$any"], SafeMethodCall'(
+        conditionalOrMethodCall: Conditional | MethodCall | SafeMethodCall,
+      ) {
+        const isChildOfBoundEvent = !!getNearestNodeFrom(
+          conditionalOrMethodCall,
+          isBoundEvent,
+        );
+
+        if (isChildOfBoundEvent) return;
+
+        if (!(conditionalOrMethodCall instanceof Conditional)) {
+          report(conditionalOrMethodCall);
+
+          return;
+        }
+
+        const { falseExp, trueExp } = conditionalOrMethodCall;
+
+        if (isMethodCall(falseExp)) report(falseExp);
+
+        if (isMethodCall(trueExp)) report(trueExp);
       },
     };
   },
 });
+
+function isBoundEvent(node: unknown): node is TmplAstBoundEvent {
+  return node instanceof TmplAstBoundEvent;
+}
+
+function isMethodCall(node: unknown): node is MethodCall | SafeMethodCall {
+  return node instanceof MethodCall || node instanceof SafeMethodCall;
+}

--- a/packages/eslint-plugin-template/src/utils/get-nearest-node-from.ts
+++ b/packages/eslint-plugin-template/src/utils/get-nearest-node-from.ts
@@ -1,5 +1,5 @@
-import { AST } from '@angular/compiler';
-import { Node } from '@angular/compiler/src/render3/r3_ast';
+import type { AST } from '@angular/compiler';
+import type { Node } from '@angular/compiler/src/render3/r3_ast';
 
 type ASTOrNodeWithParent = (AST | Node) & { parent?: ASTOrNodeWithParent };
 

--- a/packages/eslint-plugin-template/src/utils/get-nearest-node-from.ts
+++ b/packages/eslint-plugin-template/src/utils/get-nearest-node-from.ts
@@ -1,0 +1,23 @@
+import { AST } from '@angular/compiler';
+import { Node } from '@angular/compiler/src/render3/r3_ast';
+
+type ASTOrNodeWithParent = (AST | Node) & { parent?: ASTOrNodeWithParent };
+
+function isProgram({ type }: any): boolean {
+  return type === 'Program';
+}
+
+export function getNearestNodeFrom<T extends ASTOrNodeWithParent>(
+  { parent }: ASTOrNodeWithParent,
+  predicate: (parent: ASTOrNodeWithParent) => parent is T,
+): T | null {
+  while (parent && !isProgram(parent)) {
+    if (predicate(parent)) {
+      return (parent as unknown) as T;
+    }
+
+    parent = parent.parent as ASTOrNodeWithParent | undefined;
+  }
+
+  return null;
+}

--- a/packages/eslint-plugin-template/tests/rules/no-call-expression.test.ts
+++ b/packages/eslint-plugin-template/tests/rules/no-call-expression.test.ts
@@ -24,6 +24,9 @@ ruleTester.run(RULE_NAME, rule, {
       <button type="button" (click)="handleClick()">Click Here</button>
       {{ $any(info) }}
       <input (change)="obj?.changeHandler()">
+      <form [formGroup]="form" (ngSubmit)="form.valid || save()"></form>
+      <form [formGroup]="form" (ngSubmit)="form.valid && save()"></form>
+      <form [formGroup]="form" (ngSubmit)="id ? save() : edit()"></form>
     `,
   ],
   invalid: [
@@ -52,6 +55,33 @@ ruleTester.run(RULE_NAME, rule, {
                    ~~~~~~~~
       `,
       messageId,
+    }),
+    convertAnnotatedSourceToFailureCase({
+      description: 'it should fail for call expression with binaries',
+      annotatedSource: `
+        <a [href]="id && createUrl()">info</a>
+                         ~~~~~~~~~~~
+        {{ id || obj?.nested1() }}
+                 ^^^^^^^^^^^^^^
+      `,
+      messages: [
+        { char: '~', messageId },
+        { char: '^', messageId },
+      ],
+    }),
+    convertAnnotatedSourceToFailureCase({
+      description: 'it should fail for call expression within conditionals',
+      annotatedSource: `
+        <a [href]="id ? a?.createUrl() : editUrl()">info</a>
+                        ~~~~~~~~~~~~~~   ^^^^^^^^^
+        {{ 1 === 2 ? 3 : obj?.nested1() }}
+                         ##############
+      `,
+      messages: [
+        { char: '~', messageId },
+        { char: '^', messageId },
+        { char: '#', messageId },
+      ],
     }),
     convertAnnotatedSourceToFailureCase({
       description: 'it should fail for safe/unsafe method calls',


### PR DESCRIPTION
…nals

Currently, the `no-call-expression` rule incorrectly reports the use of `methods` within `BoundEvent`, when preceded by conditionals, as related in https://github.com/angular-eslint/angular-eslint/issues/374#issuecomment-809386614.