### PR TITLE
fix(eslint-plugin): directive-class-suffix reporting selectorless directives

### DIFF
--- a/packages/eslint-plugin/src/rules/directive-class-suffix.ts
+++ b/packages/eslint-plugin/src/rules/directive-class-suffix.ts
@@ -5,7 +5,7 @@ import {
   getClassName,
   getDeclaredInterfaceNames,
   getDecoratorPropertyValue,
-  getReadablePrefixes,
+  toHumanReadableText,
 } from '../utils/utils';
 
 type Options = [{ readonly suffixes: readonly string[] }];
@@ -72,7 +72,7 @@ export default createESLintRule<Options, MessageIds>({
             messageId: 'directiveClassSuffix',
             data: {
               className,
-              suffixes: getReadablePrefixes(allSuffixes),
+              suffixes: toHumanReadableText(allSuffixes),
             },
           });
         }

--- a/packages/eslint-plugin/src/rules/directive-class-suffix.ts
+++ b/packages/eslint-plugin/src/rules/directive-class-suffix.ts
@@ -5,19 +5,15 @@ import {
   getClassName,
   getDeclaredInterfaceNames,
   getDecoratorPropertyValue,
+  getReadablePrefixes,
 } from '../utils/utils';
 
-type Options = [
-  {
-    suffixes: string[];
-  },
-];
+type Options = [{ readonly suffixes: readonly string[] }];
 export type MessageIds = 'directiveClassSuffix';
 export const RULE_NAME = 'directive-class-suffix';
-
 const STYLE_GUIDE_LINK = 'https://angular.io/styleguide#style-02-03';
