### PR TITLE
feat(schematics): dynamically install tslint-to-eslint-config as needed

### DIFF
--- a/packages/schematics/package.json
+++ b/packages/schematics/package.json
@@ -33,12 +33,15 @@
   "dependencies": {
     "@angular-eslint/eslint-plugin": "4.0.0",
     "@angular-eslint/eslint-plugin-template": "4.0.0",
+    "ignore": "5.1.8",
     "strip-json-comments": "3.1.1",
-    "tslint-to-eslint-config": "2.2.0"
+    "tmp": "0.2.1"
   },
   "devDependencies": {
+    "@types/tmp": "0.2.0",
     "@typescript-eslint/experimental-utils": "4.16.1",
-    "eslint": "^7.6.0"
+    "eslint": "^7.6.0",
+    "tslint-to-eslint-config": "^2.3.0"
   },
   "peerDependencies": {
     "@angular/cli": ">= 11.2.0 < 12.0.0"

--- a/packages/schematics/src/convert-tslint-to-eslint/convert-to-eslint-config.ts
+++ b/packages/schematics/src/convert-tslint-to-eslint/convert-to-eslint-config.ts
@@ -1,84 +1,185 @@
+import { normalize } from '@angular-devkit/core';
+import type { Rule, SchematicContext, Tree } from '@angular-devkit/schematics';
+import { execSync } from 'child_process';
 import type { Linter as ESLintLinter } from 'eslint';
-import type { TSLintRuleOptions } from 'tslint-to-eslint-config';
-import {
-  createESLintConfiguration,
-  findReportedConfiguration,
-  joinConfigConversionResults,
-} from 'tslint-to-eslint-config';
+import { dirSync } from 'tmp';
+import type * as TslintToEslintConfig from 'tslint-to-eslint-config';
+import { readJsonInTree, visitNotIgnoredFiles } from '../utils';
 
-export async function convertToESLintConfig(
-  pathToTslintJson: string,
-  tslintJson: Record<string, unknown>,
-): Promise<{
-  convertedESLintConfig: ESLintLinter.Config;
-  unconvertedTSLintRules: TSLintRuleOptions[];
-  ensureESLintPlugins: string[];
-}> {
-  const reportedConfiguration = await findReportedConfiguration(
-    'npx tslint --print-config',
-    pathToTslintJson,
-  );
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const tslintToEslintConfigVersion = require('../../package.json')
+  .devDependencies['tslint-to-eslint-config'];
 
-  if (reportedConfiguration instanceof Error) {
-    if (
-      reportedConfiguration.message.includes('unknown option `--print-config')
-    ) {
-      throw new Error(
-        '\nError: TSLint v5.18 required in order to run this schematic. Please update your version and try again.\n',
-      );
-    }
-    /**
-     * Make a print-config issue easier to understand for the end user.
-     * This error could occur if, for example, the user does not have a TSLint plugin installed correctly that they
-     * reference in their config.
-     */
-    const printConfigFailureMessageStart =
-      'Command failed: npx tslint --print-config "tslint.json"';
-    if (
-      reportedConfiguration.message.startsWith(printConfigFailureMessageStart)
-    ) {
-      throw new Error(
-        `\nThere was a critical error when trying to inspect your tslint.json: \n${reportedConfiguration.message.replace(
-          printConfigFailureMessageStart,
-          '',
-        )}`,
-      );
-    }
+type TslintToEslintConfigLibrary = {
+  createESLintConfiguration: typeof TslintToEslintConfig['createESLintConfiguration'];
+  findReportedConfiguration: typeof TslintToEslintConfig['findReportedConfiguration'];
+  joinConfigConversionResults: typeof TslintToEslintConfig['joinConfigConversionResults'];
+  convertFileComments: typeof TslintToEslintConfig['convertFileComments'];
+};
 
-    throw new Error(`Unexpected error: ${reportedConfiguration.message}`);
+let tslintToEslintConfigLibrary: TslintToEslintConfigLibrary;
+function getTslintToEslintConfigLibrary(
+  context: SchematicContext,
+): TslintToEslintConfigLibrary {
+  if (tslintToEslintConfigLibrary) {
+    return tslintToEslintConfigLibrary;
   }
 
-  const originalConfigurations = {
-    tslint: {
-      full: reportedConfiguration,
-      raw: tslintJson,
-    },
-  };
+  try {
+    // This is usually not available at runtime but makes it easier to work with in our tests
+    return require('tslint-to-eslint-config');
+    // eslint-disable-next-line no-empty
+  } catch (e) {}
 
-  const summarizedConfiguration = await createESLintConfiguration(
-    originalConfigurations,
+  context.logger.info(
+    '\nINFO: We are now installing the "tslint-to-eslint-config" package into a tmp directory to aid with the conversion',
   );
+  context.logger.info('\nThis may take a minute or two...\n');
 
-  const expectedESLintPlugins = [
-    // These are added to support the ng-cli-compat configs
-    'eslint-plugin-jsdoc',
-    'eslint-plugin-prefer-arrow',
-    'eslint-plugin-import',
-    // These are already covered by our recommended config, and are installed by the `ng add` schematic
-    '@angular-eslint/eslint-plugin',
-    '@angular-eslint/eslint-plugin-template',
-  ];
+  /**
+   * In order to avoid all users of angular-eslint needing to have tslint-to-eslint-config (and therefore tslint)
+   * in their node_modules, we dynamically install and uninstall the library as part of the conversion
+   * process.
+   */
+  const tempDir = dirSync().name;
+  execSync(`npm i -D tslint-to-eslint-config@${tslintToEslintConfigVersion}`, {
+    cwd: tempDir,
+    stdio: 'ignore',
+  });
 
-  const convertedESLintConfig = joinConfigConversionResults(
-    summarizedConfiguration,
-    originalConfigurations,
-  ) as ESLintLinter.Config;
+  tslintToEslintConfigLibrary = require(require.resolve(
+    'tslint-to-eslint-config',
+    {
+      paths: [tempDir],
+    },
+  ));
+  return tslintToEslintConfigLibrary;
+}
 
-  return {
-    convertedESLintConfig,
-    unconvertedTSLintRules: summarizedConfiguration.missing,
-    ensureESLintPlugins: Array.from(summarizedConfiguration.plugins).filter(
-      (pluginName) => !expectedESLintPlugins.includes(pluginName),
-    ),
+export function createConvertToESLintConfig(context: SchematicContext) {
+  return async function convertToESLintConfig(
+    pathToTslintJson: string,
+    tslintJson: Record<string, unknown>,
+  ): Promise<{
+    convertedESLintConfig: ESLintLinter.Config;
+    unconvertedTSLintRules: TslintToEslintConfig.TSLintRuleOptions[];
+    ensureESLintPlugins: string[];
+  }> {
+    const {
+      findReportedConfiguration,
+      createESLintConfiguration,
+      joinConfigConversionResults,
+    } = getTslintToEslintConfigLibrary(context);
+
+    const reportedConfiguration = await findReportedConfiguration(
+      'npx tslint --print-config',
+      pathToTslintJson,
+    );
+
+    if (reportedConfiguration instanceof Error) {
+      if (
+        reportedConfiguration.message.includes('unknown option `--print-config')
+      ) {
+        throw new Error(
+          '\nError: TSLint v5.18 required in order to run this schematic. Please update your version and try again.\n',
+        );
+      }
+      /**
+       * Make a print-config issue easier to understand for the end user.
+       * This error could occur if, for example, the user does not have a TSLint plugin installed correctly that they
+       * reference in their config.
+       */
+      const printConfigFailureMessageStart =
+        'Command failed: npx tslint --print-config "tslint.json"';
+      if (
+        reportedConfiguration.message.startsWith(printConfigFailureMessageStart)
+      ) {
+        throw new Error(
+          `\nThere was a critical error when trying to inspect your tslint.json: \n${reportedConfiguration.message.replace(
+            printConfigFailureMessageStart,
+            '',
+          )}`,
+        );
+      }
+
+      throw new Error(`Unexpected error: ${reportedConfiguration.message}`);
+    }
+
+    const originalConfigurations = {
+      tslint: {
+        full: reportedConfiguration,
+        raw: tslintJson,
+      },
+    };
+
+    const summarizedConfiguration = await createESLintConfiguration(
+      originalConfigurations,
+    );
+
+    const expectedESLintPlugins = [
+      // These are added to support the ng-cli-compat configs
+      'eslint-plugin-jsdoc',
+      'eslint-plugin-prefer-arrow',
+      'eslint-plugin-import',
+      // These are already covered by our recommended config, and are installed by the `ng add` schematic
+      '@angular-eslint/eslint-plugin',
+      '@angular-eslint/eslint-plugin-template',
+    ];
+
+    const convertedESLintConfig = joinConfigConversionResults(
+      summarizedConfiguration,
+      originalConfigurations,
+    ) as ESLintLinter.Config;
+
+    return {
+      convertedESLintConfig,
+      unconvertedTSLintRules: summarizedConfiguration.missing,
+      ensureESLintPlugins: Array.from(summarizedConfiguration.plugins).filter(
+        (pluginName) => !expectedESLintPlugins.includes(pluginName),
+      ),
+    };
+  };
+}
+
+function likelyContainsTSLintComment(fileContent: string): boolean {
+  return fileContent.includes('tslint:');
+}
+
+export function convertTSLintDisableCommentsForProject(
+  projectName: string,
+): Rule {
+  return (tree: Tree, context: SchematicContext) => {
+    /**
+     * We need to avoid a direct dependency on tslint-to-eslint-config
+     * and ensure we are only resolving the dependency from the user's
+     * node_modules on demand (it will be installed as part of the
+     * conversion schematic).
+     */
+    const { convertFileComments } = getTslintToEslintConfigLibrary(context);
+    const workspaceJson = readJsonInTree(tree, 'angular.json');
+    const existingProjectConfig = workspaceJson.projects[projectName];
+
+    let pathRoot = '';
+
+    // Default Angular CLI project at the root of the workspace
+    if (existingProjectConfig.root === '') {
+      pathRoot = 'src';
+    } else {
+      pathRoot = existingProjectConfig.root;
+    }
+
+    return visitNotIgnoredFiles((filePath, host) => {
+      if (!filePath.endsWith('.ts')) {
+        return;
+      }
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      const fileContent = host.read(filePath)!.toString('utf-8');
+      // Avoid updating files if we don't have to
+      if (!likelyContainsTSLintComment(fileContent)) {
+        return;
+      }
+      const updatedFileContent = convertFileComments({ fileContent, filePath });
+      host.overwrite(filePath, updatedFileContent);
+    }, normalize(pathRoot));
   };
 }

--- a/packages/schematics/tests/convert-tslint-to-eslint/convert-to-eslint-config.test.ts
+++ b/packages/schematics/tests/convert-tslint-to-eslint/convert-to-eslint-config.test.ts
@@ -25,9 +25,14 @@ jest.mock('tslint-to-eslint-config', () => {
 });
 
 const {
-  convertToESLintConfig,
+  createConvertToESLintConfig,
   // eslint-disable-next-line @typescript-eslint/no-var-requires
 } = require('../../src/convert-tslint-to-eslint/convert-to-eslint-config');
+
+const convertToESLintConfig = createConvertToESLintConfig({
+  // eslint-disable-next-line @typescript-eslint/no-empty-function
+  logger: { info: () => {} },
+});
 
 describe('convertToESLintConfig()', () => {
   beforeEach(() => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3839,6 +3839,11 @@
   resolved "https://registry.yarnpkg.com/@types/stack-utils/-/stack-utils-2.0.0.tgz#7036640b4e21cc2f259ae826ce843d277dad8cff"
   integrity sha512-RJJrrySY7A8havqpGObOB4W92QXKJo63/jFLLgpvOtsGUqbQZ9Sbgl35KMm1DjC6j7AvmmU2bIno+3IyEaemaw==
 
+"@types/tmp@0.2.0":
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/@types/tmp/-/tmp-0.2.0.tgz#e3f52b4d7397eaa9193592ef3fdd44dc0af4298c"
+  integrity sha512-flgpHJjntpBAdJD43ShRosQvNC0ME97DCfGvZEDlAThQmnerRXrLbX6YgzRBQCZTthET9eAWFAMaYP0m0Y4HzQ==
+
 "@types/webpack-sources@^0.1.5":
   version "0.1.8"
   resolved "https://registry.yarnpkg.com/@types/webpack-sources/-/webpack-sources-0.1.8.tgz#078d75410435993ec8a0a2855e88706f3f751f81"
@@ -5744,10 +5749,10 @@ commander@3.0.2:
   resolved "https://registry.yarnpkg.com/commander/-/commander-3.0.2.tgz#6837c3fb677ad9933d1cfba42dd14d5117d6b39e"
   integrity sha512-Gar0ASD4BDyKC4hl4DwHqDrmvjoxWKZigVnAbn5H1owvm4CxCPdb0HQDehwNYMJpla5+M2tPmPARzhtYuwpHow==
 
-commander@7.1.0:
-  version "7.1.0"
-  resolved "https://registry.yarnpkg.com/commander/-/commander-7.1.0.tgz#f2eaecf131f10e36e07d894698226e36ae0eb5ff"
-  integrity sha512-pRxBna3MJe6HKnBGsDyMv8ETbptw3axEdYHoqNh7gu5oDcew8fs0xnivZGm06Ogk8zGAJ9VX+OPEr2GXEQK4dg==
+commander@7.2.0:
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-7.2.0.tgz#a36cb57d0b501ce108e4d20559a150a391d97ab7"
+  integrity sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==
 
 commander@^2.12.1, commander@^2.20.0:
   version "2.20.3"
@@ -6196,10 +6201,10 @@ crypto-browserify@^3.11.0:
     randombytes "^2.0.0"
     randomfill "^1.0.3"
 
-cson-parser@4.0.8:
-  version "4.0.8"
-  resolved "https://registry.yarnpkg.com/cson-parser/-/cson-parser-4.0.8.tgz#373f3bde1be018267fccbc575d82120c2a7a645e"
-  integrity sha512-Hdv3N2E5JU4vAp88cxcs/Y+0L0y0HJnpoc067E//qbXNF4/cG713rFLryD0QvKZYK6w3QBA67t7UOfo2ymh8Sg==
+cson-parser@4.0.9:
+  version "4.0.9"
+  resolved "https://registry.yarnpkg.com/cson-parser/-/cson-parser-4.0.9.tgz#eef0cf77edd057f97861ef800300c8239224eedb"
+  integrity sha512-I79SAcCYquWnEfXYj8hBqOOWKj6eH6zX1hhX3yqmS4K3bYp7jME3UFpHPzu3rUew0oyfc0s8T6IlWGXRAheHag==
   dependencies:
     coffeescript "1.12.7"
 
@@ -7229,10 +7234,10 @@ eslint-config-prettier@7.1.0:
   resolved "https://registry.yarnpkg.com/eslint-config-prettier/-/eslint-config-prettier-7.1.0.tgz#5402eb559aa94b894effd6bddfa0b1ca051c858f"
   integrity sha512-9sm5/PxaFG7qNJvJzTROMM1Bk1ozXVTKI0buKOyb0Bsr1hrwi0H/TzxF/COtf1uxikIK8SwhX7K6zg78jAzbeA==
 
-eslint-config-prettier@8.1.0:
-  version "8.1.0"
-  resolved "https://registry.yarnpkg.com/eslint-config-prettier/-/eslint-config-prettier-8.1.0.tgz#4ef1eaf97afe5176e6a75ddfb57c335121abc5a6"
-  integrity sha512-oKMhGv3ihGbCIimCAjqkdzx2Q+jthoqnXSP+d86M9tptwugycmTFdVR4IpLgq2c4SHifbwO90z2fQ8/Aio73yw==
+eslint-config-prettier@8.2.0:
+  version "8.2.0"
+  resolved "https://registry.yarnpkg.com/eslint-config-prettier/-/eslint-config-prettier-8.2.0.tgz#78de77d63bca8e9e59dae75a614b5299925bb7b3"
+  integrity sha512-dWV9EVeSo2qodOPi1iBYU/x6F6diHv8uujxbxr77xExs3zTAlNXvVZKiyLsQGNz7yPV2K49JY5WjPzNIuDc2Bw==
 
 eslint-scope@^4.0.3:
   version "4.0.3"
@@ -8710,15 +8715,15 @@ ignore-walk@^3.0.1, ignore-walk@^3.0.3:
   dependencies:
     minimatch "^3.0.4"
 
+ignore@5.1.8, ignore@^5.0.4, ignore@^5.1.1, ignore@^5.1.4:
+  version "5.1.8"
+  resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.1.8.tgz#f150a8b50a34289b33e22f5889abd4d8016f0e57"
+  integrity sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw==
+
 ignore@^4.0.3, ignore@^4.0.6:
   version "4.0.6"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-4.0.6.tgz#750e3db5862087b4737ebac8207ffd1ef27b25fc"
   integrity sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==
-
-ignore@^5.0.4, ignore@^5.1.1, ignore@^5.1.4:
-  version "5.1.8"
-  resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.1.8.tgz#f150a8b50a34289b33e22f5889abd4d8016f0e57"
-  integrity sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw==
 
 image-size@~0.5.0:
   version "0.5.5"
@@ -15047,6 +15052,13 @@ tmp@0.0.33, tmp@^0.0.33:
   dependencies:
     os-tmpdir "~1.0.2"
 
+tmp@0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.2.1.tgz#8457fc3037dcf4719c251367a1af6500ee1ccf14"
+  integrity sha512-76SUhtfqR2Ijn+xllcI5P1oyannHNHByD80W1q447gU3mp9G9PSpGdWmjUOHRDPiHYacIk66W7ubDTuPF3BEtQ==
+  dependencies:
+    rimraf "^3.0.0"
+
 tmpl@1.0.x:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/tmpl/-/tmpl-1.0.4.tgz#23640dd7b42d00433911140820e5cf440e521dd1"
@@ -15207,26 +15219,31 @@ tslib@2.1.0, tslib@^2.0.3:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.1.0.tgz#da60860f1c2ecaa5703ab7d39bc05b6bf988b97a"
   integrity sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A==
 
-tslib@^1.10.0, tslib@^1.13.0, tslib@^1.8.1, tslib@^1.9.0:
+tslib@^1.10.0, tslib@^1.8.1, tslib@^1.9.0:
   version "1.13.0"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.13.0.tgz#c881e13cc7015894ed914862d276436fa9a47043"
   integrity sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q==
 
-tslint-to-eslint-config@2.2.0:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/tslint-to-eslint-config/-/tslint-to-eslint-config-2.2.0.tgz#711a1596b765175139193a3878a8a12ebdf91318"
-  integrity sha512-ta+V1G8y431CPXuJHbzlYYxuAyvKZM8llLZnFN7jy0C98dMsz0jIQCZW7dH5I6wt10gTyMOw7h5W+JEeQumbfQ==
+tslib@^1.13.0:
+  version "1.14.1"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
+  integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
+
+tslint-to-eslint-config@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/tslint-to-eslint-config/-/tslint-to-eslint-config-2.3.0.tgz#9573200403f7ababfe865071e9113fc80dcde7ab"
+  integrity sha512-m4/6MNI9NADIpyAwpRxT5ouih5uJt2mmwqB4yKmbwOkuLF5w4jKVCw9nc8KTZz/i7TlFirvRCrpQJil9E2e+Ig==
   dependencies:
     chalk "4.1.0"
-    commander "7.1.0"
-    cson-parser "4.0.8"
-    eslint-config-prettier "8.1.0"
+    commander "7.2.0"
+    cson-parser "4.0.9"
+    eslint-config-prettier "8.2.0"
     glob "7.1.6"
     json5 "2.2.0"
     lodash "4.17.21"
     minimatch "3.0.4"
     tslint "6.1.3"
-    typescript "4.2.2"
+    typescript "4.2.4"
 
 tslint@6.1.3:
   version "6.1.3"
@@ -15362,10 +15379,10 @@ typescript@4.1.5:
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.1.5.tgz#123a3b214aaff3be32926f0d8f1f6e704eb89a72"
   integrity sha512-6OSu9PTIzmn9TCDiovULTnET6BgXtDYL4Gg4szY+cGsc3JP1dQL8qvE8kShTRx1NIw4Q9IBHlwODjkjWEtMUyA==
 
-typescript@4.2.2:
-  version "4.2.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.2.2.tgz#1450f020618f872db0ea17317d16d8da8ddb8c4c"
-  integrity sha512-tbb+NVrLfnsJy3M59lsDgrzWIflR4d4TIUjz+heUnHZwdF7YsrMTKoRERiIvI2lvBG95dfpLxB21WZhys1bgaQ==
+typescript@4.2.4:
+  version "4.2.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.2.4.tgz#8610b59747de028fda898a8aef0e103f156d0961"
+  integrity sha512-V+evlYHZnQkaz8TRBuxTA92yZBPotr5H+WhQ7bD3hZUndx5tGOa1fuCgeSjxAzM1RiN5IzvadIXTVefuuwZCRg==
 
 typescript@^4.1.3:
   version "4.2.3"


### PR DESCRIPTION
Refactors the internals of schematics to make a few improvements:

- `tslint-to-eslint-config` is no longer a static dependency of the schematics package, meaning that TSLint no longer is either, so users will no longer see warnings about it being deprecated as part of `ng add`

- Bumps the version and slightly expands the range of `tslint-to-eslint-config` (Fixes #344)

- when iterating through the files in the `Tree` as part of a conversion it now takes `.gitignore` data into account
