### PR TITLE
refactor(eslint-plugin-template): [i18n] refactor to improve readability and maintainability

### DIFF
--- a/packages/eslint-plugin-template/src/rules/i18n.ts
+++ b/packages/eslint-plugin-template/src/rules/i18n.ts
@@ -1,66 +1,73 @@
+import type { AST } from '@angular/compiler';
+import {
+  ASTWithSource,
+  Interpolation,
+  TmplAstBoundText,
+  TmplAstElement,
+  TmplAstTemplate,
+  TmplAstText,
+} from '@angular/compiler';
+import type {
+  Message,
+  Node as I18nNode,
+} from '@angular/compiler/src/i18n/i18n_ast';
+import type { Node } from '@angular/compiler/src/render3/r3_ast';
 import {
   createESLintRule,
   getTemplateParserServices,
 } from '../utils/create-eslint-rule';
 
-const TEXT_TYPE_NAMES = ['Text', 'Icu'];
-const ATTRIB_I18N = 'i18n';
-const DEFAULT_IGNORE_ATTRIBUTES = [
+const DEFAULT_BOUND_TEXT_ALLOWED_PATTERN = /[a-z]/i;
+const SAFELIST_ATTRIBUTES: ReadonlySet<string> = new Set([
+  'charset',
   'class',
-  'style',
   'color',
-  'svgIcon',
+  'colspan',
+  'fill',
+  'formControlName',
+  'height',
   'href',
-  'src',
   'id',
   'lang',
-  'charset',
-  'height',
-  'width',
+  'src',
+  'stroke',
+  'stroke-width',
+  'style',
+  'svgIcon',
+  'tabindex',
   'target',
   'type',
-  'colspan',
-  'uiSref',
-  'uiSrefActive',
-  'ui-view',
-  'xmlns',
-  'stroke-width',
-  'stroke',
-  'fill',
   'viewBox',
-  'tabindex',
-  'formControlName',
-];
-const DEFAULT_IGNORE_TAGS: string[] = [];
-const DEFAULT_BOUND_TEXT_ALLOWED_PATTERN = /[A-Z]/i;
+  'width',
+  'xmlns',
+]);
 
 type Options = [
   {
-    checkId?: boolean;
-    checkText?: boolean;
-    checkAttributes?: boolean;
-    ignoreAttributes?: string[];
-    ignoreTags?: string[];
-    boundTextAllowedPattern?: string;
+    readonly boundTextAllowedPattern?: string;
+    readonly checkId?: boolean;
+    readonly checkText?: boolean;
+    readonly checkAttributes?: boolean;
+    readonly ignoreAttributes?: readonly string[];
+    readonly ignoreTags?: readonly string[];
   },
 ];
