### PR TITLE
fix(eslint-plugin-template): accessibility-elements-content not allowing some attributes/inputs

### DIFF
--- a/packages/eslint-plugin-template/src/utils/is-hidden-from-screen-reader.ts
+++ b/packages/eslint-plugin-template/src/utils/is-hidden-from-screen-reader.ts
@@ -1,22 +1,23 @@
+import type { TmplAstElement } from '@angular/compiler';
 import { PROPERTY } from './constants';
-import { getLiteralValue } from './get-literal-value';
 import { getAttributeValue } from './get-attribute-value';
+import { getLiteralValue } from './get-literal-value';
 
 /**
- * Returns boolean indicating that the aria-hidden prop
- * is present or the value is true. Will also return true if
- * there is an input with type='hidden'.
- *
- * <div aria-hidden /> is equivalent to the DOM as <div aria-hidden=true />.
+ * Whether an element has the `aria-hidden` property and its value is empty or
+ * `true`. It also returns `true` if the element is an `input` with `type="hidden"`.
  */
-export function isHiddenFromScreenReader(node: any): boolean {
+export function isHiddenFromScreenReader(node: TmplAstElement): boolean {
   if (node.name.toUpperCase() === 'INPUT') {
-    const hidden = getAttributeValue(node, 'type');
-    if (typeof hidden === 'string' && hidden.toUpperCase() === 'HIDDEN') {
+    const typeAttributeValue = getAttributeValue(node, 'type');
+    if (
+      typeof typeAttributeValue === 'string' &&
+      typeAttributeValue.toUpperCase() === 'HIDDEN'
+    ) {
       return true;
     }
   }
 
   const ariaHidden = getLiteralValue(getAttributeValue(node, 'aria-hidden'));
-  return ariaHidden === PROPERTY || ariaHidden === true;
+  return ariaHidden === '' || ariaHidden === PROPERTY || ariaHidden === true;
 }

--- a/packages/eslint-plugin-template/tests/rules/accessibility-elements-content.test.ts
+++ b/packages/eslint-plugin-template/tests/rules/accessibility-elements-content.test.ts
@@ -27,31 +27,39 @@ ruleTester.run(RULE_NAME, rule, {
     '<a><app-content></app-content></a>',
     '<a [innerHTML]="dangerouslySetHTML"></a>',
     '<a [innerText]="text"></a>',
+    '<a [outerHTML]="text"></a>',
+    '<a aria-hidden></a>',
+    '<button [attr.aria-hidden]="true"></button>',
+    '<h5 [attr.aria-label]="text"></h5>',
+    '<h6 title="text"></h6>',
   ],
   invalid: [
     convertAnnotatedSourceToFailureCase({
-      messageId,
       description: 'should fail with no content in heading tag',
       annotatedSource: `
         <h1 class="size-1"></h1>
         ~~~~~~~~~~~~~~~~~~~~~~~~
       `,
+      messageId,
+      data: { element: 'h1' },
     }),
     convertAnnotatedSourceToFailureCase({
-      messageId,
       description: 'should fail with no content in anchor tag',
       annotatedSource: `
         <a href="#" [routerLink]="['route1']"></a>
         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
       `,
+      messageId,
+      data: { element: 'a' },
     }),
     convertAnnotatedSourceToFailureCase({
-      messageId,
       description: 'should fail with no content in button tag',
       annotatedSource: `
         <button></button>
         ~~~~~~~~~~~~~~~~~
       `,
+      messageId,
+      data: { element: 'button' },
     }),
   ],
 });

--- a/packages/eslint-plugin-template/tests/rules/click-events-have-key-events.test.ts
+++ b/packages/eslint-plugin-template/tests/rules/click-events-have-key-events.test.ts
@@ -34,6 +34,7 @@ ruleTester.run(RULE_NAME, rule, {
     {
       // It should work when element has aria-hidden.
       code: `
+        <div (click)="onClick()" aria-hidden"></div>
         <div (click)="onClick()" aria-hidden="true"></div>
         <div (click)="onClick()" [attr.aria-hidden]="true"></div>
         <div (click)="onClick()" [attr.aria-hidden]="ariaHidden"></div>


### PR DESCRIPTION
**1st. commit**: with this `isHiddenFromScreenReader` now returns `true` for empty `aria-hidden`, e.g.: `<div aria-hidden></div>`;
**2nd. commit**: with this `accessibility-elements-content` now ignores elements when the attributes `aria-hidden`, `aria-label`, `outerHTML` and `title` are present.

Btw, part of this fix was reported in https://github.com/mgechev/codelyzer/issues/993.

It's also related to https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/issues/423 and its proposed fix https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/pull/727