### PR TITLE
fix(template-parser): add missing `Program#body`

### DIFF
--- a/packages/template-parser/src/index.ts
+++ b/packages/template-parser/src/index.ts
@@ -206,6 +206,7 @@ function parseForESLint(code: string, options: { filePath: string }) {
   const ast: AST = {
     type: 'Program',
     comments: convertNgAstCommentsToTokens(ngAstCommentNodes),
+    body: [],
     tokens: [],
     range: [0, 0],
     loc: {


### PR DESCRIPTION
close #476

`body` is required in `estree`

https://github.com/estree/estree/blob/master/es2015.md#programs

https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/estree/index.d.ts#L65