### PR TITLE
refactor(eslint-plugin): no-attribute-decorator switch to selectors

### DIFF
--- a/packages/eslint-plugin/src/rules/no-attribute-decorator.ts
+++ b/packages/eslint-plugin/src/rules/no-attribute-decorator.ts
@@ -1,16 +1,8 @@
-import {
-  AST_NODE_TYPES,
-  TSESTree,
-} from '@typescript-eslint/experimental-utils';
+import { TSESTree } from '@typescript-eslint/experimental-utils';
 import { createESLintRule } from '../utils/create-eslint-rule';
-import { AngularInnerClassDecorators, getDecoratorName } from '../utils/utils';
 
 type Options = [];
-
 export type MessageIds = 'noAttributeDecorator';
-
-export const CONSTRUCTOR_METHOD_NAME = 'constructor';
-
 export const RULE_NAME = 'no-attribute-decorator';
 
 export default createESLintRule<Options, MessageIds>({
@@ -18,49 +10,26 @@ export default createESLintRule<Options, MessageIds>({
   meta: {
     type: 'problem',
     docs: {
-      description: `Disallows usage of @${AngularInnerClassDecorators.Attribute} decorator.`,
+      description: 'Disallows usage of @Attribute decorator.',
       category: 'Possible Errors',
       recommended: false,
     },
     schema: [],
     messages: {
-      noAttributeDecorator: `@${AngularInnerClassDecorators.Attribute} is considered bad practice. Use @Input instead`,
+      noAttributeDecorator:
+        'The usage of @Attribute is considered a bad practice. Use @Input instead',
     },
   },
   defaultOptions: [],
   create(context) {
-    function checkIfConstructor(node: TSESTree.MethodDefinition): boolean {
-      return node.kind === CONSTRUCTOR_METHOD_NAME;
-    }
-
-    function validateParams(node: TSESTree.MethodDefinition): void {
-      node.value.params.forEach((parameter) => {
-        if (parameter.decorators != null) {
-          for (const decorator of parameter.decorators) {
-            if (
-              getDecoratorName(decorator) ===
-              AngularInnerClassDecorators.Attribute
-            ) {
-              context.report({
-                node: parameter,
-                messageId: 'noAttributeDecorator',
-              });
-              break;
-            }
-          }
-        }
-      });
-    }
-
     return {
-      MethodDefinition(node: TSESTree.MethodDefinition): void {
-        if (
-          node.value &&
-          node.value.type === AST_NODE_TYPES.FunctionExpression &&
-          checkIfConstructor(node)
-        ) {
-          validateParams(node);
-        }
+      'ClassDeclaration MethodDefinition[key.name="constructor"] Decorator[expression.callee.name="Attribute"]'(
+        node: TSESTree.Decorator,
+      ): void {
+        context.report({
+          node,
+          messageId: 'noAttributeDecorator',
+        });
       },
     };
   },

--- a/packages/eslint-plugin/tests/rules/no-attribute-decorator.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-attribute-decorator.test.ts
@@ -17,108 +17,53 @@ ruleTester.run(RULE_NAME, rule, {
   valid: [
     // should pass if constructor does not exist
     `
-      class Test {
-        public foo(){}
-      }
+    class Test {
+      foo() {}
+    }
     `,
-    // should pass if constructor exists but no parameter
+    // should pass if the constructor has no parameter properties
     `
-      class Test {
-        constructor() {}
-      }
+    class Test {
+      constructor() {}
+    }
     `,
-    // should pass if constructor exists and have one parameter without decorator
+    // should pass if the constructor exists, but none of the parameter properties are decorated with `@ Attribute`
     `
-      class Test {
-        constructor(foo: any) {}
-      }
-    `,
-    // should pass if constructor exists and have one parameter with decorator
-    `
-      class Test {
-        constructor(@Optional() foo: any) {}
-      }
-    `,
-    // // should pass if constructor exists and have multiple parameters without decorator
-    `
-      class Test {
-        constructor(foo: any, @Optional() bar: any) {}
-      }
-    `,
-    // // should pass if constructor exists and have multiple parameters with decorator
-    `
-      class Test {
-        constructor(@Optional() foo: any, @Optional() bar: any) {}
-      }
+    class Test {
+      constructor(@Optional() foo: string, @Optional() bar: string, baz: number) {}
+    }
     `,
   ],
   invalid: [
     convertAnnotatedSourceToFailureCase({
       description:
-        'should fail if constructor has one parameter with @Attribute decorator',
+        'should fail if a parameter property is decorated with `@Attribute`',
       annotatedSource: `
-      class Test {
-        constructor(@Attribute() foo: any) {}
-                                 ~~~~~~~~
-      }
-    `,
+        class Test {
+          constructor(@Attribute() foo: string) {}
+                      ~~~~~~~~~~~~
+        }
+      `,
       messageId,
     }),
-
     convertAnnotatedSourceToFailureCase({
       description:
-        'should fail if constructor has one parameter with @Attribute decorator',
+        'should fail if multiple parameter properties are decorated with `@Attribute`',
       annotatedSource: `
-      class Test {
-        constructor(@Attribute("name") foo: any) {}
-                                       ~~~~~~~~
-      }
-    `,
-      messageId,
-    }),
-
-    convertAnnotatedSourceToFailureCase({
-      description:
-        'should fail if constructor has multiple parameters but one with @Attribute decorator',
-      annotatedSource: `
-      class Test {
-        constructor(foo: any, @Attribute() bar: any) {}
-                                           ~~~~~~~~
-      }
-    `,
-      messageId,
-    }),
-
-    convertAnnotatedSourceToFailureCase({
-      description:
-        'should fail if constructor has multiple parameters but one with @Attribute decorator',
-      annotatedSource: `
-      class Test {
-        constructor(@Optional() foo: any, @Attribute() bar: any) {}
-                                                       ~~~~~~~~
-      }
-    `,
-      messageId,
-    }),
-
-    convertAnnotatedSourceToFailureCase({
-      description: `should fail if constructor has multiple parameters
-      and all with @Attribute decorator`,
-      annotatedSource: `
-      class Test {
-        constructor(@Attribute() foo: any, @Attribute() bar: any) {}
-                                 ~~~~~~~~               ^^^^^^^^
-      }
-    `,
+        class Test {
+          constructor(
+            @Inject(TOKEN) token: string,
+            randomNumber: number,
+            @Attribute() foo: string,
+            ~~~~~~~~~~~~
+            @Attribute('baz') bar: string
+            ^^^^^^^^^^^^^^^^^
+          ) {}
+        }
+      `,
       messages: [
-        {
-          char: '~',
-          messageId: messageId,
-        },
-        {
-          char: '^',
-          messageId: messageId,
-        },
+        { char: '~', messageId },
+        { char: '^', messageId },
       ],
     }),
   ],


### PR DESCRIPTION
This PR changes the implementation of `no-attribute-decorator` to use selectors. In addition, I removed some unnecessary tests and still kept 100% coverage.