### PR TITLE
fix(utils): support passing `data` and `suggestions` individually for each error

### DIFF
--- a/packages/eslint-plugin-template/src/rules/conditional-complexity.ts
+++ b/packages/eslint-plugin-template/src/rules/conditional-complexity.ts
@@ -39,7 +39,7 @@ export default createESLintRule<Options, MessageIds>({
     ],
     messages: {
       conditionalСomplexity:
-        'The conditional complexity "{{totalComplexity}}" exceeds the defined limit "{{maxComplexity}}"',
+        'The conditional complexity {{totalComplexity}} exceeds the defined limit {{maxComplexity}}',
     },
   },
   defaultOptions: [{ maxComplexity: 5 }],

--- a/packages/eslint-plugin-template/src/rules/cyclomatic-complexity.ts
+++ b/packages/eslint-plugin-template/src/rules/cyclomatic-complexity.ts
@@ -34,7 +34,7 @@ export default createESLintRule<Options, MessageIds>({
     ],
     messages: {
       cyclomaticComplexity:
-        'The cyclomatic complexity "{{totalComplexity}}" exceeds the defined limit "{{maxComplexity}}"',
+        'The cyclomatic complexity {{totalComplexity}} exceeds the defined limit {{maxComplexity}}',
     },
   },
   defaultOptions: [{ maxComplexity: 5 }],

