### PR TITLE
fix(schematics): skip e2e tsconfig for add to non e2e project

### DIFF
--- a/packages/integration-tests/tests/__snapshots__/v12-new-workspace.test.ts.snap
+++ b/packages/integration-tests/tests/__snapshots__/v12-new-workspace.test.ts.snap
@@ -108,7 +108,6 @@ Object {
         "project": Array [
           "projects/another-app/tsconfig.app.json",
           "projects/another-app/tsconfig.spec.json",
-          "projects/another-app/e2e/tsconfig.json",
         ],
       },
       "rules": Object {

--- a/packages/integration-tests/tests/__snapshots__/v12-new-workspace.test.ts.snap
+++ b/packages/integration-tests/tests/__snapshots__/v12-new-workspace.test.ts.snap
@@ -44,7 +44,6 @@ Object {
         "createDefaultProgram": true,
         "project": Array [
           "tsconfig.json",
-          "e2e/tsconfig.json",
         ],
       },
       "rules": Object {

--- a/packages/schematics/src/convert-tslint-to-eslint/index.ts
+++ b/packages/schematics/src/convert-tslint-to-eslint/index.ts
@@ -498,7 +498,11 @@ function convertNonRootTSLintConfig(
       {
         files: ['*.ts'],
         parserOptions: {
-          project: setESLintProjectBasedOnProjectType(projectRoot, projectType),
+          project: setESLintProjectBasedOnProjectType(
+            projectRoot,
+            projectType,
+            true,
+          ),
           createDefaultProgram: true,
         },
         extends: convertedExtends || undefined,

--- a/packages/schematics/src/utils.ts
+++ b/packages/schematics/src/utils.ts
@@ -427,6 +427,5 @@ export function determineTargetProjectHasE2E(
   angularJSON: any,
   projectName: string,
 ): boolean {
-  const { architect } = angularJSON.projects[projectName];
-  return Object.prototype.hasOwnProperty.call(architect, 'e2e');
+  return !!getTargetsConfigFromProject(angularJSON.projects[projectName])?.e2e;
 }

--- a/packages/schematics/src/utils.ts
+++ b/packages/schematics/src/utils.ts
@@ -218,14 +218,18 @@ type ProjectType = 'application' | 'library';
 export function setESLintProjectBasedOnProjectType(
   projectRoot: string,
   projectType: ProjectType,
+  hasE2e?: boolean,
 ) {
   let project;
   if (projectType === 'application') {
     project = [
       `${projectRoot}/tsconfig.app.json`,
       `${projectRoot}/tsconfig.spec.json`,
-      `${projectRoot}/e2e/tsconfig.json`,
     ];
+
+    if (hasE2e) {
+      project.push(`${projectRoot}/e2e/tsconfig.json`);
+    }
   }
   // Libraries don't have an e2e directory
   if (projectType === 'library') {
@@ -237,7 +241,10 @@ export function setESLintProjectBasedOnProjectType(
   return project;
 }
 
-export function createRootESLintConfig(prefix: string | null) {
+export function createRootESLintConfig(
+  prefix: string | null,
+  hasE2e?: boolean,
+) {
   let codeRules;
   if (prefix) {
     codeRules = {
@@ -254,6 +261,11 @@ export function createRootESLintConfig(prefix: string | null) {
     codeRules = {};
   }
 
+  const project = ['tsconfig.json'];
+  if (hasE2e) {
+    project.push('e2e/tsconfig.json');
+  }
+
   return {
     root: true,
     ignorePatterns: ['projects/**/*'],
@@ -261,7 +273,7 @@ export function createRootESLintConfig(prefix: string | null) {
       {
         files: ['*.ts'],
         parserOptions: {
-          project: ['tsconfig.json', 'e2e/tsconfig.json'],
+          project: project,
           createDefaultProgram: true,
         },
         extends: [
@@ -285,6 +297,7 @@ function createProjectESLintConfig(
   projectRoot: string,
   projectType: ProjectType,
   prefix: string,
+  hasE2e: boolean,
 ) {
   return {
     extends: `${offsetFromRoot(rootPath)}.eslintrc.json`,
@@ -293,7 +306,11 @@ function createProjectESLintConfig(
       {
         files: ['*.ts'],
         parserOptions: {
-          project: setESLintProjectBasedOnProjectType(projectRoot, projectType),
+          project: setESLintProjectBasedOnProjectType(
+            projectRoot,
+            projectType,
+            hasE2e,
+          ),
           createDefaultProgram: true,
         },
         rules: {
@@ -322,6 +339,9 @@ export function createESLintConfigForProject(projectName: string): Rule {
     const { root: projectRoot, projectType, prefix } = angularJSON.projects[
       projectName
     ];
+
+    const hasE2e = determineTargetProjectHasE2E(angularJSON, projectName);
+
     /**
      * If the root is an empty string it must be the initial project created at the
      * root by the Angular CLI's workspace schematic
@@ -337,6 +357,7 @@ export function createESLintConfigForProject(projectName: string): Rule {
           projectRoot,
           projectType,
           prefix,
+          hasE2e,
         ),
     );
   };
@@ -357,12 +378,15 @@ function createRootESLintConfigFile(projectName: string): Rule {
   return (tree) => {
     const angularJSON = readJsonInTree(tree, getWorkspacePath(tree));
     let lintPrefix: string | null = null;
+    const hasE2e = determineTargetProjectHasE2E(angularJSON, projectName);
+
     if (angularJSON.projects?.[projectName]) {
       const { prefix } = angularJSON.projects[projectName];
       lintPrefix = prefix;
     }
+
     return updateJsonInTree('.eslintrc.json', () =>
-      createRootESLintConfig(lintPrefix),
+      createRootESLintConfig(lintPrefix, hasE2e),
     );
   };
 }
@@ -395,4 +419,19 @@ export function determineTargetProjectName(
     return projects[0];
   }
   return null;
+}
+
+/**
+ * Checking if the target project has e2e setup
+ * Method will check if angular project architect has e2e configuration to determine if e2e setup
+ */
+export function determineTargetProjectHasE2E(
+  angularJSON: any,
+  projectName: string,
+): boolean {
+  if (angularJSON.projects?.[projectName]) {
+    const { architect } = angularJSON.projects[projectName];
+    return Object.prototype.hasOwnProperty.call(architect, 'e2e');
+  }
+  return false;
 }

--- a/packages/schematics/src/utils.ts
+++ b/packages/schematics/src/utils.ts
@@ -427,9 +427,6 @@ export function determineTargetProjectHasE2E(
   angularJSON: any,
   projectName: string,
 ): boolean {
-  if (angularJSON.projects?.[projectName]) {
-    const { architect } = angularJSON.projects[projectName];
-    return Object.prototype.hasOwnProperty.call(architect, 'e2e');
-  }
-  return false;
+  const { architect } = angularJSON.projects[projectName];
+  return Object.prototype.hasOwnProperty.call(architect, 'e2e');
 }

--- a/packages/schematics/src/utils.ts
+++ b/packages/schematics/src/utils.ts
@@ -189,6 +189,7 @@ export function visitNotIgnoredFiles(
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       ig.add(host.read('.gitignore')!.toString());
     }
+
     function visit(_dir: Path) {
       if (_dir && ig?.ignores(_dir)) {
         return;
@@ -261,11 +262,6 @@ export function createRootESLintConfig(
     codeRules = {};
   }
 
-  const project = ['tsconfig.json'];
-  if (hasE2e) {
-    project.push('e2e/tsconfig.json');
-  }
-
   return {
     root: true,
     ignorePatterns: ['projects/**/*'],
@@ -273,7 +269,9 @@ export function createRootESLintConfig(
       {
         files: ['*.ts'],
         parserOptions: {
-          project: project,
+          project: hasE2e
+            ? ['tsconfig.json', 'e2e/tsconfig.json']
+            : ['tsconfig.json'],
           createDefaultProgram: true,
         },
         extends: [

--- a/packages/schematics/tests/add-eslint-to-project/index.test.ts
+++ b/packages/schematics/tests/add-eslint-to-project/index.test.ts
@@ -12,6 +12,7 @@ const schematicRunner = new SchematicTestRunner(
 );
 
 const rootProjectName = 'root-project';
+const legacyProjectName = 'legacy-project';
 const otherProjectName = 'other-project';
 
 describe('add-eslint-to-project', () => {
@@ -39,6 +40,20 @@ describe('add-eslint-to-project', () => {
               'extract-i18n': {},
               test: {},
               lint: {},
+            },
+          },
+          [legacyProjectName]: {
+            projectType: 'application',
+            schematics: {},
+            root: `projects/${legacyProjectName}`,
+            sourceRoot: `projects/${legacyProjectName}/src`,
+            prefix: 'app',
+            architect: {
+              build: {},
+              serve: {},
+              'extract-i18n': {},
+              test: {},
+              lint: {},
               e2e: {},
             },
           },
@@ -54,7 +69,6 @@ describe('add-eslint-to-project', () => {
               'extract-i18n': {},
               test: {},
               lint: {},
-              e2e: {},
             },
           },
         },
@@ -104,7 +118,6 @@ describe('add-eslint-to-project', () => {
               "createDefaultProgram": true,
               "project": Array [
                 "tsconfig.json",
-                "e2e/tsconfig.json",
               ],
             },
             "rules": Object {
@@ -141,9 +154,9 @@ describe('add-eslint-to-project', () => {
     `);
   });
 
-  it('should add ESLint to the any other Angular CLI projects which are generated after the workspace is', async () => {
+  it('should add ESLint to the legacy Angular CLI projects which are generated with e2e after the workspace is', async () => {
     const options = {
-      project: otherProjectName,
+      project: legacyProjectName,
     };
 
     await schematicRunner
@@ -151,7 +164,7 @@ describe('add-eslint-to-project', () => {
       .toPromise();
 
     const projectConfig = readJsonInTree(appTree, 'angular.json').projects[
-      otherProjectName
+      legacyProjectName
     ];
 
     expect(projectConfig.architect.lint).toMatchInlineSnapshot(`
@@ -159,8 +172,8 @@ describe('add-eslint-to-project', () => {
         "builder": "@angular-eslint/builder:lint",
         "options": Object {
           "lintFilePatterns": Array [
-            "projects/other-project/**/*.ts",
-            "projects/other-project/**/*.html",
+            "projects/legacy-project/**/*.ts",
+            "projects/legacy-project/**/*.html",
           ],
         },
       }
@@ -181,9 +194,9 @@ describe('add-eslint-to-project', () => {
             "parserOptions": Object {
               "createDefaultProgram": true,
               "project": Array [
-                "projects/other-project/tsconfig.app.json",
-                "projects/other-project/tsconfig.spec.json",
-                "projects/other-project/e2e/tsconfig.json",
+                "projects/legacy-project/tsconfig.app.json",
+                "projects/legacy-project/tsconfig.spec.json",
+                "projects/legacy-project/e2e/tsconfig.json",
               ],
             },
             "rules": Object {
@@ -212,132 +225,6 @@ describe('add-eslint-to-project', () => {
             "rules": Object {},
           },
         ],
-      }
-    `);
-  });
-});
-
-describe('add-eslint-to-non-e2e-project', () => {
-  let appTree: UnitTestTree;
-
-  beforeEach(() => {
-    appTree = new UnitTestTree(Tree.empty());
-    appTree.create('package.json', JSON.stringify({}));
-    appTree.create(
-      'angular.json',
-      JSON.stringify({
-        $schema: './node_modules/@angular/cli/lib/config/schema.json',
-        version: 1,
-        newProjectRoot: 'projects',
-        projects: {
-          [rootProjectName]: {
-            projectType: 'application',
-            schematics: {},
-            root: '',
-            sourceRoot: 'src',
-            prefix: 'app',
-            architect: {
-              build: {},
-              serve: {},
-              'extract-i18n': {},
-              test: {},
-              lint: {},
-            },
-          },
-          [otherProjectName]: {
-            projectType: 'application',
-            schematics: {},
-            root: `projects/${otherProjectName}`,
-            sourceRoot: `projects/${otherProjectName}/src`,
-            prefix: 'app',
-            architect: {
-              build: {},
-              serve: {},
-              'extract-i18n': {},
-              test: {},
-              lint: {},
-              e2e: {},
-            },
-          },
-        },
-      }),
-    );
-  });
-
-  it('should add ESLint to the standard Angular CLI root project which it generates by default', async () => {
-    const options = {
-      project: rootProjectName,
-    };
-
-    await schematicRunner
-      .runSchematicAsync('add-eslint-to-project', options, appTree)
-      .toPromise();
-
-    expect(
-      readJsonInTree(appTree, 'angular.json').projects[rootProjectName]
-        .architect.lint,
-    ).toMatchInlineSnapshot(`
-      Object {
-        "builder": "@angular-eslint/builder:lint",
-        "options": Object {
-          "lintFilePatterns": Array [
-            "src/**/*.ts",
-            "src/**/*.html",
-          ],
-        },
-      }
-    `);
-
-    expect(readJsonInTree(appTree, '.eslintrc.json')).toMatchInlineSnapshot(`
-      Object {
-        "ignorePatterns": Array [
-          "projects/**/*",
-        ],
-        "overrides": Array [
-          Object {
-            "extends": Array [
-              "plugin:@angular-eslint/recommended",
-              "plugin:@angular-eslint/template/process-inline-templates",
-            ],
-            "files": Array [
-              "*.ts",
-            ],
-            "parserOptions": Object {
-              "createDefaultProgram": true,
-              "project": Array [
-                "tsconfig.json",
-              ],
-            },
-            "rules": Object {
-              "@angular-eslint/component-selector": Array [
-                "error",
-                Object {
-                  "prefix": "app",
-                  "style": "kebab-case",
-                  "type": "element",
-                },
-              ],
-              "@angular-eslint/directive-selector": Array [
-                "error",
-                Object {
-                  "prefix": "app",
-                  "style": "camelCase",
-                  "type": "attribute",
-                },
-              ],
-            },
-          },
-          Object {
-            "extends": Array [
-              "plugin:@angular-eslint/template/recommended",
-            ],
-            "files": Array [
-              "*.html",
-            ],
-            "rules": Object {},
-          },
-        ],
-        "root": true,
       }
     `);
   });

--- a/packages/schematics/tests/add-eslint-to-project/index.test.ts
+++ b/packages/schematics/tests/add-eslint-to-project/index.test.ts
@@ -216,3 +216,203 @@ describe('add-eslint-to-project', () => {
     `);
   });
 });
+
+describe('add-eslint-to-non-e2e-project', () => {
+  let appTree: UnitTestTree;
+
+  beforeEach(() => {
+    appTree = new UnitTestTree(Tree.empty());
+    appTree.create('package.json', JSON.stringify({}));
+    appTree.create(
+      'angular.json',
+      JSON.stringify({
+        $schema: './node_modules/@angular/cli/lib/config/schema.json',
+        version: 1,
+        newProjectRoot: 'projects',
+        projects: {
+          [rootProjectName]: {
+            projectType: 'application',
+            schematics: {},
+            root: '',
+            sourceRoot: 'src',
+            prefix: 'app',
+            architect: {
+              build: {},
+              serve: {},
+              'extract-i18n': {},
+              test: {},
+              lint: {},
+            },
+          },
+          [otherProjectName]: {
+            projectType: 'application',
+            schematics: {},
+            root: `projects/${otherProjectName}`,
+            sourceRoot: `projects/${otherProjectName}/src`,
+            prefix: 'app',
+            architect: {
+              build: {},
+              serve: {},
+              'extract-i18n': {},
+              test: {},
+              lint: {},
+              e2e: {},
+            },
+          },
+        },
+      }),
+    );
+  });
+
+  it('should add ESLint to the standard Angular CLI root project which it generates by default', async () => {
+    const options = {
+      project: rootProjectName,
+    };
+
+    await schematicRunner
+      .runSchematicAsync('add-eslint-to-project', options, appTree)
+      .toPromise();
+
+    expect(
+      readJsonInTree(appTree, 'angular.json').projects[rootProjectName]
+        .architect.lint,
+    ).toMatchInlineSnapshot(`
+      Object {
+        "builder": "@angular-eslint/builder:lint",
+        "options": Object {
+          "lintFilePatterns": Array [
+            "src/**/*.ts",
+            "src/**/*.html",
+          ],
+        },
+      }
+    `);
+
+    expect(readJsonInTree(appTree, '.eslintrc.json')).toMatchInlineSnapshot(`
+      Object {
+        "ignorePatterns": Array [
+          "projects/**/*",
+        ],
+        "overrides": Array [
+          Object {
+            "extends": Array [
+              "plugin:@angular-eslint/recommended",
+              "plugin:@angular-eslint/template/process-inline-templates",
+            ],
+            "files": Array [
+              "*.ts",
+            ],
+            "parserOptions": Object {
+              "createDefaultProgram": true,
+              "project": Array [
+                "tsconfig.json",
+              ],
+            },
+            "rules": Object {
+              "@angular-eslint/component-selector": Array [
+                "error",
+                Object {
+                  "prefix": "app",
+                  "style": "kebab-case",
+                  "type": "element",
+                },
+              ],
+              "@angular-eslint/directive-selector": Array [
+                "error",
+                Object {
+                  "prefix": "app",
+                  "style": "camelCase",
+                  "type": "attribute",
+                },
+              ],
+            },
+          },
+          Object {
+            "extends": Array [
+              "plugin:@angular-eslint/template/recommended",
+            ],
+            "files": Array [
+              "*.html",
+            ],
+            "rules": Object {},
+          },
+        ],
+        "root": true,
+      }
+    `);
+  });
+
+  it('should add ESLint to the any other Angular CLI projects which are generated after the workspace is', async () => {
+    const options = {
+      project: otherProjectName,
+    };
+
+    await schematicRunner
+      .runSchematicAsync('add-eslint-to-project', options, appTree)
+      .toPromise();
+
+    const projectConfig = readJsonInTree(appTree, 'angular.json').projects[
+      otherProjectName
+    ];
+
+    expect(projectConfig.architect.lint).toMatchInlineSnapshot(`
+      Object {
+        "builder": "@angular-eslint/builder:lint",
+        "options": Object {
+          "lintFilePatterns": Array [
+            "projects/other-project/**/*.ts",
+            "projects/other-project/**/*.html",
+          ],
+        },
+      }
+    `);
+
+    expect(readJsonInTree(appTree, `${projectConfig.root}/.eslintrc.json`))
+      .toMatchInlineSnapshot(`
+      Object {
+        "extends": "../../.eslintrc.json",
+        "ignorePatterns": Array [
+          "!**/*",
+        ],
+        "overrides": Array [
+          Object {
+            "files": Array [
+              "*.ts",
+            ],
+            "parserOptions": Object {
+              "createDefaultProgram": true,
+              "project": Array [
+                "projects/other-project/tsconfig.app.json",
+                "projects/other-project/tsconfig.spec.json",
+              ],
+            },
+            "rules": Object {
+              "@angular-eslint/component-selector": Array [
+                "error",
+                Object {
+                  "prefix": "app",
+                  "style": "kebab-case",
+                  "type": "element",
+                },
+              ],
+              "@angular-eslint/directive-selector": Array [
+                "error",
+                Object {
+                  "prefix": "app",
+                  "style": "camelCase",
+                  "type": "attribute",
+                },
+              ],
+            },
+          },
+          Object {
+            "files": Array [
+              "*.html",
+            ],
+            "rules": Object {},
+          },
+        ],
+      }
+    `);
+  });
+});

--- a/packages/schematics/tests/application/index.test.ts
+++ b/packages/schematics/tests/application/index.test.ts
@@ -105,8 +105,7 @@ describe('application', () => {
             \\"parserOptions\\": {
               \\"project\\": [
                 \\"projects/foo/tsconfig.app.json\\",
-                \\"projects/foo/tsconfig.spec.json\\",
-                \\"projects/foo/e2e/tsconfig.json\\"
+                \\"projects/foo/tsconfig.spec.json\\"
               ],
               \\"createDefaultProgram\\": true
             },

--- a/packages/schematics/tests/library/index.test.ts
+++ b/packages/schematics/tests/library/index.test.ts
@@ -106,7 +106,6 @@ describe('library', () => {
               \\"project\\": [
                 \\"projects/bar/tsconfig.app.json\\",
                 \\"projects/bar/tsconfig.spec.json\\",
-                \\"projects/bar/e2e/tsconfig.json\\"
               ],
               \\"createDefaultProgram\\": true
             },

--- a/packages/schematics/tests/library/index.test.ts
+++ b/packages/schematics/tests/library/index.test.ts
@@ -105,7 +105,7 @@ describe('library', () => {
             \\"parserOptions\\": {
               \\"project\\": [
                 \\"projects/bar/tsconfig.app.json\\",
-                \\"projects/bar/tsconfig.spec.json\\",
+                \\"projects/bar/tsconfig.spec.json\\"
               ],
               \\"createDefaultProgram\\": true
             },


### PR DESCRIPTION
fix #453 
The pr contains the change to determine if the project contains e2e content by checking for the presence of e2e architect in the `angular.json`, then skip adding e2e's tsconfig to`parserOptions.projects` if the target project is a non-e2e project.