### PR TITLE
refactor(schematics): suppress lint warnings

### DIFF
--- a/packages/schematics/src/convert-tslint-to-eslint/convert-to-eslint-config.ts
+++ b/packages/schematics/src/convert-tslint-to-eslint/convert-to-eslint-config.ts
@@ -172,8 +172,7 @@ export function convertTSLintDisableCommentsForProject(
       if (!filePath.endsWith('.ts')) {
         return;
       }
-      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-      const fileContent = host.read(filePath)!.toString('utf-8');
+      const fileContent = (host.read(filePath) as Buffer).toString('utf-8');
       // Avoid updating files if we don't have to
       if (!likelyContainsTSLintComment(fileContent)) {
         return;

--- a/packages/schematics/src/convert-tslint-to-eslint/index.ts
+++ b/packages/schematics/src/convert-tslint-to-eslint/index.ts
@@ -30,6 +30,7 @@ import {
   updateObjPropAndRemoveDuplication,
 } from './utils';
 
+/* eslint-disable @typescript-eslint/no-explicit-any */
 const eslintPluginConfigBaseOriginal: any = eslintPlugin.configs.base;
 const eslintPluginConfigNgCliCompatOriginal: any =
   eslintPlugin.configs['ng-cli-compat'];
@@ -37,6 +38,7 @@ const eslintPluginConfigNgCliCompatFormattingAddOnOriginal: any =
   eslintPlugin.configs['ng-cli-compat--formatting-add-on'];
 const eslintPluginTemplateConfigRecommendedOriginal: any =
   eslintPluginTemplate.configs.recommended;
+/* eslint-enable @typescript-eslint/no-explicit-any */
 
 export default function convert(schema: Schema): Rule {
   return (tree: Tree) => {

--- a/packages/schematics/src/convert-tslint-to-eslint/utils.ts
+++ b/packages/schematics/src/convert-tslint-to-eslint/utils.ts
@@ -4,7 +4,9 @@ import * as assert from 'assert';
 import { sortObjectByKeys } from '../utils';
 
 export function updateArrPropAndRemoveDuplication(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   json: Record<string, any>,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   configBeingExtended: Record<string, any>,
   arrPropName: string,
   deleteIfUltimatelyEmpty: boolean,
@@ -21,7 +23,9 @@ export function updateArrPropAndRemoveDuplication(
 }
 
 export function updateObjPropAndRemoveDuplication(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   json: Record<string, any>,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   configBeingExtended: Record<string, any>,
   objPropName: string,
   deleteIfUltimatelyEmpty: boolean,
@@ -59,8 +63,9 @@ export function ensureESLintPluginsAreInstalled(
       );
     }
 
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-    const projectPackageJSON = host.read('package.json')!.toString('utf-8');
+    const projectPackageJSON = (host.read('package.json') as Buffer).toString(
+      'utf-8',
+    );
     const json = JSON.parse(projectPackageJSON);
     json.devDependencies = json.devDependencies || {};
 
@@ -101,8 +106,9 @@ export function uninstallTSLintAndCodelyzer(): Rule {
       );
     }
 
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-    const projectPackageJSON = host.read('package.json')!.toString('utf-8');
+    const projectPackageJSON = (host.read('package.json') as Buffer).toString(
+      'utf-8',
+    );
     const json = JSON.parse(projectPackageJSON);
 
     if (json.devDependencies) {

--- a/packages/schematics/src/library/index.ts
+++ b/packages/schematics/src/library/index.ts
@@ -17,7 +17,7 @@ function eslintRelatedChanges(options: Schema) {
    * The types coming from the @schematics/angular schema seem to be wrong, if name isn't
    * provided the interactive CLI prompt will throw
    */
-  const projectName: string = options.name!;
+  const projectName = options.name as string;
   return chain([
     // Update the lint builder and config in angular.json
     addESLintTargetToProject(projectName, 'lint'),

--- a/packages/schematics/src/migrations/update-2-0-0/update-2-0-0.ts
+++ b/packages/schematics/src/migrations/update-2-0-0/update-2-0-0.ts
@@ -1,4 +1,4 @@
-import type { SchematicContext, Tree } from '@angular-devkit/schematics';
+import type { Rule, SchematicContext, Tree } from '@angular-devkit/schematics';
 import { chain } from '@angular-devkit/schematics';
 import { NodePackageInstallTask } from '@angular-devkit/schematics/tasks';
 import type { Linter } from 'eslint';
@@ -91,6 +91,6 @@ function removeUsePipeDecoratorRule() {
   ]);
 }
 
-export default function () {
+export default function (): Rule {
   return chain([updateRelevantDependencies, removeUsePipeDecoratorRule]);
 }

--- a/packages/schematics/src/migrations/update-3-0-0/update-3-0-0.ts
+++ b/packages/schematics/src/migrations/update-3-0-0/update-3-0-0.ts
@@ -1,4 +1,4 @@
-import type { SchematicContext, Tree } from '@angular-devkit/schematics';
+import type { Rule, SchematicContext, Tree } from '@angular-devkit/schematics';
 import { chain } from '@angular-devkit/schematics';
 import { NodePackageInstallTask } from '@angular-devkit/schematics/tasks';
 import type { Linter } from 'eslint';
@@ -135,7 +135,7 @@ function updateComponentMaxInlineDeclarations() {
   ]);
 }
 
-export default function () {
+export default function (): Rule {
   return chain([
     updateRelevantDependencies,
     applyRecommendedExtraExtends,

--- a/packages/schematics/src/migrations/update-4-0-0/update-4-0-0.ts
+++ b/packages/schematics/src/migrations/update-4-0-0/update-4-0-0.ts
@@ -1,4 +1,4 @@
-import type { SchematicContext, Tree } from '@angular-devkit/schematics';
+import type { Rule, SchematicContext, Tree } from '@angular-devkit/schematics';
 import { chain } from '@angular-devkit/schematics';
 import { NodePackageInstallTask } from '@angular-devkit/schematics/tasks';
 import { updateJsonInTree } from '../../utils';
@@ -47,6 +47,6 @@ function updateRelevantDependencies(host: Tree, context: SchematicContext) {
   })(host, context);
 }
 
-export default function () {
+export default function (): Rule {
   return chain([updateRelevantDependencies]);
 }

--- a/packages/schematics/src/ng-add/index.ts
+++ b/packages/schematics/src/ng-add/index.ts
@@ -25,7 +25,9 @@ function addAngularESLintPackages() {
       );
     }
 
-    const projectPackageJSON = host.read('package.json')!.toString('utf-8');
+    const projectPackageJSON = (host.read('package.json') as Buffer).toString(
+      'utf-8',
+    );
     const json = JSON.parse(projectPackageJSON);
     json.devDependencies = json.devDependencies || {};
     json.devDependencies['eslint'] = packageJSON.devDependencies['eslint'];

--- a/packages/schematics/src/utils.ts
+++ b/packages/schematics/src/utils.ts
@@ -18,12 +18,14 @@ import stripJsonComments from 'strip-json-comments';
  * @param path The path to the JSON file
  * @returns The JSON data in the file.
  */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function readJsonInTree<T = any>(host: Tree, path: string): T {
   if (!host.exists(path)) {
     throw new Error(`Cannot find ${path}`);
   }
-  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-  const contents = stripJsonComments(host.read(path)!.toString('utf-8'));
+  const contents = stripJsonComments(
+    (host.read(path) as Buffer).toString('utf-8'),
+  );
   try {
     return JSON.parse(contents);
   } catch (e) {
@@ -37,6 +39,7 @@ export function readJsonInTree<T = any>(host: Tree, path: string): T {
  * @param callback Manipulation of the JSON data
  * @returns A rule which updates a JSON file file in a Tree
  */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function updateJsonInTree<T = any, O = T>(
   path: string,
   callback: (json: T, context: SchematicContext) => O,
@@ -86,6 +89,7 @@ export function isTSLintUsedInWorkspace(tree: Tree): boolean {
 
   for (const [, projectConfig] of Object.entries(
     workspaceJson.projects,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
   ) as any) {
     const targetsConfig = getTargetsConfigFromProject(projectConfig);
     if (!targetsConfig) {
@@ -107,6 +111,7 @@ export function isTSLintUsedInWorkspace(tree: Tree): boolean {
   return false;
 }
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function getProjectConfig(host: Tree, name: string): any {
   const workspaceJson = readJsonInTree(host, getWorkspacePath(host));
   const projectConfig = workspaceJson.projects[name];
@@ -126,10 +131,11 @@ export function offsetFromRoot(fullPathToSourceDir: string): string {
   return offset;
 }
 
-function serializeJson(json: any): string {
+function serializeJson(json: unknown): string {
   return `${JSON.stringify(json, null, 2)}\n`;
 }
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function updateWorkspaceInTree<T = any, O = T>(
   callback: (json: T, context: SchematicContext, host: Tree) => O,
 ): Rule {
@@ -186,8 +192,7 @@ export function visitNotIgnoredFiles(
     let ig: Ignore;
     if (host.exists('.gitignore')) {
       ig = ignore();
-      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-      ig.add(host.read('.gitignore')!.toString());
+      ig.add((host.read('.gitignore') as Buffer).toString());
     }
 
     function visit(_dir: Path) {
@@ -216,6 +221,7 @@ export function visitNotIgnoredFiles(
 
 type ProjectType = 'application' | 'library';
 
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
 export function setESLintProjectBasedOnProjectType(
   projectRoot: string,
   projectType: ProjectType,
@@ -242,6 +248,7 @@ export function setESLintProjectBasedOnProjectType(
   return project;
 }
 
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
 export function createRootESLintConfig(
   prefix: string | null,
   hasE2e?: boolean,
@@ -389,7 +396,9 @@ function createRootESLintConfigFile(projectName: string): Rule {
   };
 }
 
-export function sortObjectByKeys(obj: Record<string, unknown>) {
+export function sortObjectByKeys(
+  obj: Record<string, unknown>,
+): Record<string, unknown> {
   return Object.keys(obj)
     .sort()
     .reduce((result, key) => {
@@ -424,6 +433,7 @@ export function determineTargetProjectName(
  * Method will check if angular project architect has e2e configuration to determine if e2e setup
  */
 export function determineTargetProjectHasE2E(
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any
   angularJSON: any,
   projectName: string,
 ): boolean {


### PR DESCRIPTION
Unfortunately `eslint-disable *` is the most viable solution in most cases here, because if we try to modify the types, it breaks in many places with difficult solutions.