### PR TITLE
fix(template-parser): add missing `Conditional` and its keys to `VisitorKeys`

### DIFF
--- a/packages/template-parser/src/index.ts
+++ b/packages/template-parser/src/index.ts
@@ -49,6 +49,7 @@ const KEYS: VisitorKeys = {
   BoundAttribute: ['value'],
   BoundEvent: ['handler'],
   BoundText: ['value'],
+  Conditional: ['condition', 'trueExp', 'falseExp'],
   Element: ['children', 'inputs', 'outputs', 'attributes'],
   Interpolation: ['expressions'],
   PrefixNot: ['expression'],


### PR DESCRIPTION
When working on #444, I realized that this key was missing and it was a little difficult to make the rules work correctly without a lot of effort.