### PR TITLE
refactor(eslint-plugin-template): no-negated-async no longer perform equality checks

### DIFF
--- a/packages/eslint-plugin-template/src/rules/no-negated-async.ts
+++ b/packages/eslint-plugin-template/src/rules/no-negated-async.ts
@@ -1,11 +1,11 @@
-import type { Binary, PrefixNot } from '@angular/compiler';
+import type { BindingPipe } from '@angular/compiler';
 import {
   createESLintRule,
   ensureTemplateParser,
 } from '../utils/create-eslint-rule';
 
 type Options = [];
-export type MessageIds = 'noNegatedAsync' | 'noLooseEquality';
+export type MessageIds = 'noNegatedAsync';
 export const RULE_NAME = 'no-negated-async';
 
 export default createESLintRule<Options, MessageIds>({
@@ -13,17 +13,14 @@ export default createESLintRule<Options, MessageIds>({
   meta: {
     type: 'suggestion',
     docs: {
-      description:
-        'Ensures that strict equality is used when evaluating negations on async pipe output',
+      description: 'Ensures that async pipe results are not negated',
       category: 'Best Practices',
       recommended: 'error',
     },
     schema: [],
     messages: {
       noNegatedAsync:
-        'Async pipes should not be negated. Use (observable | async) === (false || null || undefined) to check its value instead',
-      noLooseEquality:
-        'Async pipes must use strict equality `===` when comparing with `false`',
+        'Async pipe results should not be negated. Use (observable | async) === (false || null || undefined) to check its value instead',
     },
   },
   defaultOptions: [],
@@ -32,25 +29,16 @@ export default createESLintRule<Options, MessageIds>({
     const sourceCode = context.getSourceCode();
 
     return {
-      'PrefixNot > BindingPipe[name=async]'({ parent }: { parent: PrefixNot }) {
+      'PrefixNot > BindingPipe[name="async"]'({
+        parent: { sourceSpan },
+      }: {
+        parent: BindingPipe;
+      }) {
         context.report({
           messageId: 'noNegatedAsync',
           loc: {
-            start: sourceCode.getLocFromIndex(parent.sourceSpan.start),
-            end: sourceCode.getLocFromIndex(parent.sourceSpan.end),
-          },
-        });
-      },
-      'Binary[operation="=="] > BindingPipe[name=async]'({
-        parent,
-      }: {
-        parent: Binary;
-      }) {
-        context.report({
-          messageId: 'noLooseEquality',
-          loc: {
-            start: sourceCode.getLocFromIndex(parent.sourceSpan.start),
-            end: sourceCode.getLocFromIndex(parent.sourceSpan.end),
+            start: sourceCode.getLocFromIndex(sourceSpan.start),
+            end: sourceCode.getLocFromIndex(sourceSpan.end),
           },
         });
       },

--- a/packages/eslint-plugin-template/tests/rules/no-negated-async.test.ts
+++ b/packages/eslint-plugin-template/tests/rules/no-negated-async.test.ts
@@ -12,28 +12,20 @@ import rule, { RULE_NAME } from '../../src/rules/no-negated-async';
 const ruleTester = new RuleTester({
   parser: '@angular-eslint/template-parser',
 });
-
-const noLooseEquality: MessageIds = 'noLooseEquality';
-const noNegatedAsync: MessageIds = 'noNegatedAsync';
+const messageId: MessageIds = 'noNegatedAsync';
 
 ruleTester.run(RULE_NAME, rule, {
   valid: [
     // it should succeed if async pipe is not negated
-    `
-      {{ (foo | async) }}
-    `,
+    `{{ (foo | async) }}`,
     // it should succeed if async pipe is not the last pipe in the negated chain
-    `
-      {{ !(foo | async | somethingElse) }}
-    `,
+    `{{ !(foo | async | somethingElse) }}`,
+    // it should succeed if async pipe uses loose equality
+    `{{ (foo | async) == null }}`,
     // it should succeed if async pipe uses strict equality
-    `
-      {{ (foo | async) === false }}
-    `,
+    `{{ (foo | async) === false }}`,
     // it should succeed if any other pipe is negated
-    `
-      {{ !(foo | notAnAsyncPipe) }}
-    `,
+    `{{ !(foo | notAnAsyncPipe) }}`,
   ],
   invalid: [
     convertAnnotatedSourceToFailureCase({
@@ -46,28 +38,16 @@ ruleTester.run(RULE_NAME, rule, {
         {{      !(foo | async) }}
                 ~~~~~~~~~~~~~~
       `,
-      messageId: noNegatedAsync,
+      messageId,
     }),
     convertAnnotatedSourceToFailureCase({
       description:
         'it should fail if async pipe is the last pipe in the negated chain',
       annotatedSource: `
-          {{ !(foo | somethingElse | async) }}
-             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+        {{ !(foo | somethingElse | async) }}
+           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
       `,
-      messageId: noNegatedAsync,
-    }),
-    convertAnnotatedSourceToFailureCase({
-      description: 'it should fail if the async pipe uses loose equality',
-      /**
-       * Deliberately including some leading whitespace within the binding to assert
-       * location correctness
-       */
-      annotatedSource: `
-        {{    (foo | async) == false }}
-              ~~~~~~~~~~~~~~~~~~~~~~
-      `,
-      messageId: noLooseEquality,
+      messageId,
     }),
     convertAnnotatedSourceToFailureCase({
       description: 'it should fail if async pipe is negated using *ngIf',
@@ -75,30 +55,7 @@ ruleTester.run(RULE_NAME, rule, {
         <div *ngIf="!(a | async)"></div>
                     ~~~~~~~~~~~~
       `,
-      messageId: noNegatedAsync,
-    }),
-    convertAnnotatedSourceToFailureCase({
-      description:
-        'it should fail for multiple negated/loose equality async pipes',
-      annotatedSource: `
-        <div *ngFor="let elem of [1, 2, 3]; trackBy: trackByFn">
-          {{ elem }}
-        </div>
-        <div *ngIf="!(foo | async)">
-                    ~~~~~~~~~~~~~~
-          {{ (foo | async) == false }}
-             ^^^^^^^^^^^^^^^^^^^^^^
-          <div *ngIf="(foo | async) == false">
-                      ######################
-            works!
-          </div>
-        </div>
-      `,
-      messages: [
-        { char: '~', messageId: noNegatedAsync },
-        { char: '^', messageId: noLooseEquality },
-        { char: '#', messageId: noLooseEquality },
-      ],
+      messageId,
     }),
   ],
 });


### PR DESCRIPTION
BREAKING CHANGE.

Currently it's a proposal. If it gets approved, we could implement a rule to perform equality checks.

Fixes #315.