--- a/packages/eslint-plugin-template/src/rules/i18n.ts
+++ b/packages/eslint-plugin-template/src/rules/i18n.ts
@@ -122,7 +122,7 @@ export default createESLintRule<Options, MessageIds>({
       },
     ],
     messages: {
-      i18nAttribute: `Attribute '{{attributeName}}' has no corresponding i18n attribute. See more at ${STYLE_GUIDE_I18N_ATTRIBUTE_LINK}`,
+      i18nAttribute: `Attribute "{{attributeName}}" has no corresponding i18n attribute. See more at ${STYLE_GUIDE_I18N_ATTRIBUTE_LINK}`,
       i18nId: `Missing custom message identifier. See more at ${STYLE_GUIDE_I18N_ATTRIBUTE_ID_LINK}`,
       i18nIdOnAttribute: `Missing custom message identifier on attribute "{{attributeName}}". See more at ${STYLE_GUIDE_I18N_ATTRIBUTE_ID_LINK}`,
       i18nSuggestIgnore:

--- a/packages/eslint-plugin-template/tests/rules/accessibility-alt-text.test.ts
+++ b/packages/eslint-plugin-template/tests/rules/accessibility-alt-text.test.ts
@@ -12,7 +12,6 @@ import rule, { RULE_NAME } from '../../src/rules/accessibility-alt-text';
 const ruleTester = new RuleTester({
   parser: '@angular-eslint/template-parser',
 });
-
 const messageId: MessageIds = 'accessibilityAltText';
 
 ruleTester.run(RULE_NAME, rule, {
@@ -45,6 +44,7 @@ ruleTester.run(RULE_NAME, rule, {
           </div>
         </ng-template>
       `,
+      data: { element: 'img' },
     }),
     convertAnnotatedSourceToFailureCase({
       messageId,
@@ -53,6 +53,7 @@ ruleTester.run(RULE_NAME, rule, {
         <object></object>
         ~~~~~~~~~~~~~~~~~
       `,
+      data: { element: 'object' },
     }),
     convertAnnotatedSourceToFailureCase({
       messageId,
@@ -61,6 +62,7 @@ ruleTester.run(RULE_NAME, rule, {
         <area />
         ~~~~~~~~
       `,
+      data: { element: 'area' },
     }),
     convertAnnotatedSourceToFailureCase({
       messageId,
@@ -70,6 +72,7 @@ ruleTester.run(RULE_NAME, rule, {
         <input type="image">
         ~~~~~~~~~~~~~~~~~~~~
       `,
+      data: { element: 'input' },
     }),
     convertAnnotatedSourceToFailureCase({
       messageId,
@@ -79,6 +82,7 @@ ruleTester.run(RULE_NAME, rule, {
         <input [type]="'image'">
         ~~~~~~~~~~~~~~~~~~~~~~~~
       `,
+      data: { element: 'input' },
     }),
   ],
 });

--- a/packages/eslint-plugin-template/tests/rules/accessibility-valid-aria.test.ts
+++ b/packages/eslint-plugin-template/tests/rules/accessibility-valid-aria.test.ts
@@ -29,7 +29,7 @@ ruleTester.run(RULE_NAME, rule, {
       <div aria-relevant="additions">additions</div>
       <div aria-checked="false">checked</div>
       <div role="slider" [aria-valuemin]="1"></div>
-      <input 
+      <input
         aria-placeholder="Placeholder"
         aria-orientation="undefined"
         [attr.aria-checked]="test && isChecked"
@@ -47,14 +47,26 @@ ruleTester.run(RULE_NAME, rule, {
         <div aria-roledescriptio="text">Text</div>
              ~~~~~~~~~~~~~~~~~~~~~~~~~~
         <input [aria-labelby]="label">
-               ^^^^^^^^^^^^^^^^^^^^^^               
+               ^^^^^^^^^^^^^^^^^^^^^^
         <input [attr.aria-requiredIf]="required">
                #################################
       `,
       messages: [
-        { char: '~', messageId: accessibilityValidAria },
-        { char: '^', messageId: accessibilityValidAria },
-        { char: '#', messageId: accessibilityValidAria },
+        {
+          char: '~',
+          messageId: accessibilityValidAria,
+          data: { attribute: 'aria-roledescriptio' },
+        },
+        {
+          char: '^',
+          messageId: accessibilityValidAria,
+          data: { attribute: 'aria-labelby' },
+        },
+        {
+          char: '#',
+          messageId: accessibilityValidAria,
+          data: { attribute: 'aria-requiredIf' },
+        },
       ],
     }),
     convertAnnotatedSourceToFailureCase({
@@ -63,7 +75,7 @@ ruleTester.run(RULE_NAME, rule, {
         <div aria-expanded="notABoolean">notABoolean</div>
              ~~~~~~~~~~~~~~~~~~~~~~~~~~~
         <div aria-haspopup="notAToken">notAToken</div>
-             ^^^^^^^^^^^^^^^^^^^^^^^^^            
+             ^^^^^^^^^^^^^^^^^^^^^^^^^
         <input [attr.aria-rowcount]="{ a: 2 }">notAnInteger
                ###############################
         <div aria-relevant="notATokenList">notATokenList</div>
@@ -76,13 +88,41 @@ ruleTester.run(RULE_NAME, rule, {
                @@@@@@@@@@@@@@@@@@@@@@@@@@@
       `,
       messages: [
-        { char: '~', messageId: accessibilityValidAriaValue },
-        { char: '^', messageId: accessibilityValidAriaValue },
-        { char: '#', messageId: accessibilityValidAriaValue },
-        { char: '%', messageId: accessibilityValidAriaValue },
-        { char: '¶', messageId: accessibilityValidAriaValue },
-        { char: '¨', messageId: accessibilityValidAriaValue },
-        { char: '@', messageId: accessibilityValidAriaValue },
+        {
+          char: '~',
+          messageId: accessibilityValidAriaValue,
+          data: { attribute: 'aria-expanded' },
+        },
+        {
+          char: '^',
+          messageId: accessibilityValidAriaValue,
+          data: { attribute: 'aria-haspopup' },
+        },
+        {
+          char: '#',
+          messageId: accessibilityValidAriaValue,
+          data: { attribute: 'aria-rowcount' },
+        },
+        {
+          char: '%',
+          messageId: accessibilityValidAriaValue,
+          data: { attribute: 'aria-relevant' },
+        },
+        {
+          char: '¶',
+          messageId: accessibilityValidAriaValue,
+          data: { attribute: 'aria-checked' },
+        },
+        {
+          char: '¨',
+          messageId: accessibilityValidAriaValue,
+          data: { attribute: 'aria-valuemin' },
+        },
+        {
+          char: '@',
+          messageId: accessibilityValidAriaValue,
+          data: { attribute: 'aria-placeholder' },
+        },
       ],
     }),
   ],

--- a/packages/eslint-plugin-template/tests/rules/cyclomatic-complexity.test.ts
+++ b/packages/eslint-plugin-template/tests/rules/cyclomatic-complexity.test.ts
@@ -12,7 +12,6 @@ import rule, { RULE_NAME } from '../../src/rules/cyclomatic-complexity';
 const ruleTester = new RuleTester({
   parser: '@angular-eslint/template-parser',
 });
-
 const messageId: MessageIds = 'cyclomaticComplexity';
 
 ruleTester.run(RULE_NAME, rule, {
@@ -71,8 +70,16 @@ ruleTester.run(RULE_NAME, rule, {
         </div>
       `,
       messages: [
-        { char: '~', messageId },
-        { char: '^', messageId },
+        {
+          char: '~',
+          messageId,
+          data: { maxComplexity: 5, totalComplexity: 6 },
+        },
+        {
+          char: '^',
+          messageId,
+          data: { maxComplexity: 5, totalComplexity: 7 },
+        },
       ],
       options: [{ maxComplexity: 5 }],
     }),
@@ -103,9 +110,21 @@ ruleTester.run(RULE_NAME, rule, {
         </div>
       `,
       messages: [
-        { char: '~', messageId },
-        { char: '^', messageId },
-        { char: '#', messageId },
+        {
+          char: '~',
+          messageId,
+          data: { maxComplexity: 6, totalComplexity: 7 },
+        },
+        {
+          char: '^',
+          messageId,
+          data: { maxComplexity: 6, totalComplexity: 8 },
+        },
+        {
+          char: '#',
+          messageId,
+          data: { maxComplexity: 6, totalComplexity: 9 },
+        },
       ],
       options: [{ maxComplexity: 6 }],
     }),

--- a/packages/eslint-plugin-template/tests/rules/no-distracting-elements.test.ts
+++ b/packages/eslint-plugin-template/tests/rules/no-distracting-elements.test.ts
@@ -24,6 +24,7 @@ ruleTester.run(RULE_NAME, rule, {
         <marquee></marquee>{{ test }}
         ~~~~~~~~~~~~~~~~~~~
       `,
+      data: { element: 'marquee' },
       annotatedOutput: `
         {{ test }}
         
@@ -36,6 +37,7 @@ ruleTester.run(RULE_NAME, rule, {
         <div></div><blink></blink>
                    ~~~~~~~~~~~~~~~
       `,
+      data: { element: 'blink' },
       annotatedOutput: `
         <div></div>
                    

--- a/packages/eslint-plugin-template/tests/rules/no-duplicate-attributes.test.ts
+++ b/packages/eslint-plugin-template/tests/rules/no-duplicate-attributes.test.ts
@@ -12,7 +12,6 @@ import rule, { RULE_NAME } from '../../src/rules/no-duplicate-attributes';
 const ruleTester = new RuleTester({
   parser: '@angular-eslint/template-parser',
 });
-
 const messageId: MessageIds = 'noDuplicateAttributes';
 
 ruleTester.run(RULE_NAME, rule, {
@@ -37,8 +36,8 @@ ruleTester.run(RULE_NAME, rule, {
                ~~~~~~~~~~~~ ^^^^^^^^^^^^
       `,
       messages: [
-        { char: '~', messageId },
-        { char: '^', messageId },
+        { char: '~', messageId, data: { attributeName: 'name' } },
+        { char: '^', messageId, data: { attributeName: 'name' } },
       ],
     }),
     convertAnnotatedSourceToFailureCase({
@@ -49,8 +48,8 @@ ruleTester.run(RULE_NAME, rule, {
                ~~~~~~~~~~~~ ^^^^^^^^^^
       `,
       messages: [
-        { char: '~', messageId },
-        { char: '^', messageId },
+        { char: '~', messageId, data: { attributeName: 'name' } },
+        { char: '^', messageId, data: { attributeName: 'name' } },
       ],
     }),
     convertAnnotatedSourceToFailureCase({
@@ -60,8 +59,8 @@ ruleTester.run(RULE_NAME, rule, {
                ~~~~~~~~~~ ^^^^^^^^^^
       `,
       messages: [
-        { char: '~', messageId },
-        { char: '^', messageId },
+        { char: '~', messageId, data: { attributeName: 'name' } },
+        { char: '^', messageId, data: { attributeName: 'name' } },
       ],
     }),
     convertAnnotatedSourceToFailureCase({
@@ -71,8 +70,8 @@ ruleTester.run(RULE_NAME, rule, {
                ~~~~~~~~~~~~~~~~~~~~~~ ^^^^^^^^^^^^^^^^^^^^^^
       `,
       messages: [
-        { char: '~', messageId },
-        { char: '^', messageId },
+        { char: '~', messageId, data: { attributeName: 'change' } },
+        { char: '^', messageId, data: { attributeName: 'change' } },
       ],
     }),
     convertAnnotatedSourceToFailureCase({
@@ -82,8 +81,8 @@ ruleTester.run(RULE_NAME, rule, {
                ~~~~~~~~~~~~~~~~~~~ ^^^^^^^^^^^^^^^^^^^^^^^^
       `,
       messages: [
-        { char: '~', messageId },
-        { char: '^', messageId },
+        { char: '~', messageId, data: { attributeName: 'ngModel' } },
+        { char: '^', messageId, data: { attributeName: 'ngModel' } },
       ],
     }),
     convertAnnotatedSourceToFailureCase({
@@ -94,8 +93,8 @@ ruleTester.run(RULE_NAME, rule, {
                ~~~~~~~~~~~~               ^^^^^^^^^^^^
       `,
       messages: [
-        { char: '~', messageId },
-        { char: '^', messageId },
+        { char: '~', messageId, data: { attributeName: 'name' } },
+        { char: '^', messageId, data: { attributeName: 'name' } },
       ],
     }),
     convertAnnotatedSourceToFailureCase({
@@ -105,9 +104,9 @@ ruleTester.run(RULE_NAME, rule, {
                ~~~~~~~~~~~~ ^^^^^^^^^^^^ ############
       `,
       messages: [
-        { char: '~', messageId },
-        { char: '^', messageId },
-        { char: '#', messageId },
+        { char: '~', messageId, data: { attributeName: 'name' } },
+        { char: '^', messageId, data: { attributeName: 'name' } },
+        { char: '#', messageId, data: { attributeName: 'name' } },
       ],
     }),
     convertAnnotatedSourceToFailureCase({
@@ -117,10 +116,10 @@ ruleTester.run(RULE_NAME, rule, {
                ~~~~~~~~~~~~~~~~~~~ ^^^^^^^^^^^^ ######################## %%%%%%%%%%
       `,
       messages: [
-        { char: '~', messageId },
-        { char: '^', messageId },
-        { char: '#', messageId },
-        { char: '%', messageId },
+        { char: '~', messageId, data: { attributeName: 'ngModel' } },
+        { char: '^', messageId, data: { attributeName: 'name' } },
+        { char: '#', messageId, data: { attributeName: 'ngModel' } },
+        { char: '%', messageId, data: { attributeName: 'name' } },
       ],
     }),
     convertAnnotatedSourceToFailureCase({
@@ -130,8 +129,8 @@ ruleTester.run(RULE_NAME, rule, {
                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
       `,
       messages: [
-        { char: '~', messageId },
-        { char: '^', messageId },
+        { char: '~', messageId, data: { attributeName: '@fade.start' } },
+        { char: '^', messageId, data: { attributeName: '@fade.start' } },
       ],
     }),
     convertAnnotatedSourceToFailureCase({
@@ -141,8 +140,8 @@ ruleTester.run(RULE_NAME, rule, {
                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
       `,
       messages: [
-        { char: '~', messageId },
-        { char: '^', messageId },
+        { char: '~', messageId, data: { attributeName: 'window:resize' } },
+        { char: '^', messageId, data: { attributeName: 'window:resize' } },
       ],
     }),
     convertAnnotatedSourceToFailureCase({
@@ -153,8 +152,8 @@ ruleTester.run(RULE_NAME, rule, {
       `,
       options: [{ allowTwoWayDataBinding: false }],
       messages: [
-        { char: '~', messageId },
-        { char: '^', messageId },
+        { char: '~', messageId, data: { attributeName: 'ngModelChange' } },
+        { char: '^', messageId, data: { attributeName: 'ngModelChange' } },
       ],
     }),
   ],

--- a/packages/eslint-plugin/src/rules/component-class-suffix.ts
+++ b/packages/eslint-plugin/src/rules/component-class-suffix.ts
@@ -17,7 +17,7 @@ export default createESLintRule<Options, MessageIds>({
   meta: {
     type: 'suggestion',
     docs: {
-      description: `Component class names should end with one of these suffixes: {{suffixes}}. See more at ${STYLE_GUIDE_LINK}`,
+      description: `Classes decorated with @Component must have suffix "Component" (or custom) in their name. See more at ${STYLE_GUIDE_LINK}`,
       category: 'Best Practices',
       recommended: 'error',
     },

--- a/packages/eslint-plugin/src/rules/component-class-suffix.ts
+++ b/packages/eslint-plugin/src/rules/component-class-suffix.ts
@@ -17,7 +17,7 @@ export default createESLintRule<Options, MessageIds>({
   meta: {
     type: 'suggestion',
     docs: {
-      description: `Classes decorated with @Component must have suffix "Component" (or custom) in their name. See more at ${STYLE_GUIDE_LINK}.`,
+      description: `Component class names should end with one of these suffixes: {{suffixes}}. See more at ${STYLE_GUIDE_LINK}`,
       category: 'Best Practices',
       recommended: 'error',
     },
@@ -36,7 +36,7 @@ export default createESLintRule<Options, MessageIds>({
       },
     ],
     messages: {
-      componentClassSuffix: `@Components should be suffixed by {{suffixes}} (${STYLE_GUIDE_LINK})`,
+      componentClassSuffix: `Component class names should end with one of these suffixes: {{suffixes}} (${STYLE_GUIDE_LINK})`,
     },
   },
   defaultOptions: [

--- a/packages/eslint-plugin/src/rules/component-class-suffix.ts
+++ b/packages/eslint-plugin/src/rules/component-class-suffix.ts
@@ -1,7 +1,7 @@
 import type { TSESTree } from '@typescript-eslint/experimental-utils';
 import { createESLintRule } from '../utils/create-eslint-rule';
 import { COMPONENT_CLASS_DECORATOR } from '../utils/selectors';
-import { getClassName } from '../utils/utils';
+import { getClassName, toHumanReadableText } from '../utils/utils';
 
 type Options = [
   {
@@ -10,7 +10,6 @@ type Options = [
 ];
 export type MessageIds = 'componentClassSuffix';
 export const RULE_NAME = 'component-class-suffix';
-
 const STYLE_GUIDE_LINK = 'https://angular.io/styleguide#style-02-03';
 
 export default createESLintRule<Options, MessageIds>({
@@ -37,7 +36,7 @@ export default createESLintRule<Options, MessageIds>({
       },
     ],
     messages: {
-      componentClassSuffix: `The name of the class {{className}} should end with the suffix {{suffixes}} (${STYLE_GUIDE_LINK})`,
+      componentClassSuffix: `@Components should be suffixed by {{suffixes}} (${STYLE_GUIDE_LINK})`,
     },
   },
   defaultOptions: [
@@ -45,9 +44,7 @@ export default createESLintRule<Options, MessageIds>({
       suffixes: ['Component'],
     },
   ],
-  create(context, [options]) {
-    const { suffixes } = options;
-
+  create(context, [{ suffixes }]) {
     return {
       [COMPONENT_CLASS_DECORATOR](node: TSESTree.Decorator) {
         const classParent = node.parent as TSESTree.ClassDeclaration;
@@ -60,10 +57,7 @@ export default createESLintRule<Options, MessageIds>({
           context.report({
             node: classParent.id ? classParent.id : classParent,
             messageId: 'componentClassSuffix',
-            data: {
-              className,
-              suffixes,
-            },
+            data: { suffixes: toHumanReadableText(suffixes) },
           });
         }
       },

--- a/packages/eslint-plugin/src/rules/component-max-inline-declarations.ts
+++ b/packages/eslint-plugin/src/rules/component-max-inline-declarations.ts
@@ -39,8 +39,7 @@ export default createESLintRule<Options, MessageIds>({
   meta: {
     type: 'suggestion',
     docs: {
-      description:
-        'Enforces a maximum number of lines in inline template, styles and animations',
+      description: `Enforces a maximum number of lines in inline template, styles and animations. See more at ${STYLE_GUIDE_LINK}`,
       category: 'Best Practices',
       recommended: false,
     },

--- a/packages/eslint-plugin/src/rules/component-selector.ts
+++ b/packages/eslint-plugin/src/rules/component-selector.ts
@@ -64,7 +64,7 @@ export default createESLintRule<Options, MessageIds>({
       },
     ],
     messages: {
-      prefixFailure: `The selector should be prefixed by {{prefix}} (${STYLE_GUIDE_PREFIX_LINK})`,
+      prefixFailure: `The selector should start with one of these prefixes: {{prefix}} (${STYLE_GUIDE_PREFIX_LINK})`,
       styleFailure: `The selector should be {{style}} (${STYLE_GUIDE_STYLE_LINK})`,
       typeFailure: `The selector should be used as an {{type}} (${STYLE_GUIDE_TYPE_LINK})`,
     },

--- a/packages/eslint-plugin/src/rules/component-selector.ts
+++ b/packages/eslint-plugin/src/rules/component-selector.ts
@@ -1,13 +1,5 @@
 import type { TSESTree } from '@typescript-eslint/experimental-utils';
 import { createESLintRule } from '../utils/create-eslint-rule';
-import { COMPONENT_CLASS_DECORATOR } from '../utils/selectors';
-import type { SelectorStyle } from '../utils/utils';
-import {
-  arrayify,
-  getDecoratorPropertyValue,
-  OPTION_STYLE_CAMEL_CASE,
-  OPTION_STYLE_KEBAB_CASE,
-} from '../utils/utils';
 import type { Options } from '../utils/property-selector';
 import {
   checkSelector,
@@ -18,10 +10,17 @@ import {
   reportStyleError,
   reportTypeError,
 } from '../utils/property-selector';
+import { COMPONENT_CLASS_DECORATOR } from '../utils/selectors';
+import type { SelectorStyle } from '../utils/utils';
+import {
+  arrayify,
+  getDecoratorPropertyValue,
+  OPTION_STYLE_CAMEL_CASE,
+  OPTION_STYLE_KEBAB_CASE,
+} from '../utils/utils';
 
 export const RULE_NAME = 'component-selector';
 export type MessageIds = 'prefixFailure' | 'styleFailure' | 'typeFailure';
-
 const STYLE_GUIDE_PREFIX_LINK =
   'https://angular.io/guide/styleguide#style-02-07';
 const STYLE_GUIDE_STYLE_LINK =
@@ -65,7 +64,7 @@ export default createESLintRule<Options, MessageIds>({
       },
     ],
     messages: {
-      prefixFailure: `The selector should be prefixed by one of the prefixes: '{{prefix}}' (${STYLE_GUIDE_PREFIX_LINK})`,
+      prefixFailure: `The selector should be prefixed by {{prefix}} (${STYLE_GUIDE_PREFIX_LINK})`,
       styleFailure: `The selector should be {{style}} (${STYLE_GUIDE_STYLE_LINK})`,
       typeFailure: `The selector should be used as an {{type}} (${STYLE_GUIDE_TYPE_LINK})`,
     },
@@ -77,9 +76,7 @@ export default createESLintRule<Options, MessageIds>({
       style: '',
     },
   ],
-  create(context, [options]) {
-    const { type, prefix, style } = options;
-
+  create(context, [{ type, prefix, style }]) {
     return {
       [COMPONENT_CLASS_DECORATOR](node: TSESTree.Decorator) {
         const rawSelectors = getDecoratorPropertyValue(node, 'selector');

--- a/packages/eslint-plugin/src/rules/contextual-lifecycle.ts
+++ b/packages/eslint-plugin/src/rules/contextual-lifecycle.ts
@@ -31,7 +31,8 @@ export default createESLintRule<Options, MessageIds>({
     },
     schema: [],
     messages: {
-      contextualLifecycle: `This lifecycle method is not called for {{decorator}}`,
+      contextualLifecycle:
+        'Lifecycle out of context for "@{{classDecoratorName}}()"',
     },
   },
   defaultOptions: [],
@@ -59,7 +60,7 @@ export default createESLintRule<Options, MessageIds>({
         context.report({
           node: method.key,
           messageId: 'contextualLifecycle',
-          data: { decorator },
+          data: { classDecoratorName: decorator },
         });
       }
     }

--- a/packages/eslint-plugin/src/rules/contextual-lifecycle.ts
+++ b/packages/eslint-plugin/src/rules/contextual-lifecycle.ts
@@ -31,8 +31,7 @@ export default createESLintRule<Options, MessageIds>({
     },
     schema: [],
     messages: {
-      contextualLifecycle:
-        'Lifecycle out of context for "@{{classDecoratorName}}()"',
+      contextualLifecycle: `Angular will not invoke the \`{{methodName}}\` lifecycle method within \`@{{classDecoratorName}}()\` classes`,
     },
   },
   defaultOptions: [],
@@ -60,7 +59,7 @@ export default createESLintRule<Options, MessageIds>({
         context.report({
           node: method.key,
           messageId: 'contextualLifecycle',
-          data: { classDecoratorName: decorator },
+          data: { classDecoratorName: decorator, methodName },
         });
       }
     }

--- a/packages/eslint-plugin/src/rules/contextual-lifecycle.ts
+++ b/packages/eslint-plugin/src/rules/contextual-lifecycle.ts
@@ -8,15 +8,15 @@ import {
   PIPE_CLASS_DECORATOR,
 } from '../utils/selectors';
 import {
-  ANGULAR_CLASS_DECORATOR_LIFECYCLE_METHOD_MAPPER,
   AngularClassDecorators,
+  ANGULAR_CLASS_DECORATOR_LIFECYCLE_METHOD_MAPPER,
   getDeclaredMethods,
   getMethodName,
   isAngularLifecycleMethod,
 } from '../utils/utils';
 
 type Options = [];
-export type MessageIds = 'contextuaLifecycle';
+export type MessageIds = 'contextualLifecycle';
 export const RULE_NAME = 'contextual-lifecycle';
 
 export default createESLintRule<Options, MessageIds>({
@@ -31,7 +31,7 @@ export default createESLintRule<Options, MessageIds>({
     },
     schema: [],
     messages: {
-      contextuaLifecycle: `This lifecycle method is not called for {{decorator}}`,
+      contextualLifecycle: `This lifecycle method is not called for {{decorator}}`,
     },
   },
   defaultOptions: [],
@@ -58,7 +58,7 @@ export default createESLintRule<Options, MessageIds>({
 
         context.report({
           node: method.key,
-          messageId: 'contextuaLifecycle',
+          messageId: 'contextualLifecycle',
           data: { decorator },
         });
       }

--- a/packages/eslint-plugin/src/rules/directive-class-suffix.ts
+++ b/packages/eslint-plugin/src/rules/directive-class-suffix.ts
@@ -20,7 +20,7 @@ export default createESLintRule<Options, MessageIds>({
   meta: {
     type: 'suggestion',
     docs: {
-      description: `Directive class names should end with one of these suffixes: {{suffixes}}. See more at ${STYLE_GUIDE_LINK}`,
+      description: `Classes decorated with @Directive must have suffix "Directive" (or custom) in their name. See more at ${STYLE_GUIDE_LINK}`,
       category: 'Best Practices',
       recommended: 'error',
     },

--- a/packages/eslint-plugin/src/rules/directive-class-suffix.ts
+++ b/packages/eslint-plugin/src/rules/directive-class-suffix.ts
@@ -39,7 +39,7 @@ export default createESLintRule<Options, MessageIds>({
       },
     ],
     messages: {
-      directiveClassSuffix: `The name of the class {{className}} should end with suffix(es) {{suffixes}} (${STYLE_GUIDE_LINK})`,
+      directiveClassSuffix: `@Directives should be suffixed by {{suffixes}} (${STYLE_GUIDE_LINK})`,
     },
   },
   defaultOptions: [{ suffixes: DEFAULT_SUFFIXES }],
@@ -70,10 +70,7 @@ export default createESLintRule<Options, MessageIds>({
           context.report({
             node: classParent.id ?? classParent,
             messageId: 'directiveClassSuffix',
-            data: {
-              className,
-              suffixes: toHumanReadableText(allSuffixes),
-            },
+            data: { suffixes: toHumanReadableText(allSuffixes) },
           });
         }
       },

--- a/packages/eslint-plugin/src/rules/directive-class-suffix.ts
+++ b/packages/eslint-plugin/src/rules/directive-class-suffix.ts
@@ -20,7 +20,7 @@ export default createESLintRule<Options, MessageIds>({
   meta: {
     type: 'suggestion',
     docs: {
-      description: `Classes decorated with @Directive must have suffix "Directive" (or custom) in their name. See more at ${STYLE_GUIDE_LINK}.`,
+      description: `Directive class names should end with one of these suffixes: {{suffixes}}. See more at ${STYLE_GUIDE_LINK}`,
       category: 'Best Practices',
       recommended: 'error',
     },
@@ -39,7 +39,7 @@ export default createESLintRule<Options, MessageIds>({
       },
     ],
     messages: {
-      directiveClassSuffix: `@Directives should be suffixed by {{suffixes}} (${STYLE_GUIDE_LINK})`,
+      directiveClassSuffix: `Directive class names should end with one of these suffixes: {{suffixes}} (${STYLE_GUIDE_LINK})`,
     },
   },
   defaultOptions: [{ suffixes: DEFAULT_SUFFIXES }],

--- a/packages/eslint-plugin/src/rules/directive-selector.ts
+++ b/packages/eslint-plugin/src/rules/directive-selector.ts
@@ -1,28 +1,26 @@
 import type { TSESTree } from '@typescript-eslint/experimental-utils';
 import { createESLintRule } from '../utils/create-eslint-rule';
-import { DIRECTIVE_CLASS_DECORATOR } from '../utils/selectors';
-import type { SelectorStyle } from '../utils/utils';
-import {
-  arrayify,
-  OPTION_STYLE_CAMEL_CASE,
-  OPTION_STYLE_KEBAB_CASE,
-  getDecoratorPropertyValue,
-} from '../utils/utils';
-
 import type { Options } from '../utils/property-selector';
 import {
   checkSelector,
   checkValidOptions,
-  reportPrefixError,
-  reportTypeError,
   OPTION_TYPE_ATTRIBUTE,
   OPTION_TYPE_ELEMENT,
+  reportPrefixError,
   reportStyleError,
+  reportTypeError,
 } from '../utils/property-selector';
+import { DIRECTIVE_CLASS_DECORATOR } from '../utils/selectors';
+import type { SelectorStyle } from '../utils/utils';
+import {
+  arrayify,
+  getDecoratorPropertyValue,
+  OPTION_STYLE_CAMEL_CASE,
+  OPTION_STYLE_KEBAB_CASE,
+} from '../utils/utils';
 
 export const RULE_NAME = 'directive-selector';
 export type MessageIds = 'prefixFailure' | 'styleFailure' | 'typeFailure';
-
 const STYLE_GUIDE_PREFIX_LINK =
   'https://angular.io/guide/styleguide#style-02-08';
 const STYLE_GUIDE_STYLE_TYPE_LINK =
@@ -64,7 +62,7 @@ export default createESLintRule<Options, MessageIds>({
       },
     ],
     messages: {
-      prefixFailure: `The selector should be prefixed by one of the prefixes: '{{prefix}}' (${STYLE_GUIDE_PREFIX_LINK})`,
+      prefixFailure: `The selector should be prefixed by {{prefix}} (${STYLE_GUIDE_PREFIX_LINK})`,
       styleFailure: `The selector should be {{style}} (${STYLE_GUIDE_STYLE_TYPE_LINK})`,
       typeFailure: `The selector should be used as an {{type}} (${STYLE_GUIDE_STYLE_TYPE_LINK})`,
     },
@@ -76,9 +74,7 @@ export default createESLintRule<Options, MessageIds>({
       style: '',
     },
   ],
-  create(context, [options]) {
-    const { type, prefix, style } = options;
-
+  create(context, [{ type, prefix, style }]) {
     return {
       [DIRECTIVE_CLASS_DECORATOR](node: TSESTree.Decorator) {
         const rawSelectors = getDecoratorPropertyValue(node, 'selector');

--- a/packages/eslint-plugin/src/rules/directive-selector.ts
+++ b/packages/eslint-plugin/src/rules/directive-selector.ts
@@ -62,7 +62,7 @@ export default createESLintRule<Options, MessageIds>({
       },
     ],
     messages: {
-      prefixFailure: `The selector should be prefixed by {{prefix}} (${STYLE_GUIDE_PREFIX_LINK})`,
+      prefixFailure: `The selector should start with one of these prefixes: {{prefix}} (${STYLE_GUIDE_PREFIX_LINK})`,
       styleFailure: `The selector should be {{style}} (${STYLE_GUIDE_STYLE_TYPE_LINK})`,
       typeFailure: `The selector should be used as an {{type}} (${STYLE_GUIDE_STYLE_TYPE_LINK})`,
     },

--- a/packages/eslint-plugin/src/rules/no-input-prefix.ts
+++ b/packages/eslint-plugin/src/rules/no-input-prefix.ts
@@ -1,6 +1,10 @@
 import type { TSESTree } from '@typescript-eslint/experimental-utils';
 import { createESLintRule } from '../utils/create-eslint-rule';
-import { getClassPropertyName, isImportedFrom } from '../utils/utils';
+import {
+  getClassPropertyName,
+  isImportedFrom,
+  toHumanReadableText,
+} from '../utils/utils';
 
 type Options = [
   {
@@ -35,7 +39,7 @@ export default createESLintRule<Options, MessageIds>({
       },
     ],
     messages: {
-      noInputPrefix: `@Inputs should not be prefixed by {{disallowedPrefixes}}`,
+      noInputPrefix: '@Inputs should not be prefixed by {{prefixes}}',
     },
   },
   defaultOptions: [
@@ -43,7 +47,7 @@ export default createESLintRule<Options, MessageIds>({
       prefixes: [],
     },
   ],
-  create(context, [options]) {
+  create(context, [{ prefixes }]) {
     return {
       ':matches(ClassProperty, MethodDefinition[kind="set"]) > Decorator[expression.callee.name="Input"]'(
         node: TSESTree.Decorator,
@@ -61,10 +65,7 @@ export default createESLintRule<Options, MessageIds>({
 
         const property = node.parent as TSESTree.ClassProperty;
         const memberName = getClassPropertyName(property);
-
-        const disallowedPrefixes = options.prefixes;
-
-        const isDisallowedPrefix = disallowedPrefixes.some(
+        const isDisallowedPrefix = prefixes.some(
           (x) => x === memberName || new RegExp(`^${x}[^a-z]`).test(memberName),
         );
 
@@ -76,7 +77,7 @@ export default createESLintRule<Options, MessageIds>({
           node: property,
           messageId: 'noInputPrefix',
           data: {
-            disallowedPrefixes: disallowedPrefixes.join(', '),
+            prefixes: toHumanReadableText(prefixes),
           },
         });
       },

--- a/packages/eslint-plugin/src/rules/no-input-rename.ts
+++ b/packages/eslint-plugin/src/rules/no-input-rename.ts
@@ -13,6 +13,7 @@ import {
 type Options = [];
 export type MessageIds = 'noInputRename';
 export const RULE_NAME = 'no-input-rename';
+const STYLE_GUIDE_LINK = 'https://angular.io/guide/styleguide#style-05-13';
 
 // source: https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques
 const safelistAliases = new Set<string>([
@@ -66,7 +67,7 @@ export default createESLintRule<Options, MessageIds>({
     },
     schema: [],
     messages: {
-      noInputRename: '@Inputs should not be renamed',
+      noInputRename: `@Inputs should not be aliased (${STYLE_GUIDE_LINK})`,
     },
   },
   defaultOptions: [],

--- a/packages/eslint-plugin/src/rules/no-output-rename.ts
+++ b/packages/eslint-plugin/src/rules/no-output-rename.ts
@@ -1,17 +1,18 @@
 import type { TSESTree } from '@typescript-eslint/experimental-utils';
 import { createESLintRule } from '../utils/create-eslint-rule';
 import {
-  getDecoratorPropertyValue,
-  isIdentifier,
-  isLiteral,
-  isCallExpression,
   AngularClassDecorators,
+  getDecoratorPropertyValue,
+  isCallExpression,
+  isIdentifier,
   isImportedFrom,
+  isLiteral,
 } from '../utils/utils';
 
 type Options = [];
 export type MessageIds = 'noOutputRename';
 export const RULE_NAME = 'no-output-rename';
+const STYLE_GUIDE_LINK = 'https://angular.io/guide/styleguide#style-05-13';
 
 export default createESLintRule<Options, MessageIds>({
   name: RULE_NAME,
@@ -25,7 +26,7 @@ export default createESLintRule<Options, MessageIds>({
     },
     schema: [],
     messages: {
-      noOutputRename: '@Outputs should not be renamed',
+      noOutputRename: `@Outputs should not be aliased (${STYLE_GUIDE_LINK})`,
     },
   },
   defaultOptions: [],

--- a/packages/eslint-plugin/src/rules/pipe-prefix.ts
+++ b/packages/eslint-plugin/src/rules/pipe-prefix.ts
@@ -43,7 +43,7 @@ export default createESLintRule<Options, MessageIds>({
       },
     ],
     messages: {
-      pipePrefix: `@Pipe's name should be prefixed by {{prefixes}}`,
+      pipePrefix: '@Pipes should be prefixed by {{prefixes}}',
     },
   },
   defaultOptions: [

--- a/packages/eslint-plugin/src/rules/use-component-selector.ts
+++ b/packages/eslint-plugin/src/rules/use-component-selector.ts
@@ -21,18 +21,13 @@ export default createESLintRule<Options, MessageIds>({
     },
     schema: [],
     messages: {
-      useComponentSelector: `The selector of the component '{{className}}' is mandatory`,
+      useComponentSelector: 'The selector of the component is mandatory',
     },
   },
   defaultOptions: [],
   create(context) {
     return {
       [COMPONENT_CLASS_DECORATOR](node: TSESTree.Decorator) {
-        const classParent = node.parent as TSESTree.ClassDeclaration;
-        if (!classParent || !classParent.id || !classParent.id.name) {
-          return;
-        }
-
         const selector = getDecoratorPropertyValue(node, 'selector');
 
         if (
@@ -46,9 +41,6 @@ export default createESLintRule<Options, MessageIds>({
         context.report({
           node,
           messageId: 'useComponentSelector',
-          data: {
-            className: classParent.id.name,
-          },
         });
       },
     };

--- a/packages/eslint-plugin/src/rules/use-lifecycle-interface.ts
+++ b/packages/eslint-plugin/src/rules/use-lifecycle-interface.ts
@@ -26,7 +26,7 @@ export default createESLintRule<Options, MessageIds>({
     },
     schema: [],
     messages: {
-      useLifecycleInterface: `Lifecycle interface \`{{interfaceName}}\` should be implemented for method \`{{methodName}}\` (${STYLE_GUIDE_LINK})`,
+      useLifecycleInterface: `Lifecycle interface '{{interfaceName}}' should be implemented for method '{{methodName}}' (${STYLE_GUIDE_LINK})`,
     },
   },
   defaultOptions: [],

--- a/packages/eslint-plugin/src/rules/use-lifecycle-interface.ts
+++ b/packages/eslint-plugin/src/rules/use-lifecycle-interface.ts
@@ -20,14 +20,13 @@ export default createESLintRule<Options, MessageIds>({
   meta: {
     type: 'suggestion',
     docs: {
-      description:
-        'Ensures that classes implement lifecycle interfaces corresponding to the declared lifecycle methods',
+      description: `Ensures that classes implement lifecycle interfaces corresponding to the declared lifecycle methods. See more at ${STYLE_GUIDE_LINK}`,
       category: 'Best Practices',
       recommended: 'warn',
     },
     schema: [],
     messages: {
-      useLifecycleInterface: `Lifecycle interface '{{interfaceName}}' should be implemented for method '{{methodName}}'. (${STYLE_GUIDE_LINK})`,
+      useLifecycleInterface: `Lifecycle interface \`{{interfaceName}}\` should be implemented for method \`{{methodName}}\` (${STYLE_GUIDE_LINK})`,
     },
   },
   defaultOptions: [],

--- a/packages/eslint-plugin/src/rules/use-lifecycle-interface.ts
+++ b/packages/eslint-plugin/src/rules/use-lifecycle-interface.ts
@@ -26,7 +26,7 @@ export default createESLintRule<Options, MessageIds>({
     },
     schema: [],
     messages: {
-      useLifecycleInterface: `Lifecycle interface '{{interfaceName}}' should be implemented for method '{{methodName}}' (${STYLE_GUIDE_LINK})`,
+      useLifecycleInterface: `Lifecycle interface '{{interfaceName}}' should be implemented for method '{{methodName}}'. (${STYLE_GUIDE_LINK})`,
     },
   },
   defaultOptions: [],

--- a/packages/eslint-plugin/src/utils/property-selector.ts
+++ b/packages/eslint-plugin/src/utils/property-selector.ts
@@ -1,6 +1,5 @@
 import { CssSelector } from '@angular/compiler';
 import type { TSESTree } from '@typescript-eslint/experimental-utils';
-
 import type { SelectorStyle } from './utils';
 import {
   arrayify,
@@ -9,6 +8,7 @@ import {
   OPTION_STYLE_CAMEL_CASE,
   OPTION_STYLE_KEBAB_CASE,
   SelectorValidator,
+  toHumanReadableText,
 } from './utils';
 
 export const OPTION_TYPE_ATTRIBUTE = 'attribute';
@@ -66,7 +66,7 @@ export const reportPrefixError = (
     node: node,
     messageId: 'prefixFailure',
     data: {
-      prefix,
+      prefix: toHumanReadableText(arrayify(prefix)),
     },
   });
 };

--- a/packages/eslint-plugin/tests/rules/component-class-suffix.test.ts
+++ b/packages/eslint-plugin/tests/rules/component-class-suffix.test.ts
@@ -12,7 +12,6 @@ import rule, { RULE_NAME } from '../../src/rules/component-class-suffix';
 const ruleTester = new RuleTester({
   parser: '@typescript-eslint/parser',
 });
-
 const messageId: MessageIds = 'componentClassSuffix';
 
 ruleTester.run(RULE_NAME, rule, {
@@ -50,11 +49,7 @@ ruleTester.run(RULE_NAME, rule, {
         })
         class TestPage {}
       `,
-      options: [
-        {
-          suffixes: ['Page'],
-        },
-      ],
+      options: [{ suffixes: ['Page'] }],
     },
     {
       code: `
@@ -63,11 +58,7 @@ ruleTester.run(RULE_NAME, rule, {
         })
         class TestPage {}
       `,
-      options: [
-        {
-          suffixes: ['Page', 'View'],
-        },
-      ],
+      options: [{ suffixes: ['Page', 'View'] }],
     },
   ],
   invalid: [
@@ -82,6 +73,7 @@ ruleTester.run(RULE_NAME, rule, {
               ~~~~
       `,
       messageId,
+      data: { suffixes: '"Component"' },
     }),
     convertAnnotatedSourceToFailureCase({
       description: `it should fail when a different list of suffixes is set and doesn't match`,
@@ -93,11 +85,8 @@ ruleTester.run(RULE_NAME, rule, {
               ~~~~~~~~
       `,
       messageId,
-      options: [
-        {
-          suffixes: ['Component', 'View'],
-        },
-      ],
+      options: [{ suffixes: ['Component', 'View'] }],
+      data: { suffixes: '"Component" or "View"' },
     }),
     convertAnnotatedSourceToFailureCase({
       description: `it should fail when a different list of suffixes is set and doesn't match`,
@@ -109,11 +98,8 @@ ruleTester.run(RULE_NAME, rule, {
               ~~~~~~~~
       `,
       messageId,
-      options: [
-        {
-          suffixes: ['Component'],
-        },
-      ],
+      options: [{ suffixes: ['Component'] }],
+      data: { suffixes: '"Component"' },
     }),
     convertAnnotatedSourceToFailureCase({
       description: `it should fail when a different list of suffixes is set and doesn't match`,
@@ -125,11 +111,8 @@ ruleTester.run(RULE_NAME, rule, {
               ~~~~~~~~~~~~~
       `,
       messageId,
-      options: [
-        {
-          suffixes: ['Page'],
-        },
-      ],
+      options: [{ suffixes: ['Page'] }],
+      data: { suffixes: '"Page"' },
     }),
   ],
 });

--- a/packages/eslint-plugin/tests/rules/component-selector.test.ts
+++ b/packages/eslint-plugin/tests/rules/component-selector.test.ts
@@ -12,7 +12,6 @@ import rule, { RULE_NAME } from '../../src/rules/component-selector';
 const ruleTester = new RuleTester({
   parser: '@typescript-eslint/parser',
 });
-
 const messageIdPrefixFailure: MessageIds = 'prefixFailure';
 const messageIdStyleFailure: MessageIds = 'styleFailure';
 const messageIdTypeFailure: MessageIds = 'typeFailure';
@@ -215,6 +214,7 @@ ruleTester.run(RULE_NAME, rule, {
       `,
       messageId: messageIdPrefixFailure,
       options: [{ type: 'element', prefix: 'sg', style: 'kebab-case' }],
+      data: { prefix: '"sg"' },
     }),
     convertAnnotatedSourceToFailureCase({
       description: `it should fail if a selector is not prefixed by a valid option`,
@@ -227,6 +227,7 @@ ruleTester.run(RULE_NAME, rule, {
       `,
       messageId: messageIdPrefixFailure,
       options: [{ type: 'element', prefix: 'sg', style: 'kebab-case' }],
+      data: { prefix: '"sg"' },
     }),
     convertAnnotatedSourceToFailureCase({
       description: `it should fail if a selector is not prefixed by any valid option`,
@@ -241,6 +242,7 @@ ruleTester.run(RULE_NAME, rule, {
       options: [
         { type: 'attribute', prefix: ['cd', 'ng'], style: 'kebab-case' },
       ],
+      data: { prefix: '"cd" or "ng"' },
     }),
     convertAnnotatedSourceToFailureCase({
       description: `it should fail if a complex selector is not prefixed by any valid option`,
@@ -255,6 +257,7 @@ ruleTester.run(RULE_NAME, rule, {
       options: [
         { type: 'element', prefix: ['foo', 'cd', 'ng'], style: 'kebab-case' },
       ],
+      data: { prefix: '"foo", "cd" or "ng"' },
     }),
     convertAnnotatedSourceToFailureCase({
       description: `it should fail if a selector is not camelCased`,
@@ -267,6 +270,7 @@ ruleTester.run(RULE_NAME, rule, {
       `,
       messageId: messageIdStyleFailure,
       options: [{ type: 'attribute', prefix: 'ng', style: 'camelCase' }],
+      data: { style: 'camelCase' },
     }),
     convertAnnotatedSourceToFailureCase({
       description: `it should fail if a selector is not kebab-cased`,
@@ -279,6 +283,7 @@ ruleTester.run(RULE_NAME, rule, {
       `,
       messageId: messageIdStyleFailure,
       options: [{ type: 'element', prefix: 'app', style: 'kebab-case' }],
+      data: { style: 'kebab-case' },
     }),
     convertAnnotatedSourceToFailureCase({
       description: `it should fail if a selector uses kebab-case style, but no dash`,
@@ -291,6 +296,7 @@ ruleTester.run(RULE_NAME, rule, {
       `,
       messageId: messageIdStyleFailure,
       options: [{ type: 'element', prefix: 'app', style: 'kebab-case' }],
+      data: { style: 'kebab-case' },
     }),
     convertAnnotatedSourceToFailureCase({
       description: `it should fail if a selector is not used as an element`,
@@ -303,6 +309,7 @@ ruleTester.run(RULE_NAME, rule, {
       `,
       messageId: messageIdTypeFailure,
       options: [{ type: 'element', prefix: ['app', 'ng'], style: 'camelCase' }],
+      data: { type: 'element' },
     }),
     convertAnnotatedSourceToFailureCase({
       description: `it should fail if a selector is not used as an attribute`,
@@ -317,9 +324,10 @@ ruleTester.run(RULE_NAME, rule, {
       options: [
         { type: 'attribute', prefix: ['app', 'ng'], style: 'kebab-case' },
       ],
+      data: { type: 'attribute' },
     }),
     convertAnnotatedSourceToFailureCase({
-      description: `it should fail if a selector is not used as an element`,
+      description: `it should fail if a selector is not used as an attribute`,
       annotatedSource: `
       @Component({
         selector: 'appFooBar'
@@ -331,6 +339,7 @@ ruleTester.run(RULE_NAME, rule, {
       options: [
         { type: 'attribute', prefix: ['app', 'ng'], style: 'camelCase' },
       ],
+      data: { type: 'attribute' },
     }),
   ],
 });

--- a/packages/eslint-plugin/tests/rules/contextual-decorator.test.ts
+++ b/packages/eslint-plugin/tests/rules/contextual-decorator.test.ts
@@ -12,7 +12,6 @@ import rule, { RULE_NAME } from '../../src/rules/contextual-decorator';
 const ruleTester = new RuleTester({
   parser: '@typescript-eslint/parser',
 });
-
 const messageId: MessageIds = 'contextualDecorator';
 
 ruleTester.run(RULE_NAME, rule, {
@@ -868,6 +867,7 @@ ruleTester.run(RULE_NAME, rule, {
           private _label: string;
         }
       `,
+      data: { classDecoratorName: 'Injectable' },
     }),
     convertAnnotatedSourceToFailureCase({
       messageId,
@@ -889,6 +889,7 @@ ruleTester.run(RULE_NAME, rule, {
           private _label: string;
         }
       `,
+      data: { classDecoratorName: 'Injectable' },
     }),
     convertAnnotatedSourceToFailureCase({
       messageId,
@@ -906,6 +907,7 @@ ruleTester.run(RULE_NAME, rule, {
           }
         }
       `,
+      data: { classDecoratorName: 'Injectable' },
     }),
     // Methods.
     convertAnnotatedSourceToFailureCase({
@@ -924,6 +926,7 @@ ruleTester.run(RULE_NAME, rule, {
           }
         }
       `,
+      data: { classDecoratorName: 'Injectable' },
     }),
     // Parameter properties.
     convertAnnotatedSourceToFailureCase({
@@ -941,6 +944,7 @@ ruleTester.run(RULE_NAME, rule, {
           ) {}
         }
       `,
+      data: { classDecoratorName: 'Injectable' },
     }),
     // Properties.
     convertAnnotatedSourceToFailureCase({
@@ -956,6 +960,7 @@ ruleTester.run(RULE_NAME, rule, {
           ~~~~~~~~~~~~~~~~~~~
         }
       `,
+      data: { classDecoratorName: 'Injectable' },
     }),
     convertAnnotatedSourceToFailureCase({
       messageId,
@@ -970,6 +975,7 @@ ruleTester.run(RULE_NAME, rule, {
           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
         }
       `,
+      data: { classDecoratorName: 'Injectable' },
     }),
     convertAnnotatedSourceToFailureCase({
       messageId,
@@ -984,6 +990,7 @@ ruleTester.run(RULE_NAME, rule, {
           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
         }
       `,
+      data: { classDecoratorName: 'Injectable' },
     }),
     convertAnnotatedSourceToFailureCase({
       messageId,
@@ -998,6 +1005,7 @@ ruleTester.run(RULE_NAME, rule, {
           ~~~~~~~~
         }
       `,
+      data: { classDecoratorName: 'NgModule' },
     }),
     convertAnnotatedSourceToFailureCase({
       messageId,
@@ -1012,6 +1020,7 @@ ruleTester.run(RULE_NAME, rule, {
           ~~~~~~~~~
         }
       `,
+      data: { classDecoratorName: 'NgModule' },
     }),
     convertAnnotatedSourceToFailureCase({
       messageId,
@@ -1026,6 +1035,7 @@ ruleTester.run(RULE_NAME, rule, {
           ~~~~~~~~~~~~~~~~
         }
       `,
+      data: { classDecoratorName: 'NgModule' },
     }),
     convertAnnotatedSourceToFailureCase({
       messageId,
@@ -1040,6 +1050,7 @@ ruleTester.run(RULE_NAME, rule, {
           ~~~~~~~~~~~~~~~~~~~
         }
       `,
+      data: { classDecoratorName: 'NgModule' },
     }),
     // Multiple declarations.
     convertAnnotatedSourceToFailureCase({
@@ -1098,22 +1109,27 @@ ruleTester.run(RULE_NAME, rule, {
         {
           char: '~',
           messageId,
+          data: { classDecoratorName: 'NgModule' },
         },
         {
           char: '^',
           messageId,
+          data: { classDecoratorName: 'NgModule' },
         },
         {
           char: '#',
           messageId,
+          data: { classDecoratorName: 'NgModule' },
         },
         {
           char: '%',
           messageId,
+          data: { classDecoratorName: 'NgModule' },
         },
         {
           char: '¶',
           messageId,
+          data: { classDecoratorName: 'NgModule' },
         },
       ],
     }),
@@ -1138,6 +1154,7 @@ ruleTester.run(RULE_NAME, rule, {
           private _label: string;
         }
       `,
+      data: { classDecoratorName: 'Pipe' },
     }),
     convertAnnotatedSourceToFailureCase({
       messageId,
@@ -1159,6 +1176,7 @@ ruleTester.run(RULE_NAME, rule, {
           private _label: string;
         }
       `,
+      data: { classDecoratorName: 'Pipe' },
     }),
     convertAnnotatedSourceToFailureCase({
       messageId,
@@ -1176,6 +1194,7 @@ ruleTester.run(RULE_NAME, rule, {
           }
         }
       `,
+      data: { classDecoratorName: 'Pipe' },
     }),
     convertAnnotatedSourceToFailureCase({
       messageId,
@@ -1193,6 +1212,7 @@ ruleTester.run(RULE_NAME, rule, {
           }
         }
       `,
+      data: { classDecoratorName: 'Pipe' },
     }),
     convertAnnotatedSourceToFailureCase({
       messageId,
@@ -1209,6 +1229,7 @@ ruleTester.run(RULE_NAME, rule, {
           ) {}
         }
       `,
+      data: { classDecoratorName: 'Pipe' },
     }),
     convertAnnotatedSourceToFailureCase({
       messageId,
@@ -1223,6 +1244,7 @@ ruleTester.run(RULE_NAME, rule, {
           ~~~~~~~~~~~~~~~~~~~
         }
       `,
+      data: { classDecoratorName: 'Pipe' },
     }),
     convertAnnotatedSourceToFailureCase({
       messageId,
@@ -1237,6 +1259,7 @@ ruleTester.run(RULE_NAME, rule, {
           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
         }
       `,
+      data: { classDecoratorName: 'Pipe' },
     }),
     convertAnnotatedSourceToFailureCase({
       messageId,
@@ -1251,6 +1274,7 @@ ruleTester.run(RULE_NAME, rule, {
           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
         }
       `,
+      data: { classDecoratorName: 'Pipe' },
     }),
     convertAnnotatedSourceToFailureCase({
       messageId,
@@ -1265,6 +1289,7 @@ ruleTester.run(RULE_NAME, rule, {
           ~~~~~~~~
         }
       `,
+      data: { classDecoratorName: 'Pipe' },
     }),
     convertAnnotatedSourceToFailureCase({
       messageId,
@@ -1279,6 +1304,7 @@ ruleTester.run(RULE_NAME, rule, {
           ~~~~~~~~~
         }
       `,
+      data: { classDecoratorName: 'Pipe' },
     }),
     convertAnnotatedSourceToFailureCase({
       messageId,
@@ -1293,6 +1319,7 @@ ruleTester.run(RULE_NAME, rule, {
           ~~~~~~~~~~~~~~~~
         }
       `,
+      data: { classDecoratorName: 'Pipe' },
     }),
     convertAnnotatedSourceToFailureCase({
       messageId,
@@ -1307,6 +1334,7 @@ ruleTester.run(RULE_NAME, rule, {
           ~~~~~~~~~~~~~~~~~~~
         }
       `,
+      data: { classDecoratorName: 'Pipe' },
     }),
     convertAnnotatedSourceToFailureCase({
       description:
@@ -1364,22 +1392,27 @@ ruleTester.run(RULE_NAME, rule, {
         {
           char: '~',
           messageId,
+          data: { classDecoratorName: 'Pipe' },
         },
         {
           char: '^',
           messageId,
+          data: { classDecoratorName: 'Pipe' },
         },
         {
           char: '#',
           messageId,
+          data: { classDecoratorName: 'Pipe' },
         },
         {
           char: '%',
           messageId,
+          data: { classDecoratorName: 'Pipe' },
         },
         {
           char: '¶',
           messageId,
+          data: { classDecoratorName: 'Pipe' },
         },
       ],
     }),
@@ -1404,6 +1437,7 @@ ruleTester.run(RULE_NAME, rule, {
           ~~~~~~~~
         }
       `,
+      data: { classDecoratorName: 'Pipe' },
     }),
   ],
 });

--- a/packages/eslint-plugin/tests/rules/contextual-lifecycle.test.ts
+++ b/packages/eslint-plugin/tests/rules/contextual-lifecycle.test.ts
@@ -12,8 +12,7 @@ import rule, { RULE_NAME } from '../../src/rules/contextual-lifecycle';
 const ruleTester = new RuleTester({
   parser: '@typescript-eslint/parser',
 });
-
-const messageId: MessageIds = 'contextuaLifecycle';
+const messageId: MessageIds = 'contextualLifecycle';
 
 ruleTester.run(RULE_NAME, rule, {
   valid: [

--- a/packages/eslint-plugin/tests/rules/contextual-lifecycle.test.ts
+++ b/packages/eslint-plugin/tests/rules/contextual-lifecycle.test.ts
@@ -148,7 +148,7 @@ ruleTester.run(RULE_NAME, rule, {
         }
       `,
       messageId,
-      data: { classDecoratorName: 'Component' },
+      data: { classDecoratorName: 'Component', methodName: 'ngDoBootstrap' },
     }),
     convertAnnotatedSourceToFailureCase({
       description:
@@ -161,7 +161,7 @@ ruleTester.run(RULE_NAME, rule, {
         }
       `,
       messageId,
-      data: { classDecoratorName: 'Directive' },
+      data: { classDecoratorName: 'Directive', methodName: 'ngDoBootstrap' },
     }),
     convertAnnotatedSourceToFailureCase({
       description:
@@ -174,7 +174,10 @@ ruleTester.run(RULE_NAME, rule, {
         }
       `,
       messageId,
-      data: { classDecoratorName: 'Injectable' },
+      data: {
+        classDecoratorName: 'Injectable',
+        methodName: 'ngAfterContentChecked',
+      },
     }),
     convertAnnotatedSourceToFailureCase({
       description:
@@ -187,7 +190,10 @@ ruleTester.run(RULE_NAME, rule, {
         }
       `,
       messageId,
-      data: { classDecoratorName: 'Injectable' },
+      data: {
+        classDecoratorName: 'Injectable',
+        methodName: 'ngAfterContentInit',
+      },
     }),
     convertAnnotatedSourceToFailureCase({
       description:
@@ -200,7 +206,7 @@ ruleTester.run(RULE_NAME, rule, {
         }
       `,
       messageId,
-      data: { classDecoratorName: 'Injectable' },
+      data: { classDecoratorName: 'Injectable', methodName: 'ngAfterViewInit' },
     }),
     convertAnnotatedSourceToFailureCase({
       description:
@@ -213,7 +219,7 @@ ruleTester.run(RULE_NAME, rule, {
         }
       `,
       messageId,
-      data: { classDecoratorName: 'Injectable' },
+      data: { classDecoratorName: 'Injectable', methodName: 'ngDoBootstrap' },
     }),
     convertAnnotatedSourceToFailureCase({
       description:
@@ -226,7 +232,7 @@ ruleTester.run(RULE_NAME, rule, {
         }
       `,
       messageId,
-      data: { classDecoratorName: 'Injectable' },
+      data: { classDecoratorName: 'Injectable', methodName: 'ngDoCheck' },
     }),
     convertAnnotatedSourceToFailureCase({
       description:
@@ -239,7 +245,7 @@ ruleTester.run(RULE_NAME, rule, {
         }
       `,
       messageId,
-      data: { classDecoratorName: 'Injectable' },
+      data: { classDecoratorName: 'Injectable', methodName: 'ngOnChanges' },
     }),
     convertAnnotatedSourceToFailureCase({
       description:
@@ -252,7 +258,7 @@ ruleTester.run(RULE_NAME, rule, {
         }
       `,
       messageId,
-      data: { classDecoratorName: 'Injectable' },
+      data: { classDecoratorName: 'Injectable', methodName: 'ngOnInit' },
     }),
     convertAnnotatedSourceToFailureCase({
       description:
@@ -265,7 +271,10 @@ ruleTester.run(RULE_NAME, rule, {
         }
       `,
       messageId,
-      data: { classDecoratorName: 'NgModule' },
+      data: {
+        classDecoratorName: 'NgModule',
+        methodName: 'ngAfterContentChecked',
+      },
     }),
     convertAnnotatedSourceToFailureCase({
       description:
@@ -278,7 +287,10 @@ ruleTester.run(RULE_NAME, rule, {
         }
       `,
       messageId,
-      data: { classDecoratorName: 'NgModule' },
+      data: {
+        classDecoratorName: 'NgModule',
+        methodName: 'ngAfterContentInit',
+      },
     }),
     convertAnnotatedSourceToFailureCase({
       description:
@@ -291,7 +303,10 @@ ruleTester.run(RULE_NAME, rule, {
         }
       `,
       messageId,
-      data: { classDecoratorName: 'NgModule' },
+      data: {
+        classDecoratorName: 'NgModule',
+        methodName: 'ngAfterViewChecked',
+      },
     }),
     convertAnnotatedSourceToFailureCase({
       description:
@@ -304,7 +319,7 @@ ruleTester.run(RULE_NAME, rule, {
         }
       `,
       messageId,
-      data: { classDecoratorName: 'NgModule' },
+      data: { classDecoratorName: 'NgModule', methodName: 'ngAfterViewInit' },
     }),
     convertAnnotatedSourceToFailureCase({
       description:
@@ -317,7 +332,7 @@ ruleTester.run(RULE_NAME, rule, {
         }
       `,
       messageId,
-      data: { classDecoratorName: 'NgModule' },
+      data: { classDecoratorName: 'NgModule', methodName: 'ngDoCheck' },
     }),
     convertAnnotatedSourceToFailureCase({
       description:
@@ -330,7 +345,7 @@ ruleTester.run(RULE_NAME, rule, {
         }
       `,
       messageId,
-      data: { classDecoratorName: 'NgModule' },
+      data: { classDecoratorName: 'NgModule', methodName: 'ngOnChanges' },
     }),
     convertAnnotatedSourceToFailureCase({
       description:
@@ -343,7 +358,7 @@ ruleTester.run(RULE_NAME, rule, {
         }
       `,
       messageId,
-      data: { classDecoratorName: 'NgModule' },
+      data: { classDecoratorName: 'NgModule', methodName: 'ngOnInit' },
     }),
     convertAnnotatedSourceToFailureCase({
       description:
@@ -356,7 +371,7 @@ ruleTester.run(RULE_NAME, rule, {
         }
       `,
       messageId,
-      data: { classDecoratorName: 'NgModule' },
+      data: { classDecoratorName: 'NgModule', methodName: 'ngOnDestroy' },
     }),
     convertAnnotatedSourceToFailureCase({
       description:
@@ -369,7 +384,7 @@ ruleTester.run(RULE_NAME, rule, {
         }
       `,
       messageId,
-      data: { classDecoratorName: 'Pipe' },
+      data: { classDecoratorName: 'Pipe', methodName: 'ngAfterContentChecked' },
     }),
     convertAnnotatedSourceToFailureCase({
       description:
@@ -382,7 +397,7 @@ ruleTester.run(RULE_NAME, rule, {
         }
       `,
       messageId,
-      data: { classDecoratorName: 'Pipe' },
+      data: { classDecoratorName: 'Pipe', methodName: 'ngAfterContentInit' },
     }),
     convertAnnotatedSourceToFailureCase({
       description:
@@ -395,7 +410,7 @@ ruleTester.run(RULE_NAME, rule, {
         }
       `,
       messageId,
-      data: { classDecoratorName: 'Pipe' },
+      data: { classDecoratorName: 'Pipe', methodName: 'ngAfterViewChecked' },
     }),
     convertAnnotatedSourceToFailureCase({
       description:
@@ -408,7 +423,7 @@ ruleTester.run(RULE_NAME, rule, {
         }
       `,
       messageId,
-      data: { classDecoratorName: 'Pipe' },
+      data: { classDecoratorName: 'Pipe', methodName: 'ngAfterViewInit' },
     }),
     convertAnnotatedSourceToFailureCase({
       description:
@@ -421,7 +436,7 @@ ruleTester.run(RULE_NAME, rule, {
         }
       `,
       messageId,
-      data: { classDecoratorName: 'Pipe' },
+      data: { classDecoratorName: 'Pipe', methodName: 'ngDoBootstrap' },
     }),
     convertAnnotatedSourceToFailureCase({
       description:
@@ -434,7 +449,7 @@ ruleTester.run(RULE_NAME, rule, {
         }
       `,
       messageId,
-      data: { classDecoratorName: 'Pipe' },
+      data: { classDecoratorName: 'Pipe', methodName: 'ngDoCheck' },
     }),
     convertAnnotatedSourceToFailureCase({
       description:
@@ -447,7 +462,7 @@ ruleTester.run(RULE_NAME, rule, {
         }
       `,
       messageId,
-      data: { classDecoratorName: 'Pipe' },
+      data: { classDecoratorName: 'Pipe', methodName: 'ngOnChanges' },
     }),
     convertAnnotatedSourceToFailureCase({
       description:
@@ -460,7 +475,7 @@ ruleTester.run(RULE_NAME, rule, {
         }
       `,
       messageId,
-      data: { classDecoratorName: 'Pipe' },
+      data: { classDecoratorName: 'Pipe', methodName: 'ngOnInit' },
     }),
     convertAnnotatedSourceToFailureCase({
       description:
@@ -473,7 +488,7 @@ ruleTester.run(RULE_NAME, rule, {
           ngDoCheck() {}
           ~~~~~~~~~
         }
-        
+ 
         @Directive()
         class TestDirective implements OnInit {
           ngOnInit() {
@@ -482,7 +497,7 @@ ruleTester.run(RULE_NAME, rule, {
         }
       `,
       messageId,
-      data: { classDecoratorName: 'Pipe' },
+      data: { classDecoratorName: 'Pipe', methodName: 'ngDoCheck' },
     }),
   ],
 });

--- a/packages/eslint-plugin/tests/rules/contextual-lifecycle.test.ts
+++ b/packages/eslint-plugin/tests/rules/contextual-lifecycle.test.ts
@@ -148,6 +148,7 @@ ruleTester.run(RULE_NAME, rule, {
         }
       `,
       messageId,
+      data: { classDecoratorName: 'Component' },
     }),
     convertAnnotatedSourceToFailureCase({
       description:
@@ -160,6 +161,7 @@ ruleTester.run(RULE_NAME, rule, {
         }
       `,
       messageId,
+      data: { classDecoratorName: 'Directive' },
     }),
     convertAnnotatedSourceToFailureCase({
       description:
@@ -167,11 +169,12 @@ ruleTester.run(RULE_NAME, rule, {
       annotatedSource: `
         @Injectable()
         class Test {
-            ngAfterContentChecked() { console.log('AfterContentChecked'); }
-            ~~~~~~~~~~~~~~~~~~~~~
+          ngAfterContentChecked() { console.log('AfterContentChecked'); }
+          ~~~~~~~~~~~~~~~~~~~~~
         }
       `,
       messageId,
+      data: { classDecoratorName: 'Injectable' },
     }),
     convertAnnotatedSourceToFailureCase({
       description:
@@ -184,6 +187,7 @@ ruleTester.run(RULE_NAME, rule, {
         }
       `,
       messageId,
+      data: { classDecoratorName: 'Injectable' },
     }),
     convertAnnotatedSourceToFailureCase({
       description:
@@ -196,6 +200,7 @@ ruleTester.run(RULE_NAME, rule, {
         }
       `,
       messageId,
+      data: { classDecoratorName: 'Injectable' },
     }),
     convertAnnotatedSourceToFailureCase({
       description:
@@ -208,6 +213,7 @@ ruleTester.run(RULE_NAME, rule, {
         }
       `,
       messageId,
+      data: { classDecoratorName: 'Injectable' },
     }),
     convertAnnotatedSourceToFailureCase({
       description:
@@ -220,6 +226,7 @@ ruleTester.run(RULE_NAME, rule, {
         }
       `,
       messageId,
+      data: { classDecoratorName: 'Injectable' },
     }),
     convertAnnotatedSourceToFailureCase({
       description:
@@ -232,6 +239,7 @@ ruleTester.run(RULE_NAME, rule, {
         }
       `,
       messageId,
+      data: { classDecoratorName: 'Injectable' },
     }),
     convertAnnotatedSourceToFailureCase({
       description:
@@ -244,6 +252,7 @@ ruleTester.run(RULE_NAME, rule, {
         }
       `,
       messageId,
+      data: { classDecoratorName: 'Injectable' },
     }),
     convertAnnotatedSourceToFailureCase({
       description:
@@ -256,6 +265,7 @@ ruleTester.run(RULE_NAME, rule, {
         }
       `,
       messageId,
+      data: { classDecoratorName: 'NgModule' },
     }),
     convertAnnotatedSourceToFailureCase({
       description:
@@ -268,6 +278,7 @@ ruleTester.run(RULE_NAME, rule, {
         }
       `,
       messageId,
+      data: { classDecoratorName: 'NgModule' },
     }),
     convertAnnotatedSourceToFailureCase({
       description:
@@ -280,6 +291,7 @@ ruleTester.run(RULE_NAME, rule, {
         }
       `,
       messageId,
+      data: { classDecoratorName: 'NgModule' },
     }),
     convertAnnotatedSourceToFailureCase({
       description:
@@ -292,6 +304,7 @@ ruleTester.run(RULE_NAME, rule, {
         }
       `,
       messageId,
+      data: { classDecoratorName: 'NgModule' },
     }),
     convertAnnotatedSourceToFailureCase({
       description:
@@ -304,6 +317,7 @@ ruleTester.run(RULE_NAME, rule, {
         }
       `,
       messageId,
+      data: { classDecoratorName: 'NgModule' },
     }),
     convertAnnotatedSourceToFailureCase({
       description:
@@ -316,6 +330,7 @@ ruleTester.run(RULE_NAME, rule, {
         }
       `,
       messageId,
+      data: { classDecoratorName: 'NgModule' },
     }),
     convertAnnotatedSourceToFailureCase({
       description:
@@ -328,6 +343,7 @@ ruleTester.run(RULE_NAME, rule, {
         }
       `,
       messageId,
+      data: { classDecoratorName: 'NgModule' },
     }),
     convertAnnotatedSourceToFailureCase({
       description:
@@ -340,6 +356,7 @@ ruleTester.run(RULE_NAME, rule, {
         }
       `,
       messageId,
+      data: { classDecoratorName: 'NgModule' },
     }),
     convertAnnotatedSourceToFailureCase({
       description:
@@ -352,6 +369,7 @@ ruleTester.run(RULE_NAME, rule, {
         }
       `,
       messageId,
+      data: { classDecoratorName: 'Pipe' },
     }),
     convertAnnotatedSourceToFailureCase({
       description:
@@ -364,6 +382,7 @@ ruleTester.run(RULE_NAME, rule, {
         }
       `,
       messageId,
+      data: { classDecoratorName: 'Pipe' },
     }),
     convertAnnotatedSourceToFailureCase({
       description:
@@ -376,6 +395,7 @@ ruleTester.run(RULE_NAME, rule, {
         }
       `,
       messageId,
+      data: { classDecoratorName: 'Pipe' },
     }),
     convertAnnotatedSourceToFailureCase({
       description:
@@ -388,6 +408,7 @@ ruleTester.run(RULE_NAME, rule, {
         }
       `,
       messageId,
+      data: { classDecoratorName: 'Pipe' },
     }),
     convertAnnotatedSourceToFailureCase({
       description:
@@ -400,6 +421,7 @@ ruleTester.run(RULE_NAME, rule, {
         }
       `,
       messageId,
+      data: { classDecoratorName: 'Pipe' },
     }),
     convertAnnotatedSourceToFailureCase({
       description:
@@ -412,6 +434,7 @@ ruleTester.run(RULE_NAME, rule, {
         }
       `,
       messageId,
+      data: { classDecoratorName: 'Pipe' },
     }),
     convertAnnotatedSourceToFailureCase({
       description:
@@ -424,6 +447,7 @@ ruleTester.run(RULE_NAME, rule, {
         }
       `,
       messageId,
+      data: { classDecoratorName: 'Pipe' },
     }),
     convertAnnotatedSourceToFailureCase({
       description:
@@ -436,6 +460,7 @@ ruleTester.run(RULE_NAME, rule, {
         }
       `,
       messageId,
+      data: { classDecoratorName: 'Pipe' },
     }),
     convertAnnotatedSourceToFailureCase({
       description:
@@ -457,6 +482,7 @@ ruleTester.run(RULE_NAME, rule, {
         }
       `,
       messageId,
+      data: { classDecoratorName: 'Pipe' },
     }),
   ],
 });

--- a/packages/eslint-plugin/tests/rules/directive-class-suffix.test.ts
+++ b/packages/eslint-plugin/tests/rules/directive-class-suffix.test.ts
@@ -12,7 +12,6 @@ import rule, { RULE_NAME } from '../../src/rules/directive-class-suffix';
 const ruleTester = new RuleTester({
   parser: '@typescript-eslint/parser',
 });
-
 const messageId: MessageIds = 'directiveClassSuffix';
 
 ruleTester.run(RULE_NAME, rule, {
@@ -94,7 +93,7 @@ ruleTester.run(RULE_NAME, rule, {
               ~~~~
       `,
       messageId,
-      data: { className: 'Test', suffixes: ['"Directive"'] },
+      data: { suffixes: '"Directive"' },
     }),
     convertAnnotatedSourceToFailureCase({
       description:
@@ -107,10 +106,7 @@ ruleTester.run(RULE_NAME, rule, {
               ~~~~~~~~~~~~~~~~~
       `,
       messageId,
-      data: {
-        className: 'TestDirectivePage',
-        suffixes: ['"Directive"', '"Validator"'].join(' or '),
-      },
+      data: { suffixes: '"Directive" or "Validator"' },
     }),
     convertAnnotatedSourceToFailureCase({
       description:
@@ -123,8 +119,8 @@ ruleTester.run(RULE_NAME, rule, {
               ~~~~~~~~~~~~~~~~~
       `,
       messageId,
-      data: { className: 'TestPageDirective', suffixes: ['"Page"'] },
       options: [{ suffixes: ['Page'] }],
+      data: { suffixes: '"Page"' },
     }),
   ],
 });

--- a/packages/eslint-plugin/tests/rules/directive-selector.test.ts
+++ b/packages/eslint-plugin/tests/rules/directive-selector.test.ts
@@ -12,7 +12,6 @@ import rule, { RULE_NAME } from '../../src/rules/directive-selector';
 const ruleTester = new RuleTester({
   parser: '@typescript-eslint/parser',
 });
-
 const messageIdPrefixFailure: MessageIds = 'prefixFailure';
 const messageIdStyleFailure: MessageIds = 'styleFailure';
 const messageIdTypeFailure: MessageIds = 'typeFailure';
@@ -195,41 +194,44 @@ ruleTester.run(RULE_NAME, rule, {
       description: `it should fail if a selector is not prefixed by a valid option`,
       annotatedSource: `
         @Directive({
-            selector: 'app-foo-bar'
-                      ~~~~~~~~~~~~~
-          })
-          class Test {}
+          selector: 'app-foo-bar'
+                    ~~~~~~~~~~~~~
+        })
+        class Test {}
       `,
       messageId: messageIdPrefixFailure,
       options: [{ type: 'element', prefix: 'bar', style: 'kebab-case' }],
+      data: { prefix: '"bar"' },
     }),
     convertAnnotatedSourceToFailureCase({
       description: `it should fail if a selector is not prefixed by any valid option`,
       annotatedSource: `
         @Directive({
-            selector: '[app-foo-bar]'
-                      ~~~~~~~~~~~~~~~
-          })
+          selector: '[app-foo-bar]'
+                    ~~~~~~~~~~~~~~~
+        })
         class Test {}
       `,
       messageId: messageIdPrefixFailure,
       options: [
         { type: 'attribute', prefix: ['cd', 'ng'], style: 'kebab-case' },
       ],
+      data: { prefix: '"cd" or "ng"' },
     }),
     convertAnnotatedSourceToFailureCase({
       description: `it should fail if a complex selector is not prefixed by any valid option`,
       annotatedSource: `
         @Directive({
-            selector: 'app-foo-bar[baz].app'
-                      ~~~~~~~~~~~~~~~~~~~~~~
-          })
-          class Test {}
+          selector: 'app-foo-bar[baz].app'
+                    ~~~~~~~~~~~~~~~~~~~~~~
+        })
+        class Test {}
       `,
       messageId: messageIdPrefixFailure,
       options: [
         { type: 'element', prefix: ['foo', 'cd', 'ng'], style: 'kebab-case' },
       ],
+      data: { prefix: '"foo", "cd" or "ng"' },
     }),
     convertAnnotatedSourceToFailureCase({
       description: `it should fail if a selector is not camelCased`,
@@ -242,56 +244,61 @@ ruleTester.run(RULE_NAME, rule, {
       `,
       messageId: messageIdStyleFailure,
       options: [{ type: 'attribute', prefix: 'app', style: 'camelCase' }],
+      data: { style: 'camelCase' },
     }),
     convertAnnotatedSourceToFailureCase({
       description: `it should fail if a selector is not kebab-cased`,
       annotatedSource: `
         @Directive({
-              selector: 'appFooBar'
-                        ~~~~~~~~~~~
+          selector: 'appFooBar'
+                    ~~~~~~~~~~~
         })
         class Test {}
       `,
       messageId: messageIdStyleFailure,
       options: [{ type: 'element', prefix: 'app', style: 'kebab-case' }],
+      data: { style: 'kebab-case' },
     }),
     convertAnnotatedSourceToFailureCase({
       description: `it should fail if a selector uses kebab-case style, but no dash`,
       annotatedSource: `
         @Directive({
-           selector: 'app'
-                     ~~~~~
+          selector: 'app'
+                    ~~~~~
         })
         class Test {}
       `,
       messageId: messageIdStyleFailure,
       options: [{ type: 'element', prefix: 'app', style: 'kebab-case' }],
+      data: { style: 'kebab-case' },
     }),
     convertAnnotatedSourceToFailureCase({
       description: `it should fail if a selector is not used as an attribute`,
       annotatedSource: `
-      @Directive({
-        selector: \`app-foo-bar\`
-                  ~~~~~~~~~~~~~
-      })
-      class Test {}
+        @Directive({
+          selector: \`app-foo-bar\`
+                    ~~~~~~~~~~~~~
+        })
+        class Test {}
       `,
       messageId: messageIdTypeFailure,
       options: [
         { type: 'attribute', prefix: ['app', 'ng'], style: 'kebab-case' },
       ],
+      data: { type: 'attribute' },
     }),
     convertAnnotatedSourceToFailureCase({
       description: `it should fail if a selector is not used as an element`,
       annotatedSource: `
-      @Directive({
-        selector: '[appFooBar]'
-                  ~~~~~~~~~~~~~
-      })
-      class Test {}
+        @Directive({
+          selector: '[appFooBar]'
+                    ~~~~~~~~~~~~~
+        })
+        class Test {}
       `,
       messageId: messageIdTypeFailure,
       options: [{ type: 'element', prefix: ['app', 'ng'], style: 'camelCase' }],
+      data: { type: 'element' },
     }),
   ],
 });

--- a/packages/eslint-plugin/tests/rules/no-input-prefix.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-input-prefix.test.ts
@@ -15,7 +15,6 @@ const ruleTester = new RuleTester({
     sourceType: 'module',
   },
 });
-
 const messageId: MessageIds = 'noInputPrefix';
 
 ruleTester.run(RULE_NAME, rule, {
@@ -28,11 +27,7 @@ ruleTester.run(RULE_NAME, rule, {
           @Input() label: string;
         }
       `,
-      options: [
-        {
-          prefixes: ['is'],
-        },
-      ],
+      options: [{ prefixes: ['is'] }],
     },
     {
       code: `
@@ -42,11 +37,7 @@ ruleTester.run(RULE_NAME, rule, {
           @Input() issueName: string;
         }
       `,
-      options: [
-        {
-          prefixes: ['is'],
-        },
-      ],
+      options: [{ prefixes: ['is'] }],
     },
     {
       code: `
@@ -56,11 +47,7 @@ ruleTester.run(RULE_NAME, rule, {
           @Input() isEnabled: boolean;
         }
       `,
-      options: [
-        {
-          prefixes: ['should'],
-        },
-      ],
+      options: [{ prefixes: ['should'] }],
     },
     {
       code: `
@@ -70,11 +57,7 @@ ruleTester.run(RULE_NAME, rule, {
           @Output() isEnabled: boolean;
         }
       `,
-      options: [
-        {
-          prefixes: ['is'],
-        },
-      ],
+      options: [{ prefixes: ['is'] }],
     },
     // should succeed when an Input decorator is not imported from '@angular/core'
     {
@@ -84,11 +67,7 @@ ruleTester.run(RULE_NAME, rule, {
           @Input() isEnabled: boolean;
         }
       `,
-      options: [
-        {
-          prefixes: ['is'],
-        },
-      ],
+      options: [{ prefixes: ['is'] }],
     },
   ],
   invalid: [
@@ -104,11 +83,8 @@ ruleTester.run(RULE_NAME, rule, {
         }
       `,
       messageId,
-      options: [
-        {
-          prefixes: ['is', 'should'],
-        },
-      ],
+      options: [{ prefixes: ['is', 'should'] }],
+      data: { prefixes: '"is" or "should"' },
     }),
     convertAnnotatedSourceToFailureCase({
       description:
@@ -122,11 +98,8 @@ ruleTester.run(RULE_NAME, rule, {
         }
       `,
       messageId,
-      options: [
-        {
-          prefixes: ['is', 'should'],
-        },
-      ],
+      options: [{ prefixes: ['is', 'should'] }],
+      data: { prefixes: '"is" or "should"' },
     }),
     convertAnnotatedSourceToFailureCase({
       description:
@@ -140,11 +113,8 @@ ruleTester.run(RULE_NAME, rule, {
         }
       `,
       messageId,
-      options: [
-        {
-          prefixes: ['is', 'should'],
-        },
-      ],
+      options: [{ prefixes: ['is', 'should'] }],
+      data: { prefixes: '"is" or "should"' },
     }),
   ],
 });

--- a/packages/eslint-plugin/tests/rules/no-input-rename.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-input-rename.test.ts
@@ -15,7 +15,6 @@ const ruleTester = new RuleTester({
     sourceType: 'module',
   },
 });
-
 const messageId: MessageIds = 'noInputRename';
 
 ruleTester.run(RULE_NAME, rule, {

--- a/packages/eslint-plugin/tests/rules/pipe-prefix.test.ts
+++ b/packages/eslint-plugin/tests/rules/pipe-prefix.test.ts
@@ -12,7 +12,6 @@ import rule, { RULE_NAME } from '../../src/rules/pipe-prefix';
 const ruleTester = new RuleTester({
   parser: '@typescript-eslint/parser',
 });
-
 const messageId: MessageIds = 'pipePrefix';
 
 ruleTester.run(RULE_NAME, rule, {
@@ -23,11 +22,7 @@ ruleTester.run(RULE_NAME, rule, {
         @Pipe
         class Test {}
       `,
-      options: [
-        {
-          prefixes: ['ng'],
-        },
-      ],
+      options: [{ prefixes: ['ng'] }],
     },
     {
       // should not fail when @Pipe does not have content
@@ -35,11 +30,7 @@ ruleTester.run(RULE_NAME, rule, {
         @Pipe({})
         class Test {}
       `,
-      options: [
-        {
-          prefixes: ['ng'],
-        },
-      ],
+      options: [{ prefixes: ['ng'] }],
     },
     {
       // should ignore the rule when the name is a variable
@@ -54,11 +45,7 @@ ruleTester.run(RULE_NAME, rule, {
           return MockPipe;
         }
       `,
-      options: [
-        {
-          prefixes: ['ng'],
-        },
-      ],
+      options: [{ prefixes: ['ng'] }],
     },
     {
       // should ignore the rule when the rule option is blank
@@ -68,11 +55,7 @@ ruleTester.run(RULE_NAME, rule, {
         })
         class Test {}
       `,
-      options: [
-        {
-          prefixes: [],
-        },
-      ],
+      options: [{ prefixes: [] }],
     },
     {
       // should succeed with prefix ng in @Pipe
@@ -82,11 +65,7 @@ ruleTester.run(RULE_NAME, rule, {
         })
         class Test {}
       `,
-      options: [
-        {
-          prefixes: ['ng'],
-        },
-      ],
+      options: [{ prefixes: ['ng'] }],
     },
     {
       // should succeed with multiple prefixes in @Pipe
@@ -96,11 +75,7 @@ ruleTester.run(RULE_NAME, rule, {
         })
         class Test {}
       `,
-      options: [
-        {
-          prefixes: ['ng', 'sg', 'mg'],
-        },
-      ],
+      options: [{ prefixes: ['ng', 'sg', 'mg'] }],
     },
     {
       // should succeed with multiple prefixes in @Pipe
@@ -110,22 +85,14 @@ ruleTester.run(RULE_NAME, rule, {
         })
         class Test {}
       `,
-      options: [
-        {
-          prefixes: ['ng', 'sg', 'mg'],
-        },
-      ],
+      options: [{ prefixes: ['ng', 'sg', 'mg'] }],
     },
     {
       // should succeed when the class is not a Pipe
       code: `
         class Test {}
       `,
-      options: [
-        {
-          prefixes: ['ng'],
-        },
-      ],
+      options: [{ prefixes: ['ng'] }],
     },
     {
       // should do nothing if the name of the pipe is not a literal
@@ -136,11 +103,7 @@ ruleTester.run(RULE_NAME, rule, {
         })
         class Test {}
       `,
-      options: [
-        {
-          prefixes: ['ng'],
-        },
-      ],
+      options: [{ prefixes: ['ng'] }],
     },
   ],
   invalid: [
@@ -154,11 +117,8 @@ ruleTester.run(RULE_NAME, rule, {
         class Test {}
       `,
       messageId,
-      options: [
-        {
-          prefixes: ['ng'],
-        },
-      ],
+      options: [{ prefixes: ['ng'] }],
+      data: { prefixes: '"ng"' },
     }),
     convertAnnotatedSourceToFailureCase({
       description:
@@ -171,11 +131,8 @@ ruleTester.run(RULE_NAME, rule, {
         class Test {}
       `,
       messageId,
-      options: [
-        {
-          prefixes: ['ng', 'mg', 'sg'],
-        },
-      ],
+      options: [{ prefixes: ['ng', 'mg', 'sg'] }],
+      data: { prefixes: '"ng", "mg" or "sg"' },
     }),
   ],
 });

--- a/packages/eslint-plugin/tests/rules/use-component-selector.test.ts
+++ b/packages/eslint-plugin/tests/rules/use-component-selector.test.ts
@@ -12,7 +12,6 @@ import rule, { RULE_NAME } from '../../src/rules/use-component-selector';
 const ruleTester = new RuleTester({
   parser: '@typescript-eslint/parser',
 });
-
 const messageId: MessageIds = 'useComponentSelector';
 
 ruleTester.run(RULE_NAME, rule, {
@@ -33,9 +32,6 @@ ruleTester.run(RULE_NAME, rule, {
         class Test {}
       `,
       messageId,
-      data: {
-        className: 'Test',
-      },
     }),
     convertAnnotatedSourceToFailureCase({
       description: 'it should fail when selector is not given in @Component',
@@ -45,9 +41,6 @@ ruleTester.run(RULE_NAME, rule, {
         class Test {}
       `,
       messageId,
-      data: {
-        className: 'Test',
-      },
     }),
     convertAnnotatedSourceToFailureCase({
       description: 'it should fail when selector is empty in @Component',
@@ -60,9 +53,6 @@ ruleTester.run(RULE_NAME, rule, {
         class Test {}
       `,
       messageId,
-      data: {
-        className: 'Test',
-      },
     }),
     convertAnnotatedSourceToFailureCase({
       description: 'it should fail when selector equals 0 in @Component',
@@ -75,9 +65,6 @@ ruleTester.run(RULE_NAME, rule, {
         class Test {}
       `,
       messageId,
-      data: {
-        className: 'Test',
-      },
     }),
     convertAnnotatedSourceToFailureCase({
       description: 'it should fail when selector equals null in @Component',
@@ -90,9 +77,6 @@ ruleTester.run(RULE_NAME, rule, {
         class Test {}
       `,
       messageId,
-      data: {
-        className: 'Test',
-      },
     }),
   ],
 });

--- a/packages/eslint-plugin/tests/rules/use-lifecycle-interface.test.ts
+++ b/packages/eslint-plugin/tests/rules/use-lifecycle-interface.test.ts
@@ -16,7 +16,6 @@ import {
 const ruleTester = new RuleTester({
   parser: '@typescript-eslint/parser',
 });
-
 const messageId: MessageIds = 'useLifecycleInterface';
 
 ruleTester.run(RULE_NAME, rule, {
@@ -108,9 +107,30 @@ ruleTester.run(RULE_NAME, rule, {
         }
       `,
       messages: [
-        { char: '~', messageId },
-        { char: '^', messageId },
-        { char: '#', messageId },
+        {
+          char: '~',
+          messageId,
+          data: {
+            interfaceName: AngularLifecycleInterfaces.DoBootstrap,
+            methodName: AngularLifecycleMethods.ngDoBootstrap,
+          },
+        },
+        {
+          char: '^',
+          messageId,
+          data: {
+            interfaceName: AngularLifecycleInterfaces.OnInit,
+            methodName: AngularLifecycleMethods.ngOnInit,
+          },
+        },
+        {
+          char: '#',
+          messageId,
+          data: {
+            interfaceName: AngularLifecycleInterfaces.OnDestroy,
+            methodName: AngularLifecycleMethods.ngOnDestroy,
+          },
+        },
       ],
     }),
     convertAnnotatedSourceToFailureCase({


### PR DESCRIPTION
With this PR we can now test `data` and `suggestions` individually for each error. Now, the test fail if we try to test something that uses `data` properties without passing `data`.

In addition, it improves the types, making it mandatory and mutually exclusive to pass one of the two properties: `messageId` or `messages`, so there is no longer a need to throw a compile-time error.