### PR TITLE
fix(eslint-plugin): `sort-ngmodule-metadata-arrays` reporting false positives

### DIFF
--- a/packages/eslint-plugin/src/rules/sort-ngmodule-metadata-arrays.ts
+++ b/packages/eslint-plugin/src/rules/sort-ngmodule-metadata-arrays.ts
@@ -53,10 +53,12 @@ export default createESLintRule<Options, MessageIds>({
           }
           const unorderedNode = initializer.elements
             .filter(isIdentifier)
-            .find(
-              ({ name }, index, list) =>
-                name.localeCompare(list[index + 1]?.name) === 1,
-            );
+            .find(({ name }, index, list) => {
+              const nextElementName = list[index + 1]?.name;
+              return (
+                nextElementName && name.localeCompare(nextElementName) === 1
+              );
+            });
           if (!unorderedNode) return;
           context.report({
             messageId: 'sortNgmoduleMetadataArrays',

--- a/packages/eslint-plugin/tests/rules/sort-ngmodule-metadata-arrays.test.ts
+++ b/packages/eslint-plugin/tests/rules/sort-ngmodule-metadata-arrays.test.ts
@@ -14,47 +14,44 @@ import rule, {
 const ruleTester = new RuleTester({
   parser: '@typescript-eslint/parser',
 });
-
-const messageIdSortFailure: MessageIds = 'sortNgmoduleMetadataArrays';
+const messageId: MessageIds = 'sortNgmoduleMetadataArrays';
 
 ruleTester.run(RULE_NAME, rule, {
   valid: [
-    {
-      code: `
-      @NgModule({
-        imports: [
-          _foo,
-          AModule,
-          bModule,
-          cModule,
-          DModule,
-        ],
-        bootstrap: [
-          AppModule1,
-          AppModule2,
-          AppModule3,
-        ],
-        declarations: [
-          AComponent,
-          bDirective,
-          cPipe,
-          DComponent,
-          VariableComponent,
-        ],
-        providers: [
-          AProvider,
-          {
-            provide: 'myprovider',
-            useClass: MyProvider,
-          },
-          bProvider,
-          cProvider,
-          DProvider,
-        ],
-      })
-      class Test {}
-      `,
-    },
+    `
+    @NgModule({
+      bootstrap: [
+        AppModule1,
+        AppModule2,
+        AppModule3,
+      ],
+      declarations: [
+        AComponent,
+        bDirective,
+        cPipe,
+        DComponent,
+        VariableComponent,
+      ],
+      imports: [
+        _foo,
+        AModule,
+        bModule,
+        cModule,
+        DModule,
+      ],
+      providers: [
+        AProvider,
+        {
+          provide: 'myprovider',
+          useClass: MyProvider,
+        },
+        bProvider,
+        cProvider,
+        DProvider,
+      ],
+    })
+    class Test {}
+    `,
   ],
   invalid: [
     convertAnnotatedSourceToFailureCase({
@@ -71,7 +68,7 @@ ruleTester.run(RULE_NAME, rule, {
       })
       class Test {}
       `,
-      messageId: messageIdSortFailure,
+      messageId,
     }),
     convertAnnotatedSourceToFailureCase({
       description: 'it should fail if declarations array is not sorted ASC',
@@ -82,12 +79,12 @@ ruleTester.run(RULE_NAME, rule, {
           cPipe,
           ~~~~~
           bDirective,
-          DComponent
+          DComponent,
         ],
       })
       class Test {}
       `,
-      messageId: messageIdSortFailure,
+      messageId,
     }),
     convertAnnotatedSourceToFailureCase({
       description: 'it should fail if exports array is not sorted ASC',
@@ -98,12 +95,12 @@ ruleTester.run(RULE_NAME, rule, {
           cPipe,
           ~~~~~
           bDirective,
-          DComponent
+          DComponent,
         ],
       })
       class Test {}
       `,
-      messageId: messageIdSortFailure,
+      messageId,
     }),
     convertAnnotatedSourceToFailureCase({
       description: 'it should fail if bootstrap array is not sorted ASC',
@@ -118,7 +115,7 @@ ruleTester.run(RULE_NAME, rule, {
       })
       class Test {}
       `,
-      messageId: messageIdSortFailure,
+      messageId,
     }),
     convertAnnotatedSourceToFailureCase({
       description: 'it should fail if schemas array is not sorted ASC',
@@ -133,7 +130,7 @@ ruleTester.run(RULE_NAME, rule, {
       })
       class Test {}
       `,
-      messageId: messageIdSortFailure,
+      messageId,
     }),
     convertAnnotatedSourceToFailureCase({
       description:
@@ -154,7 +151,7 @@ ruleTester.run(RULE_NAME, rule, {
       })
       class Test {}
       `,
-      messageId: messageIdSortFailure,
+      messageId,
     }),
   ],
 });

--- a/packages/eslint-plugin/tests/rules/sort-ngmodule-metadata-arrays.test.ts
+++ b/packages/eslint-plugin/tests/rules/sort-ngmodule-metadata-arrays.test.ts
@@ -38,7 +38,8 @@ ruleTester.run(RULE_NAME, rule, {
           AComponent,
           bDirective,
           cPipe,
-          DComponent
+          DComponent,
+          VariableComponent,
         ],
         providers: [
           AProvider,


### PR DESCRIPTION
The problem is that `undefined` is not treated properly and thus some values are flagged incorrectly.

Fixes #407.