### PR TITLE
fix(eslint-plugin): [no-host-metadata-property] correct false positive with `allowStatic` option

### DIFF
--- a/packages/eslint-plugin/src/utils/utils.ts
+++ b/packages/eslint-plugin/src/utils/utils.ts
@@ -207,7 +207,7 @@ export function isClassDeclaration(
   return node.type === 'ClassDeclaration';
 }
 
-function isObjectExpression(
+export function isObjectExpression(
   node: TSESTree.Node,
 ): node is TSESTree.ObjectExpression {
   return node.type === 'ObjectExpression';

--- a/packages/eslint-plugin/tests/rules/no-host-metadata-property.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-host-metadata-property.test.ts
@@ -31,12 +31,14 @@ ruleTester.run(RULE_NAME, rule, {
     `,
     {
       code: `
+        const shorthand = 'testing';
+
         @Component({
           host: {
             shorthand,
-            [computed]: 'test',
             static: true,
-            'class': 'class1'
+            'class': 'class1',
+            '[@routerTransition]': ''
           },
           selector: 'app-test'
         })
@@ -86,16 +88,20 @@ ruleTester.run(RULE_NAME, rule, {
       description:
         'it should fail if non-static properties are used with `allowStatic` option',
       annotatedSource: `
+        const computed = '[class]';
+
         @Directive({
           host: {
-            shorthand,
             [computed]: 'test',
+            ~~~~~~~~~~~~~~~~~~
             static: true,
             'class': 'class1',
             '(click)': 'bar()',
-            ~~~~~~~~~~~~~~~~~~
-            '[attr.role]': role
-            ^^^^^^^^^^^^^^^^^^^
+            ^^^^^^^^^^^^^^^^^^
+            '[attr.role]': role,
+            ###################
+            '[@routerTransition]': 'test'
+            %%%%%%%%%%%%%%%%%%%%%%%%%%%%%
           },
           selector: 'app-test'
         })
@@ -104,7 +110,22 @@ ruleTester.run(RULE_NAME, rule, {
       messages: [
         { char: '~', messageId },
         { char: '^', messageId },
+        { char: '#', messageId },
+        { char: '%', messageId },
       ],
+      options: [{ allowStatic: true }],
+    }),
+    convertAnnotatedSourceToFailureCase({
+      description: 'it should fail if "host" metadata property is shorthand',
+      annotatedSource: `
+        @Component({
+          host,
+          ~~~~
+          selector: 'app-test'
+        })
+        class Test {}
+      `,
+      messageId,
       options: [{ allowStatic: true }],
     }),
   ],


### PR DESCRIPTION
With this:

- `computed` properties are now reported (even with `allowStatic` option enabled) as we can't guarantee that it refers to a static value;
- when `host` is `shorthand` the rule doesn't crash anymore;
- it doesn't report empty string values anymore like `'[@routerTransition]': ''` because IMO it can be considered static, no?

**Reference**:
https://github.com/mgechev/codelyzer/issues/393
https://github.com/angular/angular/issues/19110