### PR TITLE
fix(eslint-plugin): [no-output-on-prefix] not reporting failures on alias

### DIFF
--- a/packages/eslint-plugin/src/rules/no-output-on-prefix.ts
+++ b/packages/eslint-plugin/src/rules/no-output-on-prefix.ts
@@ -1,47 +1,38 @@
 import type { TSESTree } from '@typescript-eslint/experimental-utils';
 import { createESLintRule } from '../utils/create-eslint-rule';
-import { getClassName, getClassPropertyName } from '../utils/utils';
+import { OUTPUT_DECORATOR } from '../utils/selectors';
 
 type Options = [];
 export type MessageIds = 'noOutputOnPrefix';
 export const RULE_NAME = 'no-output-on-prefix';
+const STYLE_GUIDE_LINK = 'https://angular.io/guide/styleguide#style-05-16';
+const OUTPUT_ON_PATTERN = /^on((?![a-z])|(?=$))/;
 
 export default createESLintRule<Options, MessageIds>({
   name: RULE_NAME,
   meta: {
     type: 'suggestion',
     docs: {
-      description: `Name events without the prefix on. See more at https://angular.io/guide/styleguide#dont-prefix-output-properties.`,
+      description: `Ensures that Output names or its alias are not be named "on" or prefixed with it. See more at ${STYLE_GUIDE_LINK}`,
       category: 'Best Practices',
       recommended: 'error',
     },
     schema: [],
     messages: {
-      noOutputOnPrefix:
-        'In the class "{{className}}", the output property "{{memberName}}" should not be prefixed with on',
+      noOutputOnPrefix: `Output names or its alias should not be named "on" or prefixed with it (${STYLE_GUIDE_LINK})`,
     },
   },
   defaultOptions: [],
   create(context) {
+    const outputAliasSelector = `ClassProperty:has(${OUTPUT_DECORATOR}[expression.arguments.0.value=${OUTPUT_ON_PATTERN}])`;
+    const outputPropertySelector = `ClassProperty:has(${OUTPUT_DECORATOR}):has(Identifier[name=${OUTPUT_ON_PATTERN}])`;
+    const selectors = [outputAliasSelector, outputPropertySelector].join(',');
+
     return {
-      'ClassProperty > Decorator[expression.callee.name="Output"]'(
-        node: TSESTree.Decorator,
-      ) {
-        const property = node.parent as TSESTree.ClassProperty;
-        const className = getClassName(node);
-        const memberName = getClassPropertyName(property);
-
-        if (!memberName || !/^on((?![a-z])|(?=$))/.test(memberName)) {
-          return;
-        }
-
+      [selectors](node: TSESTree.ClassProperty) {
         context.report({
-          node: property,
+          node,
           messageId: 'noOutputOnPrefix',
-          data: {
-            className,
-            memberName,
-          },
         });
       },
     };

--- a/packages/eslint-plugin/src/rules/no-output-on-prefix.ts
+++ b/packages/eslint-plugin/src/rules/no-output-on-prefix.ts
@@ -13,13 +13,13 @@ export default createESLintRule<Options, MessageIds>({
   meta: {
     type: 'suggestion',
     docs: {
-      description: `Ensures that Output names or its alias are not be named "on" or prefixed with it. See more at ${STYLE_GUIDE_LINK}`,
+      description: `Ensures that Output bindings, including aliases, are not named "on", nor prefixed with it. See more at ${STYLE_GUIDE_LINK}`,
       category: 'Best Practices',
       recommended: 'error',
     },
     schema: [],
     messages: {
-      noOutputOnPrefix: `Output names or its alias should not be named "on" or prefixed with it (${STYLE_GUIDE_LINK})`,
+      noOutputOnPrefix: `Output bindings, including aliases, should not be named "on", nor prefixed with it (${STYLE_GUIDE_LINK})`,
     },
   },
   defaultOptions: [],

--- a/packages/eslint-plugin/src/utils/selectors.ts
+++ b/packages/eslint-plugin/src/utils/selectors.ts
@@ -15,3 +15,7 @@ export const INJECTABLE_CLASS_DECORATOR =
 
 export const MODULE_CLASS_DECORATOR =
   'ClassDeclaration > Decorator[expression.callee.name="NgModule"]';
+
+export const OUTPUT_DECORATOR = 'Decorator[expression.callee.name="Output"]';
+
+export const OUTPUT_CLASS_DECORATOR = `ClassProperty > ${OUTPUT_DECORATOR}`;

--- a/packages/eslint-plugin/tests/rules/no-output-on-prefix.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-output-on-prefix.test.ts
@@ -12,94 +12,63 @@ import rule, { RULE_NAME } from '../../src/rules/no-output-on-prefix';
 const ruleTester = new RuleTester({
   parser: '@typescript-eslint/parser',
 });
-
 const messageId: MessageIds = 'noOutputOnPrefix';
 
 ruleTester.run(RULE_NAME, rule, {
   valid: [
     `
     @Component()
-    class ButtonComponent {
-      @Output() change = new EventEmitter<any>();
+    class Test {
+      @Output() change = new EventEmitter<void>();
     }
-`,
+    `,
     `
     @Component()
-    class ButtonComponent {
-      @Output() oneProp = new EventEmitter<any>();
+    class Test {
+      @Output('testing') oneProp = new EventEmitter<void>();
     }
-      `,
+    `,
     `
-    @Component()
-    class SelectComponent {
-      @Output() selectionChanged = new EventEmitter<any>();
+    @Directive()
+    class Test {
+      @Output() selectionChanged = new EventEmitter<void>();
     }
-`,
+    `,
   ],
   invalid: [
     convertAnnotatedSourceToFailureCase({
-      description:
-        'it should fail when a component output property is named with on prefix',
+      description: `it should fail if a component output property's name is prefixed with "on"`,
       annotatedSource: `
         @Component()
-        class ButtonComponent {
-          @Output() onChange = new EventEmitter<any>();
-          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+        class Test {
+          @Output() onChange = new EventEmitter<void>();
+          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
         }
       `,
       messageId,
-      data: {
-        className: 'ButtonComponent',
-        memberName: 'onChange',
-      },
+    }),
+    convertAnnotatedSourceToFailureCase({
+      description: `it should fail if a component output property's alias is prefixed with "on"`,
+      annotatedSource: `
+        @Component()
+        class Test {
+          @Output('onChange') test = new EventEmitter<void>();
+          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+        }
+      `,
+      messageId,
     }),
     convertAnnotatedSourceToFailureCase({
       description:
-        'it should fail when a directive output property is named with on prefix',
+        'it should fail if a directive output property name is equal to "on"',
       annotatedSource: `
         @Directive()
-        class ButtonDirective {
-          @Output() onChange = new EventEmitter<any>();
-          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+        class Test {
+          @Output() on = new EventEmitter<void>();
+          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
         }
       `,
       messageId,
-      data: {
-        className: 'ButtonDirective',
-        memberName: 'onChange',
-      },
-    }),
-    convertAnnotatedSourceToFailureCase({
-      description:
-        'it should fail when a directive output property is named with on prefix',
-      annotatedSource: `
-        @Directive()
-        class ButtonDirective {
-          @Output() on = new EventEmitter<any>();
-          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-        }
-      `,
-      messageId,
-      data: {
-        className: 'ButtonDirective',
-        memberName: 'on',
-      },
-    }),
-    convertAnnotatedSourceToFailureCase({
-      description:
-        'it should correctly identify the class and member names when the class is exported',
-      annotatedSource: `
-        @Directive()
-        export class ButtonDirective {
-          @Output() on = new EventEmitter<any>();
-          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-        }
-      `,
-      messageId,
-      data: {
-        className: 'ButtonDirective',
-        memberName: 'on',
-      },
     }),
   ],
 });

--- a/packages/integration-tests/tests/__snapshots__/v1123-multi-project-manual-config.test.ts.snap
+++ b/packages/integration-tests/tests/__snapshots__/v1123-multi-project-manual-config.test.ts.snap
@@ -16,15 +16,15 @@ __ROOT__/v1123-multi-project-manual-config/src/app/app.component.ts
   15:3  error  Lifecycle interface 'OnInit' should be implemented for method 'ngOnInit'. (https://angular.io/styleguide#style-09-01)  @angular-eslint/use-lifecycle-interface
 
 __ROOT__/v1123-multi-project-manual-config/src/app/example.component.ts
-   4:13  error  Strings must use singlequote                                                                                            @typescript-eslint/quotes
-  12:3   error  Use @Input rather than the \`inputs\` metadata property (https://angular.io/styleguide#style-05-12)                       @angular-eslint/no-inputs-metadata-property
-  13:3   error  Use @Output rather than the \`outputs\` metadata property (https://angular.io/styleguide#style-05-12)                     @angular-eslint/no-outputs-metadata-property
-  14:3   error  Use @HostBinding or @HostListener rather than the \`host\` metadata property (https://angular.io/styleguide#style-06-03)  @angular-eslint/no-host-metadata-property
-  18:3   error  Output names or its alias should not be named "on" or prefixed with it (https://angular.io/guide/styleguide#style-05-16)  @angular-eslint/no-output-on-prefix
-   6:35  error  Invalid binding syntax. Use [(expr)] instead                                                                            @angular-eslint/template/banana-in-box
-   8:15  error  Invalid binding syntax. Use [(expr)] instead                                                                            @angular-eslint/template/banana-in-box
-   8:29  error  Invalid binding syntax. Use [(expr)] instead                                                                            @angular-eslint/template/banana-in-box
-   9:48  error  Invalid binding syntax. Use [(expr)] instead                                                                            @angular-eslint/template/banana-in-box
+   4:13  error  Strings must use singlequote                                                                                                          @typescript-eslint/quotes
+  12:3   error  Use @Input rather than the \`inputs\` metadata property (https://angular.io/styleguide#style-05-12)                                     @angular-eslint/no-inputs-metadata-property
+  13:3   error  Use @Output rather than the \`outputs\` metadata property (https://angular.io/styleguide#style-05-12)                                   @angular-eslint/no-outputs-metadata-property
+  14:3   error  Use @HostBinding or @HostListener rather than the \`host\` metadata property (https://angular.io/styleguide#style-06-03)                @angular-eslint/no-host-metadata-property
+  18:3   error  Output bindings, including aliases, should not be named \\"on\\", nor prefixed with it (https://angular.io/guide/styleguide#style-05-16)  @angular-eslint/no-output-on-prefix
+   6:35  error  Invalid binding syntax. Use [(expr)] instead                                                                                          @angular-eslint/template/banana-in-box
+   8:15  error  Invalid binding syntax. Use [(expr)] instead                                                                                          @angular-eslint/template/banana-in-box
+   8:29  error  Invalid binding syntax. Use [(expr)] instead                                                                                          @angular-eslint/template/banana-in-box
+   9:48  error  Invalid binding syntax. Use [(expr)] instead                                                                                          @angular-eslint/template/banana-in-box
 
 __ROOT__/v1123-multi-project-manual-config/src/app/example.pipe.ts
   6:14  error  Pipes should implement \`PipeTransform\` interface  @angular-eslint/use-pipe-transform-interface

--- a/packages/integration-tests/tests/__snapshots__/v1123-multi-project-manual-config.test.ts.snap
+++ b/packages/integration-tests/tests/__snapshots__/v1123-multi-project-manual-config.test.ts.snap
@@ -20,7 +20,7 @@ __ROOT__/v1123-multi-project-manual-config/src/app/example.component.ts
   12:3   error  Use @Input rather than the \`inputs\` metadata property (https://angular.io/styleguide#style-05-12)                       @angular-eslint/no-inputs-metadata-property
   13:3   error  Use @Output rather than the \`outputs\` metadata property (https://angular.io/styleguide#style-05-12)                     @angular-eslint/no-outputs-metadata-property
   14:3   error  Use @HostBinding or @HostListener rather than the \`host\` metadata property (https://angular.io/styleguide#style-06-03)  @angular-eslint/no-host-metadata-property
-  18:3   error  In the class \\"ExampleComponent\\", the output property \\"onFoo\\" should not be prefixed with on                             @angular-eslint/no-output-on-prefix
+  18:3   error  Output names or its alias should not be named "on" or prefixed with it (https://angular.io/guide/styleguide#style-05-16)  @angular-eslint/no-output-on-prefix
    6:35  error  Invalid binding syntax. Use [(expr)] instead                                                                            @angular-eslint/template/banana-in-box
    8:15  error  Invalid binding syntax. Use [(expr)] instead                                                                            @angular-eslint/template/banana-in-box
    8:29  error  Invalid binding syntax. Use [(expr)] instead                                                                            @angular-eslint/template/banana-in-box


### PR DESCRIPTION
With this PR, `alias` like `onChange` in `@Output('onChange') test = new EventEmitter<void>();` are correctly reported.