### PR TITLE
build: enforce type imports

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -7,5 +7,8 @@
     "plugin:@typescript-eslint/recommended",
     "prettier",
     "prettier/@typescript-eslint"
-  ]
+  ],
+  "rules": {
+    "@typescript-eslint/consistent-type-imports": "error"
+  }
 }

--- a/packages/builder/src/index.ts
+++ b/packages/builder/src/index.ts
@@ -1,11 +1,8 @@
-import {
-  BuilderContext,
-  BuilderOutput,
-  createBuilder,
-} from '@angular-devkit/architect';
-import { ESLint } from 'eslint';
+import type { BuilderContext, BuilderOutput } from '@angular-devkit/architect';
+import { createBuilder } from '@angular-devkit/architect';
+import type { ESLint } from 'eslint';
 import path from 'path';
-import { Schema } from './schema';
+import type { Schema } from './schema';
 import { lint, loadESLint } from './utils/eslint-utils';
 
 async function run(

--- a/packages/builder/src/utils/eslint-utils.ts
+++ b/packages/builder/src/utils/eslint-utils.ts
@@ -1,5 +1,5 @@
 import type * as ESLintLibrary from 'eslint';
-import { Schema } from '../schema';
+import type { Schema } from '../schema';
 
 export async function loadESLint(): Promise<typeof ESLintLibrary> {
   let eslint;

--- a/packages/builder/tests/index.test.ts
+++ b/packages/builder/tests/index.test.ts
@@ -7,9 +7,9 @@
 import { Architect } from '@angular-devkit/architect';
 import { TestingArchitectHost } from '@angular-devkit/architect/testing';
 import { logging, schema } from '@angular-devkit/core';
-import { ESLint } from 'eslint';
+import type { ESLint } from 'eslint';
 import { resolve } from 'path';
-import { Schema } from '../src/schema';
+import type { Schema } from '../src/schema';
 
 const mockFormatter = {
   format: jest

--- a/packages/eslint-plugin-template/src/rules/accessibility-valid-aria.ts
+++ b/packages/eslint-plugin-template/src/rules/accessibility-valid-aria.ts
@@ -1,13 +1,13 @@
+import type { AST, ASTWithSource } from '@angular/compiler';
 import {
-  AST,
-  ASTWithSource,
   LiteralArray,
   LiteralMap,
   LiteralPrimitive,
   TmplAstBoundAttribute,
   TmplAstTextAttribute,
 } from '@angular/compiler';
-import { aria, ARIAProperty, ARIAPropertyDefinition } from 'aria-query';
+import type { ARIAProperty, ARIAPropertyDefinition } from 'aria-query';
+import { aria } from 'aria-query';
 import {
   createESLintRule,
   getTemplateParserServices,

--- a/packages/eslint-plugin-template/src/rules/no-call-expression.ts
+++ b/packages/eslint-plugin-template/src/rules/no-call-expression.ts
@@ -1,5 +1,5 @@
+import type { AST } from '@angular/compiler';
 import {
-  AST,
   Conditional,
   MethodCall,
   SafeMethodCall,

--- a/packages/eslint-plugin-template/src/utils/create-eslint-rule.ts
+++ b/packages/eslint-plugin-template/src/utils/create-eslint-rule.ts
@@ -1,4 +1,5 @@
-import { ESLintUtils, TSESLint } from '@typescript-eslint/experimental-utils';
+import type { TSESLint } from '@typescript-eslint/experimental-utils';
+import { ESLintUtils } from '@typescript-eslint/experimental-utils';
 
 export const createESLintRule = ESLintUtils.RuleCreator(
   (_ruleName) => `https://github.com/angular-eslint/angular-eslint`,

--- a/packages/eslint-plugin-template/tests/rules/accessibility-alt-text.test.ts
+++ b/packages/eslint-plugin-template/tests/rules/accessibility-alt-text.test.ts
@@ -2,10 +2,8 @@ import {
   convertAnnotatedSourceToFailureCase,
   RuleTester,
 } from '@angular-eslint/utils';
-import rule, {
-  MessageIds,
-  RULE_NAME,
-} from '../../src/rules/accessibility-alt-text';
+import type { MessageIds } from '../../src/rules/accessibility-alt-text';
+import rule, { RULE_NAME } from '../../src/rules/accessibility-alt-text';
 
 //------------------------------------------------------------------------------
 // Tests

--- a/packages/eslint-plugin-template/tests/rules/accessibility-elements-content.test.ts
+++ b/packages/eslint-plugin-template/tests/rules/accessibility-elements-content.test.ts
@@ -2,8 +2,8 @@ import {
   convertAnnotatedSourceToFailureCase,
   RuleTester,
 } from '@angular-eslint/utils';
+import type { MessageIds } from '../../src/rules/accessibility-elements-content';
 import rule, {
-  MessageIds,
   RULE_NAME,
 } from '../../src/rules/accessibility-elements-content';
 

--- a/packages/eslint-plugin-template/tests/rules/accessibility-label-for.test.ts
+++ b/packages/eslint-plugin-template/tests/rules/accessibility-label-for.test.ts
@@ -2,10 +2,8 @@ import {
   convertAnnotatedSourceToFailureCase,
   RuleTester,
 } from '@angular-eslint/utils';
-import rule, {
-  MessageIds,
-  RULE_NAME,
-} from '../../src/rules/accessibility-label-for';
+import type { MessageIds } from '../../src/rules/accessibility-label-for';
+import rule, { RULE_NAME } from '../../src/rules/accessibility-label-for';
 
 //------------------------------------------------------------------------------
 // Tests

--- a/packages/eslint-plugin-template/tests/rules/accessibility-table-scope.test.ts
+++ b/packages/eslint-plugin-template/tests/rules/accessibility-table-scope.test.ts
@@ -2,10 +2,8 @@ import {
   convertAnnotatedSourceToFailureCase,
   RuleTester,
 } from '@angular-eslint/utils';
-import rule, {
-  MessageIds,
-  RULE_NAME,
-} from '../../src/rules/accessibility-table-scope';
+import type { MessageIds } from '../../src/rules/accessibility-table-scope';
+import rule, { RULE_NAME } from '../../src/rules/accessibility-table-scope';
 
 //------------------------------------------------------------------------------
 // Tests

--- a/packages/eslint-plugin-template/tests/rules/accessibility-valid-aria.test.ts
+++ b/packages/eslint-plugin-template/tests/rules/accessibility-valid-aria.test.ts
@@ -2,10 +2,8 @@ import {
   convertAnnotatedSourceToFailureCase,
   RuleTester,
 } from '@angular-eslint/utils';
-import rule, {
-  MessageIds,
-  RULE_NAME,
-} from '../../src/rules/accessibility-valid-aria';
+import type { MessageIds } from '../../src/rules/accessibility-valid-aria';
+import rule, { RULE_NAME } from '../../src/rules/accessibility-valid-aria';
 
 //------------------------------------------------------------------------------
 // Tests

--- a/packages/eslint-plugin-template/tests/rules/banana-in-box.test.ts
+++ b/packages/eslint-plugin-template/tests/rules/banana-in-box.test.ts
@@ -2,7 +2,8 @@ import {
   convertAnnotatedSourceToFailureCase,
   RuleTester,
 } from '@angular-eslint/utils';
-import rule, { MessageIds, RULE_NAME } from '../../src/rules/banana-in-box';
+import type { MessageIds } from '../../src/rules/banana-in-box';
+import rule, { RULE_NAME } from '../../src/rules/banana-in-box';
 
 //------------------------------------------------------------------------------
 // Tests

--- a/packages/eslint-plugin-template/tests/rules/click-events-have-key-events.test.ts
+++ b/packages/eslint-plugin-template/tests/rules/click-events-have-key-events.test.ts
@@ -2,10 +2,8 @@ import {
   convertAnnotatedSourceToFailureCase,
   RuleTester,
 } from '@angular-eslint/utils';
-import rule, {
-  MessageIds,
-  RULE_NAME,
-} from '../../src/rules/click-events-have-key-events';
+import type { MessageIds } from '../../src/rules/click-events-have-key-events';
+import rule, { RULE_NAME } from '../../src/rules/click-events-have-key-events';
 
 //------------------------------------------------------------------------------
 // Tests

--- a/packages/eslint-plugin-template/tests/rules/conditional-complexity.test.ts
+++ b/packages/eslint-plugin-template/tests/rules/conditional-complexity.test.ts
@@ -2,10 +2,8 @@ import {
   convertAnnotatedSourceToFailureCase,
   RuleTester,
 } from '@angular-eslint/utils';
-import rule, {
-  MessageIds,
-  RULE_NAME,
-} from '../../src/rules/conditional-complexity';
+import type { MessageIds } from '../../src/rules/conditional-complexity';
+import rule, { RULE_NAME } from '../../src/rules/conditional-complexity';
 
 //------------------------------------------------------------------------------
 // Tests

--- a/packages/eslint-plugin-template/tests/rules/cyclomatic-complexity.test.ts
+++ b/packages/eslint-plugin-template/tests/rules/cyclomatic-complexity.test.ts
@@ -2,10 +2,8 @@ import {
   convertAnnotatedSourceToFailureCase,
   RuleTester,
 } from '@angular-eslint/utils';
-import rule, {
-  MessageIds,
-  RULE_NAME,
-} from '../../src/rules/cyclomatic-complexity';
+import type { MessageIds } from '../../src/rules/cyclomatic-complexity';
+import rule, { RULE_NAME } from '../../src/rules/cyclomatic-complexity';
 
 //------------------------------------------------------------------------------
 // Tests

--- a/packages/eslint-plugin-template/tests/rules/i18n.test.ts
+++ b/packages/eslint-plugin-template/tests/rules/i18n.test.ts
@@ -2,7 +2,8 @@ import {
   convertAnnotatedSourceToFailureCase,
   RuleTester,
 } from '@angular-eslint/utils';
-import rule, { MessageIds, RULE_NAME } from '../../src/rules/i18n';
+import type { MessageIds } from '../../src/rules/i18n';
+import rule, { RULE_NAME } from '../../src/rules/i18n';
 
 //------------------------------------------------------------------------------
 // Tests

--- a/packages/eslint-plugin-template/tests/rules/no-any.test.ts
+++ b/packages/eslint-plugin-template/tests/rules/no-any.test.ts
@@ -2,7 +2,8 @@ import {
   convertAnnotatedSourceToFailureCase,
   RuleTester,
 } from '@angular-eslint/utils';
-import rule, { MessageIds, RULE_NAME } from '../../src/rules/no-any';
+import type { MessageIds } from '../../src/rules/no-any';
+import rule, { RULE_NAME } from '../../src/rules/no-any';
 
 //------------------------------------------------------------------------------
 // Tests

--- a/packages/eslint-plugin-template/tests/rules/no-autofocus.test.ts
+++ b/packages/eslint-plugin-template/tests/rules/no-autofocus.test.ts
@@ -2,7 +2,8 @@ import {
   convertAnnotatedSourceToFailureCase,
   RuleTester,
 } from '@angular-eslint/utils';
-import rule, { MessageIds, RULE_NAME } from '../../src/rules/no-autofocus';
+import type { MessageIds } from '../../src/rules/no-autofocus';
+import rule, { RULE_NAME } from '../../src/rules/no-autofocus';
 
 //------------------------------------------------------------------------------
 // Tests

--- a/packages/eslint-plugin-template/tests/rules/no-call-expression.test.ts
+++ b/packages/eslint-plugin-template/tests/rules/no-call-expression.test.ts
@@ -2,10 +2,8 @@ import {
   convertAnnotatedSourceToFailureCase,
   RuleTester,
 } from '@angular-eslint/utils';
-import rule, {
-  MessageIds,
-  RULE_NAME,
-} from '../../src/rules/no-call-expression';
+import type { MessageIds } from '../../src/rules/no-call-expression';
+import rule, { RULE_NAME } from '../../src/rules/no-call-expression';
 
 //------------------------------------------------------------------------------
 // Tests

--- a/packages/eslint-plugin-template/tests/rules/no-distracting-elements.test.ts
+++ b/packages/eslint-plugin-template/tests/rules/no-distracting-elements.test.ts
@@ -2,10 +2,8 @@ import {
   convertAnnotatedSourceToFailureCase,
   RuleTester,
 } from '@angular-eslint/utils';
-import rule, {
-  MessageIds,
-  RULE_NAME,
-} from '../../src/rules/no-distracting-elements';
+import type { MessageIds } from '../../src/rules/no-distracting-elements';
+import rule, { RULE_NAME } from '../../src/rules/no-distracting-elements';
 
 //------------------------------------------------------------------------------
 // Tests

--- a/packages/eslint-plugin-template/tests/rules/no-duplicate-attributes.test.ts
+++ b/packages/eslint-plugin-template/tests/rules/no-duplicate-attributes.test.ts
@@ -2,10 +2,8 @@ import {
   convertAnnotatedSourceToFailureCase,
   RuleTester,
 } from '@angular-eslint/utils';
-import rule, {
-  MessageIds,
-  RULE_NAME,
-} from '../../src/rules/no-duplicate-attributes';
+import type { MessageIds } from '../../src/rules/no-duplicate-attributes';
+import rule, { RULE_NAME } from '../../src/rules/no-duplicate-attributes';
 
 //------------------------------------------------------------------------------
 // Tests

--- a/packages/eslint-plugin-template/tests/rules/no-negated-async.test.ts
+++ b/packages/eslint-plugin-template/tests/rules/no-negated-async.test.ts
@@ -2,7 +2,8 @@ import {
   convertAnnotatedSourceToFailureCase,
   RuleTester,
 } from '@angular-eslint/utils';
-import rule, { MessageIds, RULE_NAME } from '../../src/rules/no-negated-async';
+import type { MessageIds } from '../../src/rules/no-negated-async';
+import rule, { RULE_NAME } from '../../src/rules/no-negated-async';
 
 //------------------------------------------------------------------------------
 // Tests

--- a/packages/eslint-plugin-template/tests/rules/no-positive-tabindex.test.ts
+++ b/packages/eslint-plugin-template/tests/rules/no-positive-tabindex.test.ts
@@ -2,10 +2,8 @@ import {
   convertAnnotatedSourceToFailureCase,
   RuleTester,
 } from '@angular-eslint/utils';
-import rule, {
-  MessageIds,
-  RULE_NAME,
-} from '../../src/rules/no-positive-tabindex';
+import type { MessageIds } from '../../src/rules/no-positive-tabindex';
+import rule, { RULE_NAME } from '../../src/rules/no-positive-tabindex';
 
 //------------------------------------------------------------------------------
 // Tests

--- a/packages/eslint-plugin-template/tests/rules/use-track-by-function.test.ts
+++ b/packages/eslint-plugin-template/tests/rules/use-track-by-function.test.ts
@@ -2,10 +2,8 @@ import {
   convertAnnotatedSourceToFailureCase,
   RuleTester,
 } from '@angular-eslint/utils';
-import rule, {
-  MessageIds,
-  RULE_NAME,
-} from '../../src/rules/use-track-by-function';
+import type { MessageIds } from '../../src/rules/use-track-by-function';
+import rule, { RULE_NAME } from '../../src/rules/use-track-by-function';
 
 //------------------------------------------------------------------------------
 // Tests

--- a/packages/eslint-plugin/src/rules/component-class-suffix.ts
+++ b/packages/eslint-plugin/src/rules/component-class-suffix.ts
@@ -1,4 +1,4 @@
-import { TSESTree } from '@typescript-eslint/experimental-utils';
+import type { TSESTree } from '@typescript-eslint/experimental-utils';
 import { createESLintRule } from '../utils/create-eslint-rule';
 import { COMPONENT_CLASS_DECORATOR } from '../utils/selectors';
 import { getClassName } from '../utils/utils';

--- a/packages/eslint-plugin/src/rules/component-max-inline-declarations.ts
+++ b/packages/eslint-plugin/src/rules/component-max-inline-declarations.ts
@@ -1,4 +1,4 @@
-import { TSESTree } from '@typescript-eslint/experimental-utils';
+import type { TSESTree } from '@typescript-eslint/experimental-utils';
 import { createESLintRule } from '../utils/create-eslint-rule';
 import { COMPONENT_CLASS_DECORATOR } from '../utils/selectors';
 import {

--- a/packages/eslint-plugin/src/rules/component-selector.ts
+++ b/packages/eslint-plugin/src/rules/component-selector.ts
@@ -1,19 +1,19 @@
-import { TSESTree } from '@typescript-eslint/experimental-utils';
+import type { TSESTree } from '@typescript-eslint/experimental-utils';
 import { createESLintRule } from '../utils/create-eslint-rule';
 import { COMPONENT_CLASS_DECORATOR } from '../utils/selectors';
+import type { SelectorStyle } from '../utils/utils';
 import {
   arrayify,
   getDecoratorPropertyValue,
   OPTION_STYLE_CAMEL_CASE,
   OPTION_STYLE_KEBAB_CASE,
-  SelectorStyle,
 } from '../utils/utils';
+import type { Options } from '../utils/property-selector';
 import {
   checkSelector,
   checkValidOptions,
   OPTION_TYPE_ATTRIBUTE,
   OPTION_TYPE_ELEMENT,
-  Options,
   reportPrefixError,
   reportStyleError,
   reportTypeError,

--- a/packages/eslint-plugin/src/rules/contextual-decorator.ts
+++ b/packages/eslint-plugin/src/rules/contextual-decorator.ts
@@ -1,8 +1,8 @@
-import { TSESLint, TSESTree } from '@typescript-eslint/experimental-utils';
+import type { TSESLint, TSESTree } from '@typescript-eslint/experimental-utils';
 
+import type { AngularClassDecoratorKeys } from '../utils/utils';
 import {
   isAngularInnerClassDecorator,
-  AngularClassDecoratorKeys,
   ANGULAR_CLASS_DECORATOR_MAPPER,
   getAngularClassDecorator,
   getDecoratorName,

--- a/packages/eslint-plugin/src/rules/contextual-lifecycle.ts
+++ b/packages/eslint-plugin/src/rules/contextual-lifecycle.ts
@@ -1,4 +1,4 @@
-import { TSESTree } from '@typescript-eslint/experimental-utils';
+import type { TSESTree } from '@typescript-eslint/experimental-utils';
 import { createESLintRule } from '../utils/create-eslint-rule';
 import {
   COMPONENT_CLASS_DECORATOR,

--- a/packages/eslint-plugin/src/rules/directive-class-suffix.ts
+++ b/packages/eslint-plugin/src/rules/directive-class-suffix.ts
@@ -1,4 +1,4 @@
-import { TSESTree } from '@typescript-eslint/experimental-utils';
+import type { TSESTree } from '@typescript-eslint/experimental-utils';
 import { createESLintRule } from '../utils/create-eslint-rule';
 import { DIRECTIVE_CLASS_DECORATOR } from '../utils/selectors';
 import { getClassName, getDeclaredInterfaceNames } from '../utils/utils';

--- a/packages/eslint-plugin/src/rules/directive-selector.ts
+++ b/packages/eslint-plugin/src/rules/directive-selector.ts
@@ -1,14 +1,15 @@
-import { TSESTree } from '@typescript-eslint/experimental-utils';
+import type { TSESTree } from '@typescript-eslint/experimental-utils';
 import { createESLintRule } from '../utils/create-eslint-rule';
 import { DIRECTIVE_CLASS_DECORATOR } from '../utils/selectors';
+import type { SelectorStyle } from '../utils/utils';
 import {
   arrayify,
   OPTION_STYLE_CAMEL_CASE,
   OPTION_STYLE_KEBAB_CASE,
   getDecoratorPropertyValue,
-  SelectorStyle,
 } from '../utils/utils';
 
+import type { Options } from '../utils/property-selector';
 import {
   checkSelector,
   checkValidOptions,
@@ -16,7 +17,6 @@ import {
   reportTypeError,
   OPTION_TYPE_ATTRIBUTE,
   OPTION_TYPE_ELEMENT,
-  Options,
   reportStyleError,
 } from '../utils/property-selector';
 

--- a/packages/eslint-plugin/src/rules/no-attribute-decorator.ts
+++ b/packages/eslint-plugin/src/rules/no-attribute-decorator.ts
@@ -1,4 +1,4 @@
-import { TSESTree } from '@typescript-eslint/experimental-utils';
+import type { TSESTree } from '@typescript-eslint/experimental-utils';
 import { createESLintRule } from '../utils/create-eslint-rule';
 
 type Options = [];

--- a/packages/eslint-plugin/src/rules/no-conflicting-lifecycle.ts
+++ b/packages/eslint-plugin/src/rules/no-conflicting-lifecycle.ts
@@ -1,11 +1,13 @@
-import { TSESTree } from '@typescript-eslint/experimental-utils';
+import type { TSESTree } from '@typescript-eslint/experimental-utils';
 import { createESLintRule } from '../utils/create-eslint-rule';
+import type {
+  AngularLifecycleInterfaceKeys,
+  AngularLifecycleMethodKeys,
+} from '../utils/utils';
 import {
   AngularLifecycleInterfaces,
   getDeclaredAngularLifecycleInterfaces,
   AngularLifecycleMethods,
-  AngularLifecycleInterfaceKeys,
-  AngularLifecycleMethodKeys,
   getDeclaredAngularLifecycleMethods,
   getDeclaredInterfaces,
   isAngularLifecycleInterface,

--- a/packages/eslint-plugin/src/rules/no-empty-lifecycle-method.ts
+++ b/packages/eslint-plugin/src/rules/no-empty-lifecycle-method.ts
@@ -1,4 +1,4 @@
-import { TSESTree } from '@typescript-eslint/experimental-utils';
+import type { TSESTree } from '@typescript-eslint/experimental-utils';
 import { createESLintRule } from '../utils/create-eslint-rule';
 import {
   ANGULAR_LIFECYCLE_METHODS,

--- a/packages/eslint-plugin/src/rules/no-forward-ref.ts
+++ b/packages/eslint-plugin/src/rules/no-forward-ref.ts
@@ -1,4 +1,4 @@
-import { TSESTree } from '@typescript-eslint/experimental-utils';
+import type { TSESTree } from '@typescript-eslint/experimental-utils';
 
 import { createESLintRule } from '../utils/create-eslint-rule';
 

--- a/packages/eslint-plugin/src/rules/no-host-metadata-property.ts
+++ b/packages/eslint-plugin/src/rules/no-host-metadata-property.ts
@@ -1,4 +1,4 @@
-import { TSESTree } from '@typescript-eslint/experimental-utils';
+import type { TSESTree } from '@typescript-eslint/experimental-utils';
 import { createESLintRule } from '../utils/create-eslint-rule';
 import { COMPONENT_OR_DIRECTIVE_CLASS_DECORATOR } from '../utils/selectors';
 import {

--- a/packages/eslint-plugin/src/rules/no-input-prefix.ts
+++ b/packages/eslint-plugin/src/rules/no-input-prefix.ts
@@ -1,4 +1,4 @@
-import { TSESTree } from '@typescript-eslint/experimental-utils';
+import type { TSESTree } from '@typescript-eslint/experimental-utils';
 import { createESLintRule } from '../utils/create-eslint-rule';
 import { getClassPropertyName, isImportedFrom } from '../utils/utils';
 

--- a/packages/eslint-plugin/src/rules/no-input-rename.ts
+++ b/packages/eslint-plugin/src/rules/no-input-rename.ts
@@ -1,4 +1,4 @@
-import { TSESTree } from '@typescript-eslint/experimental-utils';
+import type { TSESTree } from '@typescript-eslint/experimental-utils';
 import { createESLintRule } from '../utils/create-eslint-rule';
 import {
   getDecoratorPropertyValue,

--- a/packages/eslint-plugin/src/rules/no-inputs-metadata-property.ts
+++ b/packages/eslint-plugin/src/rules/no-inputs-metadata-property.ts
@@ -1,4 +1,4 @@
-import { TSESTree } from '@typescript-eslint/experimental-utils';
+import type { TSESTree } from '@typescript-eslint/experimental-utils';
 import { createESLintRule } from '../utils/create-eslint-rule';
 import { COMPONENT_OR_DIRECTIVE_CLASS_DECORATOR } from '../utils/selectors';
 import {

--- a/packages/eslint-plugin/src/rules/no-lifecycle-call.ts
+++ b/packages/eslint-plugin/src/rules/no-lifecycle-call.ts
@@ -1,4 +1,4 @@
-import { TSESTree } from '@typescript-eslint/experimental-utils';
+import type { TSESTree } from '@typescript-eslint/experimental-utils';
 import { createESLintRule } from '../utils/create-eslint-rule';
 import {
   ANGULAR_LIFECYCLE_METHODS,

--- a/packages/eslint-plugin/src/rules/no-output-native.ts
+++ b/packages/eslint-plugin/src/rules/no-output-native.ts
@@ -1,4 +1,4 @@
-import { TSESTree } from '@typescript-eslint/experimental-utils';
+import type { TSESTree } from '@typescript-eslint/experimental-utils';
 import { createESLintRule } from '../utils/create-eslint-rule';
 import { isLiteral, getClassName, getClassPropertyName } from '../utils/utils';
 

--- a/packages/eslint-plugin/src/rules/no-output-on-prefix.ts
+++ b/packages/eslint-plugin/src/rules/no-output-on-prefix.ts
@@ -1,4 +1,4 @@
-import { TSESTree } from '@typescript-eslint/experimental-utils';
+import type { TSESTree } from '@typescript-eslint/experimental-utils';
 import { createESLintRule } from '../utils/create-eslint-rule';
 import { getClassName, getClassPropertyName } from '../utils/utils';
 

--- a/packages/eslint-plugin/src/rules/no-output-rename.ts
+++ b/packages/eslint-plugin/src/rules/no-output-rename.ts
@@ -1,4 +1,4 @@
-import { TSESTree } from '@typescript-eslint/experimental-utils';
+import type { TSESTree } from '@typescript-eslint/experimental-utils';
 import { createESLintRule } from '../utils/create-eslint-rule';
 import {
   getDecoratorPropertyValue,

--- a/packages/eslint-plugin/src/rules/no-outputs-metadata-property.ts
+++ b/packages/eslint-plugin/src/rules/no-outputs-metadata-property.ts
@@ -1,4 +1,4 @@
-import { TSESTree } from '@typescript-eslint/experimental-utils';
+import type { TSESTree } from '@typescript-eslint/experimental-utils';
 import { createESLintRule } from '../utils/create-eslint-rule';
 import { COMPONENT_OR_DIRECTIVE_CLASS_DECORATOR } from '../utils/selectors';
 import {

--- a/packages/eslint-plugin/src/rules/no-pipe-impure.ts
+++ b/packages/eslint-plugin/src/rules/no-pipe-impure.ts
@@ -1,4 +1,4 @@
-import { TSESTree } from '@typescript-eslint/experimental-utils';
+import type { TSESTree } from '@typescript-eslint/experimental-utils';
 import { createESLintRule } from '../utils/create-eslint-rule';
 import { PIPE_CLASS_DECORATOR } from '../utils/selectors';
 import { getDecoratorProperty, isLiteral } from '../utils/utils';

--- a/packages/eslint-plugin/src/rules/no-queries-metadata-property.ts
+++ b/packages/eslint-plugin/src/rules/no-queries-metadata-property.ts
@@ -1,4 +1,4 @@
-import { TSESTree } from '@typescript-eslint/experimental-utils';
+import type { TSESTree } from '@typescript-eslint/experimental-utils';
 import { createESLintRule } from '../utils/create-eslint-rule';
 import { COMPONENT_OR_DIRECTIVE_CLASS_DECORATOR } from '../utils/selectors';
 import {

--- a/packages/eslint-plugin/src/rules/pipe-prefix.ts
+++ b/packages/eslint-plugin/src/rules/pipe-prefix.ts
@@ -1,4 +1,4 @@
-import { TSESTree } from '@typescript-eslint/experimental-utils';
+import type { TSESTree } from '@typescript-eslint/experimental-utils';
 import { createESLintRule } from '../utils/create-eslint-rule';
 import { PIPE_CLASS_DECORATOR } from '../utils/selectors';
 import {

--- a/packages/eslint-plugin/src/rules/prefer-on-push-component-change-detection.ts
+++ b/packages/eslint-plugin/src/rules/prefer-on-push-component-change-detection.ts
@@ -1,4 +1,4 @@
-import { TSESTree } from '@typescript-eslint/experimental-utils';
+import type { TSESTree } from '@typescript-eslint/experimental-utils';
 import { createESLintRule } from '../utils/create-eslint-rule';
 import { COMPONENT_CLASS_DECORATOR } from '../utils/selectors';
 import { getDecoratorPropertyValue, isIdentifier } from '../utils/utils';

--- a/packages/eslint-plugin/src/rules/prefer-output-readonly.ts
+++ b/packages/eslint-plugin/src/rules/prefer-output-readonly.ts
@@ -1,4 +1,4 @@
-import { TSESTree } from '@typescript-eslint/experimental-utils';
+import type { TSESTree } from '@typescript-eslint/experimental-utils';
 import { createESLintRule } from '../utils/create-eslint-rule';
 
 type Options = [];

--- a/packages/eslint-plugin/src/rules/relative-url-prefix.ts
+++ b/packages/eslint-plugin/src/rules/relative-url-prefix.ts
@@ -1,4 +1,4 @@
-import { TSESTree } from '@typescript-eslint/experimental-utils';
+import type { TSESTree } from '@typescript-eslint/experimental-utils';
 import { createESLintRule } from '../utils/create-eslint-rule';
 import { COMPONENT_CLASS_DECORATOR } from '../utils/selectors';
 import {

--- a/packages/eslint-plugin/src/rules/sort-ngmodule-metadata-arrays.ts
+++ b/packages/eslint-plugin/src/rules/sort-ngmodule-metadata-arrays.ts
@@ -1,4 +1,4 @@
-import { TSESTree } from '@typescript-eslint/experimental-utils';
+import type { TSESTree } from '@typescript-eslint/experimental-utils';
 import { createESLintRule } from '../utils/create-eslint-rule';
 import { MODULE_CLASS_DECORATOR } from '../utils/selectors';
 import {

--- a/packages/eslint-plugin/src/rules/use-component-selector.ts
+++ b/packages/eslint-plugin/src/rules/use-component-selector.ts
@@ -1,4 +1,4 @@
-import { TSESTree } from '@typescript-eslint/experimental-utils';
+import type { TSESTree } from '@typescript-eslint/experimental-utils';
 import { createESLintRule } from '../utils/create-eslint-rule';
 import { COMPONENT_CLASS_DECORATOR } from '../utils/selectors';
 import {

--- a/packages/eslint-plugin/src/rules/use-component-view-encapsulation.ts
+++ b/packages/eslint-plugin/src/rules/use-component-view-encapsulation.ts
@@ -1,4 +1,4 @@
-import { TSESTree } from '@typescript-eslint/experimental-utils';
+import type { TSESTree } from '@typescript-eslint/experimental-utils';
 import { createESLintRule } from '../utils/create-eslint-rule';
 import { COMPONENT_CLASS_DECORATOR } from '../utils/selectors';
 import {

--- a/packages/eslint-plugin/src/rules/use-injectable-provided-in.ts
+++ b/packages/eslint-plugin/src/rules/use-injectable-provided-in.ts
@@ -1,4 +1,4 @@
-import { TSESTree } from '@typescript-eslint/experimental-utils';
+import type { TSESTree } from '@typescript-eslint/experimental-utils';
 import { createESLintRule } from '../utils/create-eslint-rule';
 import { INJECTABLE_CLASS_DECORATOR } from '../utils/selectors';
 import {

--- a/packages/eslint-plugin/src/rules/use-lifecycle-interface.ts
+++ b/packages/eslint-plugin/src/rules/use-lifecycle-interface.ts
@@ -1,8 +1,8 @@
-import { TSESTree } from '@typescript-eslint/experimental-utils';
+import type { TSESTree } from '@typescript-eslint/experimental-utils';
 import { createESLintRule } from '../utils/create-eslint-rule';
+import type { AngularLifecycleMethodKeys } from '../utils/utils';
 import {
   AngularLifecycleInterfaces,
-  AngularLifecycleMethodKeys,
   ANGULAR_LIFECYCLE_METHODS,
   getAngularClassDecorator,
   getDeclaredAngularLifecycleInterfaces,

--- a/packages/eslint-plugin/src/rules/use-pipe-transform-interface.ts
+++ b/packages/eslint-plugin/src/rules/use-pipe-transform-interface.ts
@@ -1,4 +1,4 @@
-import { TSESTree, TSESLint } from '@typescript-eslint/experimental-utils';
+import type { TSESTree, TSESLint } from '@typescript-eslint/experimental-utils';
 import { createESLintRule } from '../utils/create-eslint-rule';
 import { PIPE_CLASS_DECORATOR } from '../utils/selectors';
 import { getDeclaredInterfaceName, isImportDeclaration } from '../utils/utils';

--- a/packages/eslint-plugin/src/utils/create-eslint-rule.ts
+++ b/packages/eslint-plugin/src/utils/create-eslint-rule.ts
@@ -1,8 +1,8 @@
-import {
-  ESLintUtils,
+import type {
   ParserServices,
   TSESLint,
 } from '@typescript-eslint/experimental-utils';
+import { ESLintUtils } from '@typescript-eslint/experimental-utils';
 
 export const createESLintRule = ESLintUtils.RuleCreator(
   (_ruleName) => `https://github.com/angular-eslint/angular-eslint`,

--- a/packages/eslint-plugin/src/utils/property-selector.ts
+++ b/packages/eslint-plugin/src/utils/property-selector.ts
@@ -1,13 +1,13 @@
 import { CssSelector } from '@angular/compiler';
-import { TSESTree } from '@typescript-eslint/experimental-utils';
+import type { TSESTree } from '@typescript-eslint/experimental-utils';
 
+import type { SelectorStyle } from './utils';
 import {
   arrayify,
   isLiteral,
   isTemplateLiteral,
   OPTION_STYLE_CAMEL_CASE,
   OPTION_STYLE_KEBAB_CASE,
-  SelectorStyle,
   SelectorValidator,
 } from './utils';
 

--- a/packages/eslint-plugin/src/utils/utils.ts
+++ b/packages/eslint-plugin/src/utils/utils.ts
@@ -1,4 +1,4 @@
-import { TSESTree } from '@typescript-eslint/experimental-utils';
+import type { TSESTree } from '@typescript-eslint/experimental-utils';
 
 export const objectKeys = Object.keys as <T>(
   o: T,

--- a/packages/eslint-plugin/tests/rules/component-class-suffix.test.ts
+++ b/packages/eslint-plugin/tests/rules/component-class-suffix.test.ts
@@ -2,10 +2,8 @@ import {
   convertAnnotatedSourceToFailureCase,
   RuleTester,
 } from '@angular-eslint/utils';
-import rule, {
-  MessageIds,
-  RULE_NAME,
-} from '../../src/rules/component-class-suffix';
+import type { MessageIds } from '../../src/rules/component-class-suffix';
+import rule, { RULE_NAME } from '../../src/rules/component-class-suffix';
 
 //------------------------------------------------------------------------------
 // Tests

--- a/packages/eslint-plugin/tests/rules/component-max-inline-declarations.test.ts
+++ b/packages/eslint-plugin/tests/rules/component-max-inline-declarations.test.ts
@@ -2,8 +2,8 @@ import {
   convertAnnotatedSourceToFailureCase,
   RuleTester,
 } from '@angular-eslint/utils';
+import type { MessageIds } from '../../src/rules/component-max-inline-declarations';
 import rule, {
-  MessageIds,
   RULE_NAME,
 } from '../../src/rules/component-max-inline-declarations';
 

--- a/packages/eslint-plugin/tests/rules/component-selector.test.ts
+++ b/packages/eslint-plugin/tests/rules/component-selector.test.ts
@@ -2,10 +2,8 @@ import {
   convertAnnotatedSourceToFailureCase,
   RuleTester,
 } from '@angular-eslint/utils';
-import rule, {
-  MessageIds,
-  RULE_NAME,
-} from '../../src/rules/component-selector';
+import type { MessageIds } from '../../src/rules/component-selector';
+import rule, { RULE_NAME } from '../../src/rules/component-selector';
 
 //------------------------------------------------------------------------------
 // Tests

--- a/packages/eslint-plugin/tests/rules/contextual-decorator.test.ts
+++ b/packages/eslint-plugin/tests/rules/contextual-decorator.test.ts
@@ -2,10 +2,8 @@ import {
   convertAnnotatedSourceToFailureCase,
   RuleTester,
 } from '@angular-eslint/utils';
-import rule, {
-  MessageIds,
-  RULE_NAME,
-} from '../../src/rules/contextual-decorator';
+import type { MessageIds } from '../../src/rules/contextual-decorator';
+import rule, { RULE_NAME } from '../../src/rules/contextual-decorator';
 
 //------------------------------------------------------------------------------
 // Tests

--- a/packages/eslint-plugin/tests/rules/contextual-lifecycle.test.ts
+++ b/packages/eslint-plugin/tests/rules/contextual-lifecycle.test.ts
@@ -2,10 +2,8 @@ import {
   convertAnnotatedSourceToFailureCase,
   RuleTester,
 } from '@angular-eslint/utils';
-import rule, {
-  MessageIds,
-  RULE_NAME,
-} from '../../src/rules/contextual-lifecycle';
+import type { MessageIds } from '../../src/rules/contextual-lifecycle';
+import rule, { RULE_NAME } from '../../src/rules/contextual-lifecycle';
 
 //------------------------------------------------------------------------------
 // Tests

--- a/packages/eslint-plugin/tests/rules/directive-class-suffix.test.ts
+++ b/packages/eslint-plugin/tests/rules/directive-class-suffix.test.ts
@@ -2,10 +2,8 @@ import {
   convertAnnotatedSourceToFailureCase,
   RuleTester,
 } from '@angular-eslint/utils';
-import rule, {
-  MessageIds,
-  RULE_NAME,
-} from '../../src/rules/directive-class-suffix';
+import type { MessageIds } from '../../src/rules/directive-class-suffix';
+import rule, { RULE_NAME } from '../../src/rules/directive-class-suffix';
 
 //------------------------------------------------------------------------------
 // Tests

--- a/packages/eslint-plugin/tests/rules/directive-selector.test.ts
+++ b/packages/eslint-plugin/tests/rules/directive-selector.test.ts
@@ -2,10 +2,8 @@ import {
   convertAnnotatedSourceToFailureCase,
   RuleTester,
 } from '@angular-eslint/utils';
-import rule, {
-  MessageIds,
-  RULE_NAME,
-} from '../../src/rules/directive-selector';
+import type { MessageIds } from '../../src/rules/directive-selector';
+import rule, { RULE_NAME } from '../../src/rules/directive-selector';
 
 //------------------------------------------------------------------------------
 // Tests

--- a/packages/eslint-plugin/tests/rules/no-conflicting-lifecycle.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-conflicting-lifecycle.test.ts
@@ -2,10 +2,8 @@ import {
   convertAnnotatedSourceToFailureCase,
   RuleTester,
 } from '@angular-eslint/utils';
-import rule, {
-  MessageIds,
-  RULE_NAME,
-} from '../../src/rules/no-conflicting-lifecycle';
+import type { MessageIds } from '../../src/rules/no-conflicting-lifecycle';
+import rule, { RULE_NAME } from '../../src/rules/no-conflicting-lifecycle';
 
 //------------------------------------------------------------------------------
 // Tests

--- a/packages/eslint-plugin/tests/rules/no-empty-lifecycle-method.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-empty-lifecycle-method.test.ts
@@ -2,10 +2,8 @@ import {
   convertAnnotatedSourceToFailureCase,
   RuleTester,
 } from '@angular-eslint/utils';
-import rule, {
-  MessageIds,
-  RULE_NAME,
-} from '../../src/rules/no-empty-lifecycle-method';
+import type { MessageIds } from '../../src/rules/no-empty-lifecycle-method';
+import rule, { RULE_NAME } from '../../src/rules/no-empty-lifecycle-method';
 
 //------------------------------------------------------------------------------
 // Tests

--- a/packages/eslint-plugin/tests/rules/no-forward-ref.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-forward-ref.test.ts
@@ -2,7 +2,8 @@ import {
   convertAnnotatedSourceToFailureCase,
   RuleTester,
 } from '@angular-eslint/utils';
-import rule, { MessageIds, RULE_NAME } from '../../src/rules/no-forward-ref';
+import type { MessageIds } from '../../src/rules/no-forward-ref';
+import rule, { RULE_NAME } from '../../src/rules/no-forward-ref';
 
 //------------------------------------------------------------------------------
 // Tests

--- a/packages/eslint-plugin/tests/rules/no-host-metadata-property.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-host-metadata-property.test.ts
@@ -2,10 +2,8 @@ import {
   convertAnnotatedSourceToFailureCase,
   RuleTester,
 } from '@angular-eslint/utils';
-import rule, {
-  MessageIds,
-  RULE_NAME,
-} from '../../src/rules/no-host-metadata-property';
+import type { MessageIds } from '../../src/rules/no-host-metadata-property';
+import rule, { RULE_NAME } from '../../src/rules/no-host-metadata-property';
 
 //------------------------------------------------------------------------------
 // Tests

--- a/packages/eslint-plugin/tests/rules/no-input-prefix.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-input-prefix.test.ts
@@ -2,7 +2,8 @@ import {
   convertAnnotatedSourceToFailureCase,
   RuleTester,
 } from '@angular-eslint/utils';
-import rule, { MessageIds, RULE_NAME } from '../../src/rules/no-input-prefix';
+import type { MessageIds } from '../../src/rules/no-input-prefix';
+import rule, { RULE_NAME } from '../../src/rules/no-input-prefix';
 
 //------------------------------------------------------------------------------
 // Tests

--- a/packages/eslint-plugin/tests/rules/no-input-rename.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-input-rename.test.ts
@@ -2,7 +2,8 @@ import {
   convertAnnotatedSourceToFailureCase,
   RuleTester,
 } from '@angular-eslint/utils';
-import rule, { MessageIds, RULE_NAME } from '../../src/rules/no-input-rename';
+import type { MessageIds } from '../../src/rules/no-input-rename';
+import rule, { RULE_NAME } from '../../src/rules/no-input-rename';
 
 //------------------------------------------------------------------------------
 // Tests

--- a/packages/eslint-plugin/tests/rules/no-inputs-metadata-property.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-inputs-metadata-property.test.ts
@@ -2,10 +2,8 @@ import {
   convertAnnotatedSourceToFailureCase,
   RuleTester,
 } from '@angular-eslint/utils';
-import rule, {
-  MessageIds,
-  RULE_NAME,
-} from '../../src/rules/no-inputs-metadata-property';
+import type { MessageIds } from '../../src/rules/no-inputs-metadata-property';
+import rule, { RULE_NAME } from '../../src/rules/no-inputs-metadata-property';
 
 //------------------------------------------------------------------------------
 // Tests

--- a/packages/eslint-plugin/tests/rules/no-lifecycle-call.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-lifecycle-call.test.ts
@@ -2,7 +2,8 @@ import {
   convertAnnotatedSourceToFailureCase,
   RuleTester,
 } from '@angular-eslint/utils';
-import rule, { MessageIds, RULE_NAME } from '../../src/rules/no-lifecycle-call';
+import type { MessageIds } from '../../src/rules/no-lifecycle-call';
+import rule, { RULE_NAME } from '../../src/rules/no-lifecycle-call';
 
 const ruleTester = new RuleTester({
   parser: '@typescript-eslint/parser',

--- a/packages/eslint-plugin/tests/rules/no-output-native.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-output-native.test.ts
@@ -2,7 +2,8 @@ import {
   convertAnnotatedSourceToFailureCase,
   RuleTester,
 } from '@angular-eslint/utils';
-import rule, { MessageIds, RULE_NAME } from '../../src/rules/no-output-native';
+import type { MessageIds } from '../../src/rules/no-output-native';
+import rule, { RULE_NAME } from '../../src/rules/no-output-native';
 
 //------------------------------------------------------------------------------
 // Tests

--- a/packages/eslint-plugin/tests/rules/no-output-on-prefix.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-output-on-prefix.test.ts
@@ -2,10 +2,8 @@ import {
   convertAnnotatedSourceToFailureCase,
   RuleTester,
 } from '@angular-eslint/utils';
-import rule, {
-  MessageIds,
-  RULE_NAME,
-} from '../../src/rules/no-output-on-prefix';
+import type { MessageIds } from '../../src/rules/no-output-on-prefix';
+import rule, { RULE_NAME } from '../../src/rules/no-output-on-prefix';
 
 //------------------------------------------------------------------------------
 // Tests

--- a/packages/eslint-plugin/tests/rules/no-output-rename.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-output-rename.test.ts
@@ -2,7 +2,8 @@ import {
   convertAnnotatedSourceToFailureCase,
   RuleTester,
 } from '@angular-eslint/utils';
-import rule, { MessageIds, RULE_NAME } from '../../src/rules/no-output-rename';
+import type { MessageIds } from '../../src/rules/no-output-rename';
+import rule, { RULE_NAME } from '../../src/rules/no-output-rename';
 
 //------------------------------------------------------------------------------
 // Tests

--- a/packages/eslint-plugin/tests/rules/no-outputs-metadata-property.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-outputs-metadata-property.test.ts
@@ -2,10 +2,8 @@ import {
   convertAnnotatedSourceToFailureCase,
   RuleTester,
 } from '@angular-eslint/utils';
-import rule, {
-  MessageIds,
-  RULE_NAME,
-} from '../../src/rules/no-outputs-metadata-property';
+import type { MessageIds } from '../../src/rules/no-outputs-metadata-property';
+import rule, { RULE_NAME } from '../../src/rules/no-outputs-metadata-property';
 
 //------------------------------------------------------------------------------
 // Tests

--- a/packages/eslint-plugin/tests/rules/no-pipe-impure.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-pipe-impure.test.ts
@@ -2,7 +2,8 @@ import {
   convertAnnotatedSourceToFailureCase,
   RuleTester,
 } from '@angular-eslint/utils';
-import rule, { MessageIds, RULE_NAME } from '../../src/rules/no-pipe-impure';
+import type { MessageIds } from '../../src/rules/no-pipe-impure';
+import rule, { RULE_NAME } from '../../src/rules/no-pipe-impure';
 
 //------------------------------------------------------------------------------
 // Tests

--- a/packages/eslint-plugin/tests/rules/no-queries-metadata-property.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-queries-metadata-property.test.ts
@@ -2,10 +2,8 @@ import {
   convertAnnotatedSourceToFailureCase,
   RuleTester,
 } from '@angular-eslint/utils';
-import rule, {
-  MessageIds,
-  RULE_NAME,
-} from '../../src/rules/no-queries-metadata-property';
+import type { MessageIds } from '../../src/rules/no-queries-metadata-property';
+import rule, { RULE_NAME } from '../../src/rules/no-queries-metadata-property';
 
 //------------------------------------------------------------------------------
 // Tests

--- a/packages/eslint-plugin/tests/rules/pipe-prefix.test.ts
+++ b/packages/eslint-plugin/tests/rules/pipe-prefix.test.ts
@@ -2,7 +2,8 @@ import {
   convertAnnotatedSourceToFailureCase,
   RuleTester,
 } from '@angular-eslint/utils';
-import rule, { MessageIds, RULE_NAME } from '../../src/rules/pipe-prefix';
+import type { MessageIds } from '../../src/rules/pipe-prefix';
+import rule, { RULE_NAME } from '../../src/rules/pipe-prefix';
 
 //------------------------------------------------------------------------------
 // Tests

--- a/packages/eslint-plugin/tests/rules/prefer-on-push-component-change-detection.test.ts
+++ b/packages/eslint-plugin/tests/rules/prefer-on-push-component-change-detection.test.ts
@@ -2,8 +2,8 @@ import {
   convertAnnotatedSourceToFailureCase,
   RuleTester,
 } from '@angular-eslint/utils';
+import type { MessageIds } from '../../src/rules/prefer-on-push-component-change-detection';
 import rule, {
-  MessageIds,
   RULE_NAME,
 } from '../../src/rules/prefer-on-push-component-change-detection';
 

--- a/packages/eslint-plugin/tests/rules/prefer-output-readonly.test.ts
+++ b/packages/eslint-plugin/tests/rules/prefer-output-readonly.test.ts
@@ -2,10 +2,8 @@ import {
   convertAnnotatedSourceToFailureCase,
   RuleTester,
 } from '@angular-eslint/utils';
-import rule, {
-  MessageIds,
-  RULE_NAME,
-} from '../../src/rules/prefer-output-readonly';
+import type { MessageIds } from '../../src/rules/prefer-output-readonly';
+import rule, { RULE_NAME } from '../../src/rules/prefer-output-readonly';
 
 //------------------------------------------------------------------------------
 // Tests

--- a/packages/eslint-plugin/tests/rules/relative-url-prefix.test.ts
+++ b/packages/eslint-plugin/tests/rules/relative-url-prefix.test.ts
@@ -2,10 +2,8 @@ import {
   convertAnnotatedSourceToFailureCase,
   RuleTester,
 } from '@angular-eslint/utils';
-import rule, {
-  MessageIds,
-  RULE_NAME,
-} from '../../src/rules/relative-url-prefix';
+import type { MessageIds } from '../../src/rules/relative-url-prefix';
+import rule, { RULE_NAME } from '../../src/rules/relative-url-prefix';
 
 //------------------------------------------------------------------------------
 // Tests

--- a/packages/eslint-plugin/tests/rules/sort-ngmodule-metadata-arrays.test.ts
+++ b/packages/eslint-plugin/tests/rules/sort-ngmodule-metadata-arrays.test.ts
@@ -2,10 +2,8 @@ import {
   convertAnnotatedSourceToFailureCase,
   RuleTester,
 } from '@angular-eslint/utils';
-import rule, {
-  MessageIds,
-  RULE_NAME,
-} from '../../src/rules/sort-ngmodule-metadata-arrays';
+import type { MessageIds } from '../../src/rules/sort-ngmodule-metadata-arrays';
+import rule, { RULE_NAME } from '../../src/rules/sort-ngmodule-metadata-arrays';
 
 //------------------------------------------------------------------------------
 // Tests

--- a/packages/eslint-plugin/tests/rules/use-component-selector.test.ts
+++ b/packages/eslint-plugin/tests/rules/use-component-selector.test.ts
@@ -2,10 +2,8 @@ import {
   convertAnnotatedSourceToFailureCase,
   RuleTester,
 } from '@angular-eslint/utils';
-import rule, {
-  MessageIds,
-  RULE_NAME,
-} from '../../src/rules/use-component-selector';
+import type { MessageIds } from '../../src/rules/use-component-selector';
+import rule, { RULE_NAME } from '../../src/rules/use-component-selector';
 
 //------------------------------------------------------------------------------
 // Tests

--- a/packages/eslint-plugin/tests/rules/use-component-view-encapsulation.test.ts
+++ b/packages/eslint-plugin/tests/rules/use-component-view-encapsulation.test.ts
@@ -2,8 +2,8 @@ import {
   convertAnnotatedSourceToFailureCase,
   RuleTester,
 } from '@angular-eslint/utils';
+import type { MessageIds } from '../../src/rules/use-component-view-encapsulation';
 import rule, {
-  MessageIds,
   RULE_NAME,
 } from '../../src/rules/use-component-view-encapsulation';
 

--- a/packages/eslint-plugin/tests/rules/use-injectable-provided-in.test.ts
+++ b/packages/eslint-plugin/tests/rules/use-injectable-provided-in.test.ts
@@ -2,10 +2,8 @@ import {
   convertAnnotatedSourceToFailureCase,
   RuleTester,
 } from '@angular-eslint/utils';
-import rule, {
-  MessageIds,
-  RULE_NAME,
-} from '../../src/rules/use-injectable-provided-in';
+import type { MessageIds } from '../../src/rules/use-injectable-provided-in';
+import rule, { RULE_NAME } from '../../src/rules/use-injectable-provided-in';
 
 //------------------------------------------------------------------------------
 // Tests

--- a/packages/eslint-plugin/tests/rules/use-lifecycle-interface.test.ts
+++ b/packages/eslint-plugin/tests/rules/use-lifecycle-interface.test.ts
@@ -2,10 +2,8 @@ import {
   convertAnnotatedSourceToFailureCase,
   RuleTester,
 } from '@angular-eslint/utils';
-import rule, {
-  MessageIds,
-  RULE_NAME,
-} from '../../src/rules/use-lifecycle-interface';
+import type { MessageIds } from '../../src/rules/use-lifecycle-interface';
+import rule, { RULE_NAME } from '../../src/rules/use-lifecycle-interface';
 import {
   AngularLifecycleInterfaces,
   AngularLifecycleMethods,

--- a/packages/eslint-plugin/tests/rules/use-pipe-transform-interface.test.ts
+++ b/packages/eslint-plugin/tests/rules/use-pipe-transform-interface.test.ts
@@ -2,10 +2,8 @@ import {
   convertAnnotatedSourceToFailureCase,
   RuleTester,
 } from '@angular-eslint/utils';
-import rule, {
-  MessageIds,
-  RULE_NAME,
-} from '../../src/rules/use-pipe-transform-interface';
+import type { MessageIds } from '../../src/rules/use-pipe-transform-interface';
+import rule, { RULE_NAME } from '../../src/rules/use-pipe-transform-interface';
 
 //------------------------------------------------------------------------------
 // Tests

--- a/packages/integration-tests/integration-tests-setup.ts
+++ b/packages/integration-tests/integration-tests-setup.ts
@@ -1,5 +1,6 @@
 import execa from 'execa';
-import { ChildProcess, spawn } from 'child_process';
+import type { ChildProcess } from 'child_process';
+import { spawn } from 'child_process';
 import kill from 'tree-kill';
 
 let localRegistryProcess: ChildProcess;

--- a/packages/schematics/src/application/index.ts
+++ b/packages/schematics/src/application/index.ts
@@ -1,10 +1,5 @@
-import {
-  chain,
-  externalSchematic,
-  Rule,
-  SchematicContext,
-  Tree,
-} from '@angular-devkit/schematics';
+import type { Rule, SchematicContext, Tree } from '@angular-devkit/schematics';
+import { chain, externalSchematic } from '@angular-devkit/schematics';
 /**
  * We are able to use the full, unaltered Schema directly from @schematics/angular
  * The applicable json file is copied from node_modules as a prebuiid step to ensure

--- a/packages/schematics/src/convert-tslint-to-eslint/convert-to-eslint-config.ts
+++ b/packages/schematics/src/convert-tslint-to-eslint/convert-to-eslint-config.ts
@@ -1,9 +1,9 @@
 import type { Linter as ESLintLinter } from 'eslint';
+import type { TSLintRuleOptions } from 'tslint-to-eslint-config';
 import {
   createESLintConfiguration,
   findReportedConfiguration,
   joinConfigConversionResults,
-  TSLintRuleOptions,
 } from 'tslint-to-eslint-config';
 
 export async function convertToESLintConfig(

--- a/packages/schematics/src/convert-tslint-to-eslint/index.ts
+++ b/packages/schematics/src/convert-tslint-to-eslint/index.ts
@@ -1,11 +1,6 @@
 import { join, normalize } from '@angular-devkit/core';
-import {
-  chain,
-  noop,
-  Rule,
-  SchematicContext,
-  Tree,
-} from '@angular-devkit/schematics';
+import type { Rule, SchematicContext, Tree } from '@angular-devkit/schematics';
+import { chain, noop } from '@angular-devkit/schematics';
 import eslintPlugin from '@angular-eslint/eslint-plugin';
 import eslintPluginTemplate from '@angular-eslint/eslint-plugin-template';
 import type { Linter } from 'eslint';
@@ -21,7 +16,7 @@ import {
   updateJsonInTree,
 } from '../utils';
 import { convertToESLintConfig } from './convert-to-eslint-config';
-import { Schema } from './schema';
+import type { Schema } from './schema';
 import {
   ensureESLintPluginsAreInstalled,
   updateArrPropAndRemoveDuplication,

--- a/packages/schematics/src/convert-tslint-to-eslint/utils.ts
+++ b/packages/schematics/src/convert-tslint-to-eslint/utils.ts
@@ -1,4 +1,4 @@
-import { Rule, SchematicContext, Tree } from '@angular-devkit/schematics';
+import type { Rule, SchematicContext, Tree } from '@angular-devkit/schematics';
 import { NodePackageInstallTask } from '@angular-devkit/schematics/tasks';
 import * as assert from 'assert';
 

--- a/packages/schematics/src/library/index.ts
+++ b/packages/schematics/src/library/index.ts
@@ -1,10 +1,5 @@
-import {
-  chain,
-  externalSchematic,
-  Rule,
-  SchematicContext,
-  Tree,
-} from '@angular-devkit/schematics';
+import type { Rule, SchematicContext, Tree } from '@angular-devkit/schematics';
+import { chain, externalSchematic } from '@angular-devkit/schematics';
 /**
  * We are able to use the full, unaltered Schema directly from @schematics/angular
  * The applicable json file is copied from node_modules as a prebuiid step to ensure

--- a/packages/schematics/src/migrations/update-2-0-0/update-2-0-0.ts
+++ b/packages/schematics/src/migrations/update-2-0-0/update-2-0-0.ts
@@ -1,4 +1,5 @@
-import { chain, SchematicContext, Tree } from '@angular-devkit/schematics';
+import type { SchematicContext, Tree } from '@angular-devkit/schematics';
+import { chain } from '@angular-devkit/schematics';
 import { NodePackageInstallTask } from '@angular-devkit/schematics/tasks';
 import type { Linter } from 'eslint';
 import {

--- a/packages/schematics/src/ng-add/index.ts
+++ b/packages/schematics/src/ng-add/index.ts
@@ -1,9 +1,5 @@
-import {
-  chain,
-  Rule,
-  SchematicContext,
-  Tree,
-} from '@angular-devkit/schematics';
+import type { Rule, SchematicContext, Tree } from '@angular-devkit/schematics';
+import { chain } from '@angular-devkit/schematics';
 import { NodePackageInstallTask } from '@angular-devkit/schematics/tasks';
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires

--- a/packages/schematics/src/utils.ts
+++ b/packages/schematics/src/utils.ts
@@ -4,8 +4,9 @@
  *
  * Thanks, Nrwl folks!
  */
-import { join, normalize, Path } from '@angular-devkit/core';
-import { Rule, SchematicContext, Tree } from '@angular-devkit/schematics';
+import type { Path } from '@angular-devkit/core';
+import { join, normalize } from '@angular-devkit/core';
+import type { Rule, SchematicContext, Tree } from '@angular-devkit/schematics';
 import stripJsonComments from 'strip-json-comments';
 
 /**

--- a/packages/schematics/src/workspace-post/index.ts
+++ b/packages/schematics/src/workspace-post/index.ts
@@ -1,10 +1,6 @@
 import { join, normalize } from '@angular-devkit/core';
-import {
-  chain,
-  Rule,
-  SchematicContext,
-  Tree,
-} from '@angular-devkit/schematics';
+import type { Rule, SchematicContext, Tree } from '@angular-devkit/schematics';
+import { chain } from '@angular-devkit/schematics';
 import { NodePackageInstallTask } from '@angular-devkit/schematics/tasks';
 import {
   createRootESLintConfigFile,

--- a/packages/schematics/src/workspace/index.ts
+++ b/packages/schematics/src/workspace/index.ts
@@ -1,10 +1,8 @@
+import type { Rule, SchematicContext, Tree } from '@angular-devkit/schematics';
 import {
   chain,
   externalSchematic,
-  Rule,
   schematic,
-  SchematicContext,
-  Tree,
 } from '@angular-devkit/schematics';
 import { RunSchematicTask } from '@angular-devkit/schematics/tasks';
 /**

--- a/packages/schematics/tests/convert-tslint-to-eslint/index.test.ts
+++ b/packages/schematics/tests/convert-tslint-to-eslint/index.test.ts
@@ -4,7 +4,7 @@ import {
   UnitTestTree,
 } from '@angular-devkit/schematics/testing';
 import * as path from 'path';
-import { Schema } from '../../src/convert-tslint-to-eslint/schema';
+import type { Schema } from '../../src/convert-tslint-to-eslint/schema';
 import { exampleRootTslintJson } from './example-tslint-configs';
 import { readJsonInTree } from '../../src/utils';
 

--- a/packages/template-parser/src/convert-source-span-to-loc.ts
+++ b/packages/template-parser/src/convert-source-span-to-loc.ts
@@ -1,11 +1,7 @@
-import {
-  Node,
-  Element,
-  HtmlParser,
-  getHtmlTagDefinition,
-} from '@angular/compiler';
-import { ParseSourceSpan } from '@angular/compiler';
-import { TSESLint, TSESTree } from '@typescript-eslint/experimental-utils';
+import type { Node } from '@angular/compiler';
+import { Element, HtmlParser, getHtmlTagDefinition } from '@angular/compiler';
+import type { ParseSourceSpan } from '@angular/compiler';
+import type { TSESLint, TSESTree } from '@typescript-eslint/experimental-utils';
 
 type Context<TMessageIds extends string> = TSESLint.RuleContext<
   TMessageIds,

--- a/packages/template-parser/src/index.ts
+++ b/packages/template-parser/src/index.ts
@@ -1,4 +1,5 @@
-import { ParseSourceSpan, parseTemplate } from '@angular/compiler';
+import type { ParseSourceSpan } from '@angular/compiler';
+import { parseTemplate } from '@angular/compiler';
 import type { Comment } from '@angular/compiler/src/render3/r3_ast';
 import { Scope, ScopeManager } from 'eslint-scope';
 import {

--- a/packages/utils/src/test-helpers.ts
+++ b/packages/utils/src/test-helpers.ts
@@ -1,4 +1,4 @@
-import { TSESLint } from '@typescript-eslint/experimental-utils';
+import type { TSESLint } from '@typescript-eslint/experimental-utils';
 
 /**
  * FROM CODELYZER

--- a/tools/scripts/generate-configs.ts
+++ b/tools/scripts/generate-configs.ts
@@ -1,4 +1,4 @@
-import { TSESLint } from '@typescript-eslint/experimental-utils';
+import type { TSESLint } from '@typescript-eslint/experimental-utils';
 import chalk from 'chalk';
 import fs from 'fs';
 import path from 'path';

--- a/tools/utils/generate-rules-list.ts
+++ b/tools/utils/generate-rules-list.ts
@@ -7,7 +7,7 @@ import {
   getAngularESLintPRs,
   getCodelyzerRulesList,
 } from './github-api-helpers';
-import { CodelyzerRule, PRDetails } from './interfaces';
+import type { CodelyzerRule, PRDetails } from './interfaces';
 
 /**
  * Represents status details for an ESLint Rule.

--- a/tools/utils/github-api-helpers.ts
+++ b/tools/utils/github-api-helpers.ts
@@ -1,5 +1,6 @@
-import https, { RequestOptions } from 'https';
-import { CodelyzerRule, PRDetails } from './interfaces';
+import type { RequestOptions } from 'https';
+import https from 'https';
+import type { CodelyzerRule, PRDetails } from './interfaces';
 
 /**
  * Calls the github api for the specified path and returns a Promise for the json response.


### PR DESCRIPTION
Given some comments like https://github.com/angular-eslint/angular-eslint/pull/390#discussion_r607592984 and https://github.com/angular-eslint/angular-eslint/pull/386#discussion_r607589136, I'm submitting this PR that enables the rule [`@typescript-eslint/consistent-type-imports`](https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/consistent-type-imports.md) to report and fix these imports automatically for us.