### PR TITLE
refactor: move utility functions to utils package

### DIFF
--- a/packages/eslint-plugin/src/rules/contextual-decorator.ts
+++ b/packages/eslint-plugin/src/rules/contextual-decorator.ts
@@ -1,13 +1,14 @@
 import type { TSESLint, TSESTree } from '@typescript-eslint/experimental-utils';
-
+import { createESLintRule } from '../utils/create-eslint-rule';
 import type { AngularClassDecoratorKeys } from '../utils/utils';
 import {
-  isAngularInnerClassDecorator,
   ANGULAR_CLASS_DECORATOR_MAPPER,
   getAngularClassDecorator,
   getDecoratorName,
+  getNearestNodeFrom,
+  isAngularInnerClassDecorator,
+  isClassDeclaration,
 } from '../utils/utils';
-import { createESLintRule } from '../utils/create-eslint-rule';
 
 type Options = [];
 export type MessageIds = 'contextualDecorator';
@@ -18,8 +19,7 @@ export default createESLintRule<Options, MessageIds>({
   meta: {
     type: 'suggestion',
     docs: {
-      description:
-        'Ensures that classes use contextual decorators in its body.',
+      description: 'Ensures that classes use contextual decorators in its body',
       category: 'Best Practices',
       recommended: false,
     },
@@ -55,7 +55,7 @@ function validateNode(
     return;
   }
 
-  const classDeclaration = lookupTheClassDeclaration(node);
+  const classDeclaration = getNearestNodeFrom(node, isClassDeclaration);
 
   if (!classDeclaration) {
     return;
@@ -70,20 +70,6 @@ function validateNode(
   for (const decorator of node.decorators) {
     validateDecorator(context, decorator, classDecoratorName);
   }
-}
-
-function lookupTheClassDeclaration(
-  node: TSESTree.Node,
-): TSESTree.ClassDeclaration | null {
-  while (node.parent) {
-    if (node.type === 'ClassDeclaration') {
-      return node;
-    }
-
-    node = node.parent;
-  }
-
-  return null;
 }
 
 function validateDecorator(
@@ -101,7 +87,7 @@ function validateDecorator(
     classDecoratorName,
   );
 
-  if (!allowedDecorators || allowedDecorators.has(decoratorName)) {
+  if (allowedDecorators?.has(decoratorName)) {
     return;
   }
 

--- a/packages/eslint-plugin/src/rules/use-pipe-transform-interface.ts
+++ b/packages/eslint-plugin/src/rules/use-pipe-transform-interface.ts
@@ -1,13 +1,16 @@
-import type { TSESTree, TSESLint } from '@typescript-eslint/experimental-utils';
+import type { TSESTree } from '@typescript-eslint/experimental-utils';
 import { createESLintRule } from '../utils/create-eslint-rule';
 import { PIPE_CLASS_DECORATOR } from '../utils/selectors';
-import { getDeclaredInterfaceName, isImportDeclaration } from '../utils/utils';
+import {
+  getDeclaredInterfaceName,
+  getImplementsSchemaFixer,
+  getImportAddFix,
+} from '../utils/utils';
 
 type Options = [];
 export type MessageIds = 'usePipeTransformInterface';
 export const RULE_NAME = 'use-pipe-transform-interface';
 const PIPE_TRANSFORM = 'PipeTransform';
-const ANGULAR_CORE_MODULE_PATH = '@angular/core';
 
 export default createESLintRule<Options, MessageIds>({
   name: RULE_NAME,
@@ -32,84 +35,30 @@ export default createESLintRule<Options, MessageIds>({
       }: TSESTree.Decorator & { parent: TSESTree.ClassDeclaration }) {
         if (getDeclaredInterfaceName(classDeclaration, PIPE_TRANSFORM)) return;
 
-        const {
-          errorNode,
-          implementsNodeReplace,
-          implementsTextReplace,
-        } = getErrorSchemaOptions(classDeclaration);
-
         context.report({
-          node: errorNode,
+          node: classDeclaration.id ?? classDeclaration,
           messageId: 'usePipeTransformInterface',
-          fix: (fixer) => [
-            getImportFix(classDeclaration, fixer),
-            fixer.insertTextAfter(implementsNodeReplace, implementsTextReplace),
-          ],
+          fix: (fixer) => {
+            const {
+              implementsNodeReplace,
+              implementsTextReplace,
+            } = getImplementsSchemaFixer(classDeclaration, PIPE_TRANSFORM);
+
+            return [
+              getImportAddFix(
+                classDeclaration,
+                '@angular/core',
+                PIPE_TRANSFORM,
+                fixer,
+              ),
+              fixer.insertTextAfter(
+                implementsNodeReplace,
+                implementsTextReplace,
+              ),
+            ];
+          },
         });
       },
     };
   },
 });
-
-function getErrorSchemaOptions(classDeclaration: TSESTree.ClassDeclaration) {
-  const classDeclarationIdentifier = classDeclaration.id as TSESTree.Identifier;
-  const [
-    errorNode,
-    implementsNodeReplace,
-    implementsTextReplace,
-  ] = classDeclaration.implements
-    ? [
-        classDeclarationIdentifier,
-        getLast(classDeclaration.implements),
-        `, ${PIPE_TRANSFORM}`,
-      ]
-    : [
-        classDeclarationIdentifier,
-        classDeclarationIdentifier,
-        ` implements ${PIPE_TRANSFORM}`,
-      ];
-
-  return { errorNode, implementsNodeReplace, implementsTextReplace } as const;
-}
-
-function getImportDeclaration(
-  node: TSESTree.ClassDeclaration,
-  module: string,
-): TSESTree.ImportDeclaration | undefined {
-  let parentNode: TSESTree.Node | undefined = node;
-
-  while ((parentNode = parentNode.parent)) {
-    if (parentNode.type !== 'Program') continue;
-
-    return parentNode.body.find(
-      (node) => isImportDeclaration(node) && node.source.value === module,
-    ) as TSESTree.ImportDeclaration | undefined;
-  }
-
-  return parentNode;
-}
-
-function getImportFix(
-  node: TSESTree.ClassDeclaration,
-  fixer: TSESLint.RuleFixer,
-) {
-  const importDeclaration = getImportDeclaration(
-    node,
-    ANGULAR_CORE_MODULE_PATH,
-  );
-
-  if (!importDeclaration?.specifiers.length) {
-    return fixer.insertTextAfterRange(
-      [0, 0],
-      `import { ${PIPE_TRANSFORM} } from '${ANGULAR_CORE_MODULE_PATH}';\n`,
-    );
-  }
-
-  const lastImportSpecifier = getLast(importDeclaration.specifiers);
-
-  return fixer.insertTextAfter(lastImportSpecifier, `, ${PIPE_TRANSFORM}`);
-}
-
-function getLast<T extends readonly unknown[]>(items: T): T[0] {
-  return items.slice(-1)[0];
-}

--- a/packages/eslint-plugin/tests/rules/use-pipe-transform-interface.test.ts
+++ b/packages/eslint-plugin/tests/rules/use-pipe-transform-interface.test.ts
@@ -12,7 +12,6 @@ import rule, { RULE_NAME } from '../../src/rules/use-pipe-transform-interface';
 const ruleTester = new RuleTester({
   parser: '@typescript-eslint/parser',
 });
-
 const messageId: MessageIds = 'usePipeTransformInterface';
 
 ruleTester.run(RULE_NAME, rule, {
@@ -90,6 +89,7 @@ ruleTester.run(RULE_NAME, rule, {
       description:
         'it should fail if a Pipe implements interfaces, but not the PipeTransform',
       annotatedSource: `
+        import type { OnInit } from '@angular/core';
         import { Pipe } from '@angular/core';
 
         @OtherDecorator() @Pipe({ name: 'test' })
@@ -100,7 +100,8 @@ ruleTester.run(RULE_NAME, rule, {
       `,
       messageId,
       annotatedOutput: `
-        import { Pipe, PipeTransform } from '@angular/core';
+        import type { OnInit, PipeTransform } from '@angular/core';
+        import { Pipe } from '@angular/core';
 
         @OtherDecorator() @Pipe({ name: 'test' })
         export class TestPipe implements AnInterface, AnotherInterface, PipeTransform {


### PR DESCRIPTION
1st commit: Moves some utility functions from `contextual-decorator` and `use-pipe-transform-interface` to `utils/ ` package so we can reuse it for `imports` and `implements`;
2nd commit: A simple test addition to ensure we target the correct import in fix when there are multiple imports from the same source.