### PR TITLE
fix(builder): expose maxWarnings option

### DIFF
--- a/packages/builder/src/schema.json
+++ b/packages/builder/src/schema.json
@@ -33,7 +33,7 @@
       "default": false
     },
     "maxWarnings": {
-      "type": "integer",
+      "type": "number",
       "description": "Number of warnings to trigger nonzero exit code.",
       "default": -1
     },


### PR DESCRIPTION
Currently (v2.0.2), when running `ng lint --max-warnings=0`, the CLI throws

    Unknown option: '--max-warnings'

It turns out the `schema.json` file declares `maxWarnings` as an `integer` instead of a `number` as the CLI expects.

See https://github.com/angular/angular-cli/blob/645353db26e9d6e8f893322a52b320ccd5ca1d5d/packages/angular_devkit/build_angular/src/browser/schema.json#L258 for example

After this fix, the option is usable.