-
-const defaultOptions = {
+export type MessageIds =
+  | 'i18nAttribute'
+  | 'i18nId'
+  | 'i18nIdOnAttribute'
+  | 'i18nSuggestIgnore'
+  | 'i18nText';
+export const RULE_NAME = 'i18n';
+const DEFAULT_OPTIONS: Options[0] = {
+  checkAttributes: true,
   checkId: true,
   checkText: true,
-  checkAttributes: true,
-  ignoreAttributes: [''],
-  ignoreTags: [],
-  boundTextAllowedPattern: '',
+  ignoreAttributes: [...SAFELIST_ATTRIBUTES],
 };
-
-export type MessageIds =
-  | 'i18nId'
-  | 'i18nText'
-  | 'i18nAttrib'
-  | 'i18nIdOnAttrib'
-  | 'i18nSuggestIgnore';
-export const RULE_NAME = 'i18n';
+const STYLE_GUIDE_LINK = 'https://angular.io/guide/i18n';
+const STYLE_GUIDE_I18N_ATTRIBUTE_LINK = `${STYLE_GUIDE_LINK}#translate-attributes`;
+const STYLE_GUIDE_I18N_ATTRIBUTE_ID_LINK = `${STYLE_GUIDE_LINK}#use-a-custom-id-with-a-description`;
 
 export default createESLintRule<Options, MessageIds>({
   name: RULE_NAME,
@@ -70,32 +77,37 @@ export default createESLintRule<Options, MessageIds>({
       description:
         'Helps to ensure following best practices for i18n. ' +
         'Checks for missing i18n attributes on elements and non-ignored attributes ' +
-        'containing text. Can also highlight tags that do not use Custom ID (@@) feature. ' +
-        'Default Config = ' +
-        JSON.stringify(defaultOptions),
+        'containing text. Can also highlight tags that do not use custom ID (@@) feature. ',
       category: 'Best Practices',
       recommended: false,
-      // url: '',  // Not sure why we are excluding this, it is in the docs at eslint
+      suggestion: true,
     },
     fixable: 'code',
     schema: [
       {
         type: 'object',
         properties: {
+          boundTextAllowedPattern: {
+            type: 'string',
+          },
           checkId: {
             type: 'boolean',
+            default: DEFAULT_OPTIONS.checkId,
           },
           checkText: {
             type: 'boolean',
+            default: DEFAULT_OPTIONS.checkText,
           },
           checkAttributes: {
             type: 'boolean',
+            default: DEFAULT_OPTIONS.checkAttributes,
           },
           ignoreAttributes: {
             type: 'array',
             items: {
               type: 'string',
             },
+            default: [...SAFELIST_ATTRIBUTES],
           },
           ignoreTags: {
             type: 'array',
@@ -103,165 +115,163 @@ export default createESLintRule<Options, MessageIds>({
               type: 'string',
             },
           },
-          boundTextAllowedPattern: {
-            type: 'string',
-          },
         },
         additionalProperties: false,
       },
     ],
     messages: {
-      i18nId:
-        'Missing custom message identifier. ' +
-        'For more information visit https://angular.io/guide/i18n#use-a-custom-id-with-a-description',
-      i18nIdOnAttrib:
-        "Missing custom message identifier on attribute '{{attribName}}'. " +
-        'For more information visit https://angular.io/guide/i18n#use-a-custom-id-with-a-description',
-      i18nText:
-        'Each element containing text node should have an i18n attribute. ' +
-        'See https://angular.io/guide/i18n',
-      i18nAttrib:
-        "Attribute '{{attribName}}' has no corresponding i18n attribute. " +
-        'See https://angular.io/guide/i18n#translate-attributes',
+      i18nAttribute: `Attribute '{{attributeName}}' has no corresponding i18n attribute. See more at ${STYLE_GUIDE_I18N_ATTRIBUTE_LINK}`,
+      i18nId: `Missing custom message identifier. See more at ${STYLE_GUIDE_I18N_ATTRIBUTE_ID_LINK}`,
+      i18nIdOnAttribute: `Missing custom message identifier on attribute "{{attributeName}}". See more at ${STYLE_GUIDE_I18N_ATTRIBUTE_ID_LINK}`,
       i18nSuggestIgnore:
-        "Add the attribute name '{{attribName}}' to the ignoreAttributes option in the eslint config.",
+        'Add the attribute name "{{attributeName}}" to the `ignoreAttributes` option in the eslint config',
+      i18nText: `Each element containing text node should have an i18n attribute. See more at ${STYLE_GUIDE_LINK}`,
     },
   },
-  defaultOptions: [defaultOptions],
-  create(context, [options]) {
+  defaultOptions: [DEFAULT_OPTIONS],
+  create(
+    context,
+    [
+      {
+        boundTextAllowedPattern,
+        checkAttributes,
+        checkId,
+        checkText,
+        ignoreAttributes,
+        ignoreTags,
+      },
+    ],
+  ) {
     const parserServices = getTemplateParserServices(context);
     const sourceCode = context.getSourceCode();
-    const {
-      checkId,
-      checkText,
-      checkAttributes,
-      ignoreAttributes,
-      ignoreTags,
-      boundTextAllowedPattern,
-    } = options;
-    const checkIgnoreTags =
-      ignoreTags && ignoreTags.length > 0 ? ignoreTags : DEFAULT_IGNORE_TAGS;
-    const checkBoundTextAllowedPattern = boundTextAllowedPattern
-      ? new RegExp(boundTextAllowedPattern)
-      : DEFAULT_BOUND_TEXT_ALLOWED_PATTERN;
+    const safeBoundTextAllowedPattern = RegExp(
+      boundTextAllowedPattern ?? DEFAULT_BOUND_TEXT_ALLOWED_PATTERN,
+    );
+    const safeAttributes: ReadonlySet<string> = new Set([
+      ...SAFELIST_ATTRIBUTES,
+      ...(ignoreAttributes ?? []),
+    ]);
+    const safeTags: ReadonlySet<string> = new Set(ignoreTags);
 
-    // build a big list of attributes to ignore
-    const allIgnoredAttribs: string[] = [...DEFAULT_IGNORE_ATTRIBUTES];
-    if (ignoreAttributes && ignoreAttributes.length > 0) {
-      allIgnoredAttribs.push(...ignoreAttributes);
+    function hasI18nCustomId(node: Message | I18nNode) {
+      return (node as Message).customId;
     }
 
-    function isSizeOrNumber(value: string) {
-      let temp = value;
-      if (temp.endsWith('px')) {
-        temp = temp.substr(0, temp.length - 2);
-      }
-      return String(Number(temp)) === String(temp);
+    function isValidIdNode(node: AST | undefined, i18n: Message | I18nNode) {
+      return !(
+        (node instanceof TmplAstElement || node instanceof TmplAstTemplate) &&
+        !node?.i18n &&
+        !hasI18nCustomId(i18n)
+      );
     }
 
-    function checkNode(node: any, name: string): void {
-      if (checkIgnoreTags.includes(node.name)) return;
-      const loc = parserServices.convertNodeSourceSpanToLoc(node.sourceSpan);
-      const startIndex = sourceCode.getIndexFromLoc(loc.start);
-      let insertIndex = startIndex + 1;
-      insertIndex += name.length;
-      // Check all of the text attributes on the element
-      node.attributes.forEach((attrib: any) => {
-        if (attrib.i18n) {
-          if (checkId && !attrib.i18n.customId) {
-            // i18n attribute does not contain '@@'
-            // see https://angular.io/guide/i18n#use-a-custom-id-with-a-description
-            context.report({
-              messageId: 'i18nIdOnAttrib',
-              loc,
-              data: {
-                attribName: attrib.name,
-              },
-            });
-          }
-        } else {
-          if (
-            checkAttributes &&
-            attrib.value &&
-            typeof attrib.value === 'string' &&
-            attrib.value.length > 0 &&
-            attrib.value !== 'true' &&
-            attrib.value !== 'false' &&
-            !isSizeOrNumber(attrib.value) &&
-            !attrib.name.startsWith(':xml') &&
-            !allIgnoredAttribs.includes(attrib.name) &&
-            !allIgnoredAttribs.includes(name + '[' + attrib.name + ']')
-          ) {
-            context.report({
-              messageId: 'i18nAttrib',
-              loc,
-              data: {
-                attribName: attrib.name,
-              },
-              fix: (fixer) =>
-                fixer.replaceTextRange(
-                  [insertIndex, insertIndex],
-                  ' ' + ATTRIB_I18N + '-' + attrib.name,
-                ),
-              suggest: [
-                {
-                  messageId: 'i18nSuggestIgnore',
-                  data: {
-                    attribName: attrib.name,
-                  },
-                  // Little bit of a hack,
-                  // but VS code ignores suggestions with no fix!?
-                  fix: (fixer) => fixer.insertTextBeforeRange([0, 0], ''),
-                },
-              ],
-            });
-          }
-        }
-      });
+    function isInvalidTextNode(node: Node) {
+      return (
+        (node instanceof TmplAstText && /\S/.test(node.value)) ||
+        (node instanceof TmplAstBoundText &&
+          node.value instanceof ASTWithSource &&
+          node.value.ast instanceof Interpolation &&
+          safeBoundTextAllowedPattern.test(
+            node.value.ast.strings.join('').trim(),
+          ))
+      );
+    }
 
-      if (node.i18n && !node.parent?.i18n) {
-        // if this element already has i18n
-        if (checkId) {
-          if (!node.i18n.customId) {
-            // i18n attribute does not contain '@@'
-            // see https://angular.io/guide/i18n#use-a-custom-id-with-a-description
+    function isSafeAttribute(
+      tagName: string,
+      attributeName: string,
+      attributeValue: string,
+    ) {
+      return (
+        safeAttributes.has(attributeName) ||
+        safeAttributes.has(`${tagName}[${attributeName}]`) ||
+        attributeValue.trim().length === 0 ||
+        attributeValue === 'true' ||
+        attributeValue === 'false'
+      );
+    }
+
+    function handleNode(
+      {
+        attributes,
+        children,
+        i18n,
+        parent,
+        sourceSpan,
+      }: (TmplAstElement | TmplAstTemplate) & { parent?: AST },
+      tagName: string,
+    ) {
+      const loc = parserServices.convertNodeSourceSpanToLoc(sourceSpan);
+
+      for (const {
+        i18n: attributeI18n,
+        name: attributeName,
+        value: attributeValue,
+      } of attributes) {
+        if (attributeI18n) {
+          if (checkId && !hasI18nCustomId(attributeI18n)) {
             context.report({
-              messageId: 'i18nId',
+              messageId: 'i18nIdOnAttribute',
               loc,
+              data: { attributeName },
             });
           }
+
+          continue;
         }
-      } else if (!node.i18n && checkText) {
-        // Attempted to check for child nodes that also include i18n
-        // however these throw a template parser error before the linter
-        // is allowed to run, so no need!
+
         if (
-          node.children.some(
-            (child: any) =>
-              // is type of text node AND does not only contain whitespace
-              (TEXT_TYPE_NAMES.includes(child.type) &&
-                /\S/.test(child.value)) ||
-              // bound text that has no text
-              (child.type === 'BoundText' &&
-                checkBoundTextAllowedPattern.test(
-                  child.value.ast.strings.join('').trim(),
-                )),
-          )
+          checkAttributes &&
+          isSafeAttribute(tagName, attributeName, attributeValue)
         ) {
+          continue;
+        }
+
+        context.report({
+          messageId: 'i18nAttribute',
+          loc,
+          data: { attributeName },
+          fix: (fixer) => {
+            const startIndex = sourceCode.getIndexFromLoc(loc.start);
+            const insertIndex = startIndex + 1 + tagName.length;
+            return fixer.replaceTextRange(
+              [insertIndex, insertIndex],
+              ` i18n-${attributeName}`,
+            );
+          },
+          suggest: [
+            {
+              messageId: 'i18nSuggestIgnore',
+              data: { attributeName },
+              // Little bit of a hack as VSCode ignores suggestions with no fix!?
+              fix: (fixer) => fixer.insertTextBeforeRange([0, 0], ''),
+            },
+          ],
+        });
+      }
+
+      if (i18n) {
+        if (checkId && !isValidIdNode(parent, i18n)) {
           context.report({
-            messageId: 'i18nText',
+            messageId: 'i18nId',
             loc,
           });
         }
+      } else if (checkText && children.some(isInvalidTextNode)) {
+        context.report({
+          messageId: 'i18nText',
+          loc,
+        });
       }
     }
 
     return {
-      Element(node: any) {
-        checkNode(node, node.name);
+      Element(node: TmplAstElement & { parent?: AST }) {
+        if (safeTags.has(node.name)) return;
+        handleNode(node, node.name);
       },
-      Template(node: any) {
-        checkNode(node, node.tagName);
+      Template(node: TmplAstTemplate & { parent?: AST }) {
+        handleNode(node, node.tagName);
       },
     };
   },

--- a/packages/eslint-plugin-template/tests/rules/i18n.test.ts
+++ b/packages/eslint-plugin-template/tests/rules/i18n.test.ts
@@ -12,97 +12,60 @@ import rule, { RULE_NAME } from '../../src/rules/i18n';
 const ruleTester = new RuleTester({
   parser: '@angular-eslint/template-parser',
 });
-
 const i18nId: MessageIds = 'i18nId';
 const i18nText: MessageIds = 'i18nText';
-const i18nAttrib: MessageIds = 'i18nAttrib';
-const i18nIdOnAttrib: MessageIds = 'i18nIdOnAttrib';
+const i18nAttribute: MessageIds = 'i18nAttribute';
+const i18nIdOnAttribute: MessageIds = 'i18nIdOnAttribute';
 
 ruleTester.run(RULE_NAME, rule, {
   valid: [
+    `
+      <div>
+        <span i18n="@@my-custom-id">Some text to translate</span>
+      </div>
+    `,
+    `
+      <div i18n-tooltip="@@my-custom-id" tooltip="This also requires translation">
+        <span i18n="@@my-custom-id">Some text to translate</span>
+      </div>
+    `,
+    `
+      <div>
+        <span class="red" i18n="@@my-custom-id">
+          Some text to translate
+        </span>
+      </div>
+    `,
     {
-      filename: 'test.component.html',
       code: `
-          <div>
-            <span i18n="@@my-custom-id">Some text to translate</span>
-          </div>`,
-    },
-    {
-      filename: 'test.component.html',
-      code: `
-        <div
-          i18n-tooltip="@@my-custom-id"
-          tooltip="This also requires translation"
-        >
-          <span i18n="@@my-custom-id">Some text to translate</span>
-        </div>`,
-    },
-    {
-      filename: 'test.component.html',
-      code: `
-          <div>
-            <span
-              class="red"
-              i18n="@@my-custom-id"
-            >
-              Some text to translate
-            </span>
-          </div>`,
-    },
-    {
-      filename: 'test.component.html',
-      code: `
-        <div
-          tooltip="This tooltip property is ignored"
-        >
+        <div tooltip="This tooltip property is ignored">
           <span i18n>Some text to translate</span>
-        </div>`,
-      options: [
-        {
-          ignoreAttributes: ['tooltip'],
-          checkId: false,
-        },
-      ],
+        </div>
+      `,
+      options: [{ checkId: false, ignoreAttributes: ['tooltip'] }],
     },
     {
-      filename: 'test.component.html',
       code: `
-        <div
-          i18n-tooltip="@@tooltip.label"
-          tooltip="This tooltip property is ignored"
-        >
+        <div i18n-tooltip="@@tooltip.label" tooltip="This tooltip property is ignored">
           <span>Some text to translate</span>
-        </div>`,
-      options: [
-        {
-          checkText: false,
-        },
-      ],
+        </div>
+      `,
+      options: [{ checkText: false }],
     },
     {
-      filename: 'test.component.html',
       code: `
-        <div
-          i18n-tooltip="@@tooltip.label"
-          tooltip="This tooltip property is ignored"
-        >
+        <div i18n-tooltip="@@tooltip.label" tooltip="This tooltip property is ignored">
           <mat-icon>valid</mat-icon>
-        </div>`,
-      options: [
-        {
-          ignoreTags: ['mat-icon'],
-        },
-      ],
+        </div>
+      `,
+      options: [{ ignoreTags: ['mat-icon'] }],
     },
     {
-      filename: 'test.component.html',
       code: `
-        <div
-          i18n-tooltip="@@tooltip.label"
-          tooltip="This tooltip property is ignored"
-        >
+        <div i18n-tooltip="@@tooltip.label" tooltip="This tooltip property is ignored">
           -{{data_from_backend}}
-        </div>`,
+        </div>
+      `,
       options: [{}],
     },
     {
@@ -130,95 +93,93 @@ ruleTester.run(RULE_NAME, rule, {
     convertAnnotatedSourceToFailureCase({
       description: 'it should fail if i18n is missing',
       annotatedSource: `
-            <div>
-                <span>Some text to translate</span>
-                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-            </div>`,
+        <div>
+          <span>Some text to translate</span>
+          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+        </div>
+      `,
       messageId: i18nText,
-      options: [
-        {
-          ignoreAttributes: [],
-        },
-      ],
+      options: [{ ignoreAttributes: [] }],
+      data: { attributeName: 'span' },
     }),
     {
-      filename: 'test.component.html',
       code: `
+        <div
+          tooltip="This also requires translation"
+          i18n-placeholder
+          placeholder="More translation, please"
+          class="red"
+        >
           <div
-            tooltip="This also requires translation"
-            i18n-placeholder
-            placeholder="More translation, please"
-            class="red"
+            *ngIf="true"
+            width="100px"
+            label="Templates need translation too."
           >
-            <div
-              *ngIf="true"
-              width="100px"
-              label="Templates need translation too."
-            >
-              <span i18n label="valid with i18n">Some text to translate</span>
-            </div>
-          </div>`,
+            <span i18n label="valid with i18n">Some text to translate</span>
+          </div>
+        </div>
+      `,
       errors: [
         {
-          messageId: i18nAttrib,
+          messageId: i18nAttribute,
           line: 2,
-          column: 11,
+          column: 9,
+          data: { attributeName: 'tooltip' },
         },
         {
-          messageId: i18nIdOnAttrib,
+          messageId: i18nIdOnAttribute,
           line: 2,
+          column: 9,
+          data: { attributeName: 'placeholder' },
+        },
+        {
+          messageId: i18nAttribute,
+          line: 8,
           column: 11,
+          data: { attributeName: 'label' },
         },
         {
-          messageId: i18nAttrib,
+          messageId: i18nAttribute,
           line: 8,
-          column: 13,
-        },
-        {
-          messageId: i18nAttrib,
-          line: 8,
-          column: 13,
+          column: 11,
+          data: { attributeName: 'label' },
         },
         {
           messageId: i18nId,
           line: 13,
-          column: 15,
+          column: 13,
+          data: { attributeName: 'tooltip' },
         },
       ],
       output: `
-          <div i18n-tooltip
-            tooltip="This also requires translation"
-            i18n-placeholder
-            placeholder="More translation, please"
-            class="red"
+        <div i18n-tooltip
+          tooltip="This also requires translation"
+          i18n-placeholder
+          placeholder="More translation, please"
+          class="red"
+        >
+          <div i18n-label
+            *ngIf="true"
+            width="100px"
+            label="Templates need translation too."
           >
-            <div i18n-label
-              *ngIf="true"
-              width="100px"
-              label="Templates need translation too."
-            >
-              <span i18n label="valid with i18n">Some text to translate</span>
-            </div>
-          </div>`,
-      options: [
-        {
-          ignoreAttributes: ['span[label]'],
-        },
-      ],
+            <span i18n label="valid with i18n">Some text to translate</span>
+          </div>
+        </div>
+      `,
+      options: [{ ignoreAttributes: ['span[label]'] }],
     },
     convertAnnotatedSourceToFailureCase({
       description: 'it should fail because of the custom pattern',
       annotatedSource: `
-      <div>
-        <span>-{{data_from_backend}}</span>
-        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-      </div>`,
+        <div>
+          <span>-{{data_from_backend}}</span>
+          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+        </div>
+      `,
       messageId: i18nText,
-      options: [
-        {
-          boundTextAllowedPattern: '-',
-        },
-      ],
+      options: [{ boundTextAllowedPattern: '-' }],
+      data: { attributeName: 'span' },
     }),
   ],
 });


### PR DESCRIPTION
After some recent fixes I applied to this rule, I realized that it was a little difficult to read, fix bugs and also implement new features. That said, I decided to refactor it. This PR doesn't bring functional changes, that is, everything should work as it currently does.

- The first commit is just a cleanup in tests, removing unnecessary attributes, formatting and include data to ensure the `attributeName` is correctly passed.
- The second commit is the proposed changes to the rule in the hope of making this a little more readable and maintainable.