### PR TITLE
feat(eslint-plugin): [prefer-output-readonly] add suggestion

### DIFF
--- a/packages/eslint-plugin/src/rules/prefer-output-readonly.ts
+++ b/packages/eslint-plugin/src/rules/prefer-output-readonly.ts
@@ -2,7 +2,7 @@ import type { TSESTree } from '@typescript-eslint/experimental-utils';
 import { createESLintRule } from '../utils/create-eslint-rule';
 
 type Options = [];
-export type MessageIds = 'preferOutputReadonly';
+export type MessageIds = 'preferOutputReadonly' | 'suggestFix';
 export const RULE_NAME = 'prefer-output-readonly';
 
 export default createESLintRule<Options, MessageIds>({
@@ -19,17 +19,24 @@ export default createESLintRule<Options, MessageIds>({
     messages: {
       preferOutputReadonly:
         'Prefer to declare `@Output` as readonly since they are not supposed to be reassigned',
+      suggestFix: 'Add readonly modifier',
     },
   },
   defaultOptions: [],
   create(context) {
     return {
       'ClassProperty[readonly=undefined] > Decorator[expression.callee.name="Output"]'({
-        parent,
-      }: TSESTree.Decorator) {
+        parent: { key },
+      }: TSESTree.Decorator & { parent: TSESTree.ClassProperty }) {
         context.report({
-          node: (parent as TSESTree.ClassProperty).key,
+          node: key,
           messageId: 'preferOutputReadonly',
+          suggest: [
+            {
+              messageId: 'suggestFix',
+              fix: (fixer) => fixer.insertTextBefore(key, 'readonly '),
+            },
+          ],
         });
       },
     };

--- a/packages/eslint-plugin/src/rules/prefer-output-readonly.ts
+++ b/packages/eslint-plugin/src/rules/prefer-output-readonly.ts
@@ -2,7 +2,7 @@ import type { TSESTree } from '@typescript-eslint/experimental-utils';
 import { createESLintRule } from '../utils/create-eslint-rule';
 
 type Options = [];
-export type MessageIds = 'preferOutputReadonly' | 'suggestFix';
+export type MessageIds = 'preferOutputReadonly' | 'suggestAddReadonlyModifier';
 export const RULE_NAME = 'prefer-output-readonly';
 
 export default createESLintRule<Options, MessageIds>({
@@ -19,7 +19,7 @@ export default createESLintRule<Options, MessageIds>({
     messages: {
       preferOutputReadonly:
         'Prefer to declare `@Output` as readonly since they are not supposed to be reassigned',
-      suggestFix: 'Add readonly modifier',
+      suggestAddReadonlyModifier: 'Add readonly modifier',
     },
   },
   defaultOptions: [],
@@ -33,7 +33,7 @@ export default createESLintRule<Options, MessageIds>({
           messageId: 'preferOutputReadonly',
           suggest: [
             {
-              messageId: 'suggestFix',
+              messageId: 'suggestAddReadonlyModifier',
               fix: (fixer) => fixer.insertTextBefore(key, 'readonly '),
             },
           ],

--- a/packages/eslint-plugin/tests/rules/prefer-output-readonly.test.ts
+++ b/packages/eslint-plugin/tests/rules/prefer-output-readonly.test.ts
@@ -12,8 +12,8 @@ import rule, { RULE_NAME } from '../../src/rules/prefer-output-readonly';
 const ruleTester = new RuleTester({
   parser: '@typescript-eslint/parser',
 });
-
 const messageId: MessageIds = 'preferOutputReadonly';
+const suggestFix: MessageIds = 'suggestFix';
 
 ruleTester.run(RULE_NAME, rule, {
   valid: [
@@ -21,7 +21,7 @@ ruleTester.run(RULE_NAME, rule, {
     class Test {
       @Output() readonly testEmitter = new EventEmitter<string>();
     }
-`,
+    `,
   ],
   invalid: [
     convertAnnotatedSourceToFailureCase({
@@ -33,6 +33,17 @@ ruleTester.run(RULE_NAME, rule, {
         }
       `,
       messageId,
+      suggestions: [
+        {
+          messageId: suggestFix,
+          output: `
+        class Test {
+          @Output() readonly testEmitter = new EventEmitter<string>();
+                    
+        }
+      `,
+        },
+      ],
     }),
   ],
 });

--- a/packages/eslint-plugin/tests/rules/prefer-output-readonly.test.ts
+++ b/packages/eslint-plugin/tests/rules/prefer-output-readonly.test.ts
@@ -13,7 +13,7 @@ const ruleTester = new RuleTester({
   parser: '@typescript-eslint/parser',
 });
 const messageId: MessageIds = 'preferOutputReadonly';
-const suggestFix: MessageIds = 'suggestFix';
+const suggestAddReadonlyModifier: MessageIds = 'suggestAddReadonlyModifier';
 
 ruleTester.run(RULE_NAME, rule, {
   valid: [
@@ -35,7 +35,7 @@ ruleTester.run(RULE_NAME, rule, {
       messageId,
       suggestions: [
         {
-          messageId: suggestFix,
+          messageId: suggestAddReadonlyModifier,
           output: `
         class Test {
           @Output() readonly testEmitter = new EventEmitter<string>();


### PR DESCRIPTION
To be reviewed after #458's merge.

Note that I went with a `suggest` instead of `fix`, because if we fix it directly we can break the code since there is no guarantee that `@Output` property is not being mutated somewhere.