### PR TITLE
fix(eslint-plugin-template): [no-negated-async] ignore double-bang

### DIFF
--- a/packages/eslint-plugin-template/src/rules/no-negated-async.ts
+++ b/packages/eslint-plugin-template/src/rules/no-negated-async.ts
@@ -1,4 +1,4 @@
-import type { BindingPipe } from '@angular/compiler';
+import type { BindingPipe, PrefixNot } from '@angular/compiler';
 import {
   createESLintRule,
   ensureTemplateParser,
@@ -29,10 +29,10 @@ export default createESLintRule<Options, MessageIds>({
     const sourceCode = context.getSourceCode();
 
     return {
-      'PrefixNot > BindingPipe[name="async"]'({
+      ':not(PrefixNot) > PrefixNot > BindingPipe[name="async"]'({
         parent: { sourceSpan },
-      }: {
-        parent: BindingPipe;
+      }: BindingPipe & {
+        parent: PrefixNot;
       }) {
         context.report({
           messageId: 'noNegatedAsync',

--- a/packages/eslint-plugin-template/tests/rules/no-negated-async.test.ts
+++ b/packages/eslint-plugin-template/tests/rules/no-negated-async.test.ts
@@ -26,6 +26,8 @@ ruleTester.run(RULE_NAME, rule, {
     `{{ (foo | async) === false }}`,
     // it should succeed if any other pipe is negated
     `{{ !(foo | notAnAsyncPipe) }}`,
+    // https://github.com/angular-eslint/angular-eslint/issues/404
+    `<div [class.mx-4]="!!(foo | async)"></div>`,
   ],
   invalid: [
     convertAnnotatedSourceToFailureCase({


### PR DESCRIPTION
Fixes #404.