-
-const ValidatorSuffix = 'Validator';
+const DEFAULT_SUFFIXES = ['Directive'] as const;
+const VALIDATOR_SUFFIX = 'Validator';
 
 export default createESLintRule<Options, MessageIds>({
   name: RULE_NAME,
@@ -43,17 +39,11 @@ export default createESLintRule<Options, MessageIds>({
       },
     ],
     messages: {
-      directiveClassSuffix: `The name of the class {{className}} should end with the suffix {{suffixes}} (${STYLE_GUIDE_LINK})`,
+      directiveClassSuffix: `The name of the class {{className}} should end with suffix(es) {{suffixes}} (${STYLE_GUIDE_LINK})`,
     },
   },
-  defaultOptions: [
-    {
-      suffixes: ['Directive'],
-    },
-  ],
-  create(context, [options]) {
-    const { suffixes } = options;
-
+  defaultOptions: [{ suffixes: DEFAULT_SUFFIXES }],
+  create(context, [{ suffixes }]) {
     return {
       [DIRECTIVE_CLASS_DECORATOR](node: TSESTree.Decorator) {
         const selectorPropertyValue = getDecoratorPropertyValue(
@@ -65,26 +55,24 @@ export default createESLintRule<Options, MessageIds>({
 
         const classParent = node.parent as TSESTree.ClassDeclaration;
         const className = getClassName(classParent);
-
         const declaredInterfaceNames = getDeclaredInterfaceNames(classParent);
         const hasValidatorInterface = declaredInterfaceNames.some(
-          (interfaceName) => interfaceName.endsWith(ValidatorSuffix),
+          (interfaceName) => interfaceName.endsWith(VALIDATOR_SUFFIX),
         );
-
-        if (hasValidatorInterface) {
-          suffixes.push(ValidatorSuffix);
-        }
+        const allSuffixes = suffixes.concat(
+          hasValidatorInterface ? VALIDATOR_SUFFIX : [],
+        );
 
         if (
           !className ||
-          !suffixes.some((suffix) => className.endsWith(suffix))
+          !allSuffixes.some((suffix) => className.endsWith(suffix))
         ) {
           context.report({
-            node: classParent.id ? classParent.id : classParent,
+            node: classParent.id ?? classParent,
             messageId: 'directiveClassSuffix',
             data: {
               className,
-              suffixes,
+              suffixes: getReadablePrefixes(allSuffixes),
             },
           });
         }

--- a/packages/eslint-plugin/src/rules/directive-class-suffix.ts
+++ b/packages/eslint-plugin/src/rules/directive-class-suffix.ts
@@ -1,7 +1,11 @@
 import { TSESTree } from '@typescript-eslint/experimental-utils';
 import { createESLintRule } from '../utils/create-eslint-rule';
 import { DIRECTIVE_CLASS_DECORATOR } from '../utils/selectors';
-import { getClassName, getDeclaredInterfaceNames } from '../utils/utils';
+import {
+  getClassName,
+  getDeclaredInterfaceNames,
+  getDecoratorPropertyValue,
+} from '../utils/utils';
 
 type Options = [
   {
@@ -52,6 +56,13 @@ export default createESLintRule<Options, MessageIds>({
 
     return {
       [DIRECTIVE_CLASS_DECORATOR](node: TSESTree.Decorator) {
+        const selectorPropertyValue = getDecoratorPropertyValue(
+          node,
+          'selector',
+        );
+
+        if (!selectorPropertyValue) return;
+
         const classParent = node.parent as TSESTree.ClassDeclaration;
         const className = getClassName(classParent);
 

--- a/packages/eslint-plugin/src/rules/pipe-prefix.ts
+++ b/packages/eslint-plugin/src/rules/pipe-prefix.ts
@@ -3,10 +3,10 @@ import { createESLintRule } from '../utils/create-eslint-rule';
 import { PIPE_CLASS_DECORATOR } from '../utils/selectors';
 import {
   getDecoratorPropertyValue,
-  getReadablePrefixes,
   isLiteralWithStringValue,
   isTemplateLiteral,
   SelectorValidator,
+  toHumanReadableText,
 } from '../utils/utils';
 
 type Options = [
@@ -93,7 +93,7 @@ export default createESLintRule<Options, MessageIds>({
             node: nameSelector,
             messageId: 'pipePrefix',
             data: {
-              prefixes: getReadablePrefixes(prefixes),
+              prefixes: toHumanReadableText(prefixes),
             },
           });
         }

--- a/packages/eslint-plugin/src/utils/utils.ts
+++ b/packages/eslint-plugin/src/utils/utils.ts
@@ -296,7 +296,7 @@ export function getNearestNodeFrom<T extends TSESTree.Node>(
 
 export const getClassName = (node: TSESTree.Node): string | undefined => {
   if (isClassDeclaration(node)) {
-    return node.id ? node.id.name : undefined;
+    return node.id?.name;
   }
   if (node.parent) {
     return getClassName(node.parent);

--- a/packages/eslint-plugin/src/utils/utils.ts
+++ b/packages/eslint-plugin/src/utils/utils.ts
@@ -597,19 +597,19 @@ export function isImportedFrom(
 }
 
 /**
- * Convert an array of prefix to human-readable text.
+ * Convert an array to human-readable text.
  */
-export const getReadablePrefixes = (prefixes: string[]): string => {
-  const prefixesLength = prefixes.length;
+export const toHumanReadableText = (items: readonly string[]): string => {
+  const itemsLength = items.length;
 
-  if (prefixesLength === 1) {
-    return `"${prefixes[0]}"`;
+  if (itemsLength === 1) {
+    return `"${items[0]}"`;
   }
 
-  return `${prefixes
-    .map((x) => `"${x}"`)
-    .slice(0, prefixesLength - 1)
-    .join(', ')} or "${[...prefixes].pop()}"`;
+  return `${items
+    .map((item) => `"${item}"`)
+    .slice(0, itemsLength - 1)
+    .join(', ')} or "${[...items].pop()}"`;
 };
 
 export const toPattern = (value: readonly unknown[]) =>

--- a/packages/eslint-plugin/tests/rules/directive-class-suffix.test.ts
+++ b/packages/eslint-plugin/tests/rules/directive-class-suffix.test.ts
@@ -38,8 +38,8 @@ ruleTester.run(RULE_NAME, rule, {
     class TestValidator implements AsyncValidator {}
 `,
     `
-    @Directive
-    class TestDirective {}
+    @Directive()
+    class Test {}
 `,
     `
     @Pipe({

--- a/packages/eslint-plugin/tests/rules/directive-class-suffix.test.ts
+++ b/packages/eslint-plugin/tests/rules/directive-class-suffix.test.ts
@@ -37,6 +37,10 @@ ruleTester.run(RULE_NAME, rule, {
     })
     class TestValidator implements AsyncValidator {}
     `,
+    `
+    @Directive
+    class Test {}
+    `,
     // https://github.com/angular-eslint/angular-eslint/issues/353
     `
     @Directive()

--- a/packages/eslint-plugin/tests/rules/directive-class-suffix.test.ts
+++ b/packages/eslint-plugin/tests/rules/directive-class-suffix.test.ts
@@ -24,48 +24,50 @@ ruleTester.run(RULE_NAME, rule, {
       selector: 'sgBarFoo'
     })
     class TestDirective {}
-`,
+    `,
     `
     @Directive({
       selector: 'sgBarFoo'
     })
     class TestValidator implements Validator {}
-`,
+    `,
     `
     @Directive({
       selector: 'sgBarFoo'
     })
     class TestValidator implements AsyncValidator {}
-`,
+    `,
     `
     @Directive()
     class Test {}
-`,
+    `,
+    `
+    @Component({
+      selector: 'sg-bar-foo'
+    })
+    class TestComponent {}
+    `,
     `
     @Pipe({
-      selector: 'sg-test-pipe'
+      name: 'sgPipe'
     })
     class TestPipe {}
-`,
+    `,
     `
     @Injectable()
     class TestService {}
-`,
+    `,
     `
     class TestEmpty {}
-`,
+    `,
     {
       code: `
         @Directive({
-            selector: 'sgBarFoo'
+          selector: 'sgBarFoo'
         })
-        class TestPage {}
+        class TestDir {}
       `,
-      options: [
-        {
-          suffixes: ['Page'],
-        },
-      ],
+      options: [{ suffixes: ['Dir'] }],
     },
     {
       code: `
@@ -74,16 +76,13 @@ ruleTester.run(RULE_NAME, rule, {
         })
         class TestPage {}
       `,
-      options: [
-        {
-          suffixes: ['Page', 'View'],
-        },
-      ],
+      options: [{ suffixes: ['Page', 'View'] }],
     },
   ],
   invalid: [
     convertAnnotatedSourceToFailureCase({
-      description: 'it should fail when directive class has the wrong suffix',
+      description:
+        'it should fail if directive class name does not end with the default suffix',
       annotatedSource: `
         @Directive({
           selector: 'sg-foo-bar'
@@ -92,54 +91,37 @@ ruleTester.run(RULE_NAME, rule, {
               ~~~~
       `,
       messageId,
+      data: { className: 'Test', suffixes: ['"Directive"'] },
     }),
     convertAnnotatedSourceToFailureCase({
-      description: `it should fail when a different list of suffixes is set and doesn't match`,
+      description:
+        'it should fail if directive class name does not end with one of the default suffixes',
       annotatedSource: `
         @Directive({
-            selector: 'sgBarFoo'
+          selector: 'sg-foo-bar'
         })
-        class TestPage {}
-              ~~~~~~~~
+        class TestDirectivePage implements AsyncValidator {}
+              ~~~~~~~~~~~~~~~~~
       `,
       messageId,
-      options: [
-        {
-          suffixes: ['Directive', 'View'],
-        },
-      ],
+      data: {
+        className: 'TestDirectivePage',
+        suffixes: ['"Directive"', '"Validator"'].join(' or '),
+      },
     }),
     convertAnnotatedSourceToFailureCase({
-      description: `it should fail when a different list of suffixes is set and doesn't match`,
-      annotatedSource: `
-        @Directive({
-          selector: 'sgBarFoo'
-        })
-        class TestPage {}
-              ~~~~~~~~
-      `,
-      messageId,
-      options: [
-        {
-          suffixes: ['Directive'],
-        },
-      ],
-    }),
-    convertAnnotatedSourceToFailureCase({
-      description: `it should fail when a different list of suffixes is set and doesn't match`,
+      description:
+        'it should fail if directive class name does not end with the custom suffix',
       annotatedSource: `
         @Directive({
           selector: 'sgBarFoo'
         })
-        class TestDirective {}
-              ~~~~~~~~~~~~~
+        class TestPageDirective {}
+              ~~~~~~~~~~~~~~~~~
       `,
       messageId,
-      options: [
-        {
-          suffixes: ['Page'],
-        },
-      ],
+      data: { className: 'TestPageDirective', suffixes: ['"Page"'] },
+      options: [{ suffixes: ['Page'] }],
     }),
   ],
 });

--- a/packages/eslint-plugin/tests/rules/directive-class-suffix.test.ts
+++ b/packages/eslint-plugin/tests/rules/directive-class-suffix.test.ts
@@ -37,6 +37,7 @@ ruleTester.run(RULE_NAME, rule, {
     })
     class TestValidator implements AsyncValidator {}
     `,
+    // https://github.com/angular-eslint/angular-eslint/issues/353
     `
     @Directive()
     class Test {}


### PR DESCRIPTION
1st. commit is the fix for #353.
2nd. commit is a refactor that:

- makes report message more-friendly;
- removes unnecessary tests and uses `data` property to ensure we pass the correct parameters to the user.

In any case, if you prefer, I could split it into 2 PRs.

Fixes #353.