### PR TITLE
fix(template-parser): generate correct index.d.ts when building

### DIFF
--- a/README.md
+++ b/README.md
@@ -815,4 +815,6 @@ If you see a rule below that has **no status** against it, then please feel free
 
 <!-- PR Links -->
 
+[`pr475`]: https://api.github.com/repos/angular-eslint/angular-eslint/pulls/475
+
 <!-- end rule list -->

--- a/packages/template-parser/src/index.ts
+++ b/packages/template-parser/src/index.ts
@@ -246,7 +246,7 @@ function parseForESLint(code: string, options: { filePath: string }) {
   };
 }
 
-module.exports = {
+export default {
   parseForESLint,
   parse: function parse(code: string, options: { filePath: string }) {
     return parseForESLint(code, options).ast;

--- a/packages/template-parser/tests/index.test.ts
+++ b/packages/template-parser/tests/index.test.ts
@@ -1,10 +1,13 @@
-// eslint-disable-next-line @typescript-eslint/no-var-requires
-const { parseForESLint } = require('../src/index');
+/**
+ * This usage seems a little wonky, but don't want to run any risk of breaking changes
+ * to the compiled output of the template-parser node module, so leaving until v13.
+ */
+import { default as templateParser } from '../src/index';
 
 describe('parseForESLint()', () => {
   it('should work', () => {
     expect(
-      parseForESLint(
+      templateParser.parseForESLint(
         `
       <!-- eslint-disable-next-line -->
       <div>some node</div>


### PR DESCRIPTION
Fixes #479 