### PR TITLE
refactor(eslint-plugin): suppress lint warnings and better typings

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -10,6 +10,10 @@
   ],
   "rules": {
     "@typescript-eslint/consistent-type-imports": "error",
-    "@typescript-eslint/no-unused-vars": ["error", { "argsIgnorePattern": "_" }]
+    "@typescript-eslint/no-unused-vars": [
+      "error",
+      { "argsIgnorePattern": "_" }
+    ],
+    "@typescript-eslint/array-type": "error"
   }
 }

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -9,6 +9,7 @@
     "prettier/@typescript-eslint"
   ],
   "rules": {
-    "@typescript-eslint/consistent-type-imports": "error"
+    "@typescript-eslint/consistent-type-imports": "error",
+    "@typescript-eslint/no-unused-vars": ["error", { "argsIgnorePattern": "_" }]
   }
 }

--- a/packages/builder/tests/index.test.ts
+++ b/packages/builder/tests/index.test.ts
@@ -98,12 +98,12 @@ async function runBuilder(options: Schema) {
   const { default: builderImplementation } = require('../src/index');
   testArchitectHost.addBuilder(builderName, builderImplementation);
 
-  const architect = new Architect(testArchitectHost, registry as any);
+  const architect = new Architect(testArchitectHost, registry);
   const logger = new logging.Logger('');
   logger.subscribe(loggerSpy);
 
   const run = await architect.scheduleBuilder(builderName, options, {
-    logger: logger as any,
+    logger,
   });
 
   return run.result;

--- a/packages/eslint-plugin/src/rules/contextual-decorator.ts
+++ b/packages/eslint-plugin/src/rules/contextual-decorator.ts
@@ -45,7 +45,7 @@ export default createESLintRule<Options, MessageIds>({
 });
 
 function validateNode(
-  context: TSESLint.RuleContext<MessageIds, []>,
+  context: Readonly<TSESLint.RuleContext<string, readonly unknown[]>>,
   node:
     | TSESTree.MethodDefinition
     | TSESTree.ClassProperty
@@ -73,7 +73,7 @@ function validateNode(
 }
 
 function validateDecorator(
-  context: TSESLint.RuleContext<MessageIds, []>,
+  context: Readonly<TSESLint.RuleContext<string, readonly unknown[]>>,
   decorator: TSESTree.Decorator,
   classDecoratorName: AngularClassDecoratorKeys,
 ): void {

--- a/packages/eslint-plugin/src/rules/contextual-lifecycle.ts
+++ b/packages/eslint-plugin/src/rules/contextual-lifecycle.ts
@@ -50,6 +50,7 @@ export default createESLintRule<Options, MessageIds>({
         const methodName = getMethodName(method);
 
         if (
+          !methodName ||
           !isAngularLifecycleMethod(methodName) ||
           allowedMethods?.has(methodName)
         ) {

--- a/packages/eslint-plugin/src/rules/no-conflicting-lifecycle.ts
+++ b/packages/eslint-plugin/src/rules/no-conflicting-lifecycle.ts
@@ -1,4 +1,5 @@
 import type { TSESTree } from '@typescript-eslint/experimental-utils';
+import { ASTUtils } from '@typescript-eslint/experimental-utils';
 import { createESLintRule } from '../utils/create-eslint-rule';
 import type {
   AngularLifecycleInterfaceKeys,
@@ -6,13 +7,12 @@ import type {
 } from '../utils/utils';
 import {
   AngularLifecycleInterfaces,
-  getDeclaredAngularLifecycleInterfaces,
   AngularLifecycleMethods,
+  getDeclaredAngularLifecycleInterfaces,
   getDeclaredAngularLifecycleMethods,
   getDeclaredInterfaces,
-  isAngularLifecycleInterface,
-  isIdentifier,
   getDeclaredMethods,
+  isAngularLifecycleInterface,
   isAngularLifecycleMethod,
 } from '../utils/utils';
 
@@ -20,16 +20,12 @@ type Options = [];
 export type MessageIds =
   | 'noConflictingLifecycleInterface'
   | 'noConflictingLifecycleMethod';
-
 export const RULE_NAME = 'no-conflicting-lifecycle';
-
-// const STYLE_GUIDE_LINK = 'https://angular.io/api/core/DoCheck#description.';
-
-const LIFECYCLE_INTERFACES: ReadonlyArray<AngularLifecycleInterfaceKeys> = [
+const LIFECYCLE_INTERFACES: readonly AngularLifecycleInterfaceKeys[] = [
   AngularLifecycleInterfaces.DoCheck,
   AngularLifecycleInterfaces.OnChanges,
 ];
-const LIFECYCLE_METHODS: ReadonlyArray<AngularLifecycleMethodKeys> = [
+const LIFECYCLE_METHODS: readonly AngularLifecycleMethodKeys[] = [
   AngularLifecycleMethods.ngDoCheck,
   AngularLifecycleMethods.ngOnChanges,
 ];
@@ -67,7 +63,7 @@ export default createESLintRule<Options, MessageIds>({
       const declaredInterfaces = getDeclaredInterfaces(node);
       const declaredAngularLifecycleInterfacesNodes = declaredInterfaces.filter(
         (node) =>
-          isIdentifier(node.expression) &&
+          ASTUtils.isIdentifier(node.expression) &&
           isAngularLifecycleInterface(node.expression.name),
       );
 
@@ -93,7 +89,8 @@ export default createESLintRule<Options, MessageIds>({
       const declaredMethods = getDeclaredMethods(node);
       const declaredAngularLifecycleMethodNodes = declaredMethods.filter(
         (node) =>
-          isIdentifier(node.key) && isAngularLifecycleMethod(node.key.name),
+          ASTUtils.isIdentifier(node.key) &&
+          isAngularLifecycleMethod(node.key.name),
       );
 
       for (const method of declaredAngularLifecycleMethodNodes) {

--- a/packages/eslint-plugin/src/rules/no-host-metadata-property.ts
+++ b/packages/eslint-plugin/src/rules/no-host-metadata-property.ts
@@ -1,10 +1,10 @@
 import type { TSESTree } from '@typescript-eslint/experimental-utils';
+import { ASTUtils } from '@typescript-eslint/experimental-utils';
 import { createESLintRule } from '../utils/create-eslint-rule';
 import { COMPONENT_OR_DIRECTIVE_CLASS_DECORATOR } from '../utils/selectors';
 import {
   AngularInnerClassDecorators,
-  isIdentifier,
-  isLiteral,
+  isLiteralWithStringValue,
   isObjectExpression,
   isProperty,
 } from '../utils/utils';
@@ -72,7 +72,9 @@ function isEmptyStringValue(
 ): property is TSESTree.Property & {
   value: TSESTree.Literal & { value: '' };
 } {
-  return isLiteral(property.value) && property.value.value === '';
+  return (
+    isLiteralWithStringValue(property.value) && property.value.value === ''
+  );
 }
 
 function isStatic(
@@ -83,9 +85,8 @@ function isStatic(
 } {
   return (
     !property.computed &&
-    (isIdentifier(property.key) ||
-      (isLiteral(property.key) &&
-        typeof property.key.value === 'string' &&
+    (ASTUtils.isIdentifier(property.key) ||
+      (isLiteralWithStringValue(property.key) &&
         startsWithLetter(property.key.value)))
   );
 }

--- a/packages/eslint-plugin/src/rules/no-lifecycle-call.ts
+++ b/packages/eslint-plugin/src/rules/no-lifecycle-call.ts
@@ -1,11 +1,11 @@
 import type { TSESTree } from '@typescript-eslint/experimental-utils';
+import { ASTUtils } from '@typescript-eslint/experimental-utils';
 import { createESLintRule } from '../utils/create-eslint-rule';
 import {
   ANGULAR_LIFECYCLE_METHODS,
   getAngularClassDecorator,
   getNearestNodeFrom,
   isClassDeclaration,
-  isIdentifier,
   isMethodDefinition,
   isSuper,
   toPattern,
@@ -60,7 +60,9 @@ function hasSameName(
   { key }: TSESTree.MethodDefinition,
 ): boolean {
   return (
-    isIdentifier(property) && isIdentifier(key) && property.name === key.name
+    ASTUtils.isIdentifier(property) &&
+    ASTUtils.isIdentifier(key) &&
+    property.name === key.name
   );
 }
 

--- a/packages/eslint-plugin/src/rules/prefer-on-push-component-change-detection.ts
+++ b/packages/eslint-plugin/src/rules/prefer-on-push-component-change-detection.ts
@@ -1,7 +1,8 @@
 import type { TSESTree } from '@typescript-eslint/experimental-utils';
+import { ASTUtils } from '@typescript-eslint/experimental-utils';
 import { createESLintRule } from '../utils/create-eslint-rule';
 import { COMPONENT_CLASS_DECORATOR } from '../utils/selectors';
-import { getDecoratorPropertyValue, isIdentifier } from '../utils/utils';
+import { getDecoratorPropertyValue } from '../utils/utils';
 
 type Options = [];
 export type MessageIds = 'preferOnPushComponentChangeDetection';
@@ -41,7 +42,7 @@ export default createESLintRule<Options, MessageIds>({
         }
 
         if (
-          !isIdentifier(changeDetectionExpression.property) ||
+          !ASTUtils.isIdentifier(changeDetectionExpression.property) ||
           changeDetectionExpression.property.name !== ON_PUSH
         ) {
           context.report({

--- a/packages/eslint-plugin/src/rules/sort-ngmodule-metadata-arrays.ts
+++ b/packages/eslint-plugin/src/rules/sort-ngmodule-metadata-arrays.ts
@@ -1,13 +1,9 @@
+import type { NgModule } from '@angular/compiler/src/core';
 import type { TSESTree } from '@typescript-eslint/experimental-utils';
+import { ASTUtils } from '@typescript-eslint/experimental-utils';
 import { createESLintRule } from '../utils/create-eslint-rule';
 import { MODULE_CLASS_DECORATOR } from '../utils/selectors';
-import {
-  getDecoratorPropertyValue,
-  isArrayExpression,
-  isIdentifier,
-} from '../utils/utils';
-
-import type { NgModule } from '@angular/compiler/src/core';
+import { getDecoratorPropertyValue, isArrayExpression } from '../utils/utils';
 
 type Options = [];
 export const RULE_NAME = 'sort-ngmodule-metadata-arrays';
@@ -53,7 +49,7 @@ export default createESLintRule<Options, MessageIds>({
             return;
           }
           const unorderedNodes = initializer.elements
-            .filter(isIdentifier)
+            .filter(ASTUtils.isIdentifier)
             .map((current, index, list) => {
               return [current, list[index + 1]];
             })

--- a/packages/eslint-plugin/src/rules/use-lifecycle-interface.ts
+++ b/packages/eslint-plugin/src/rules/use-lifecycle-interface.ts
@@ -38,14 +38,14 @@ export default createESLintRule<Options, MessageIds>({
     return {
       [`MethodDefinition[key.name=${angularLifecycleMethodsPattern}]`]({
         key,
-        parent,
-      }: TSESTree.MethodDefinition) {
-        const classDeclaration = parent!.parent as TSESTree.ClassDeclaration;
-
-        if (!getAngularClassDecorator(classDeclaration)) return;
+        parent: { parent },
+      }: TSESTree.MethodDefinition & { parent: TSESTree.ClassBody } & {
+        parent: TSESTree.ClassDeclaration;
+      }) {
+        if (!getAngularClassDecorator(parent)) return;
 
         const declaredLifecycleInterfaces = getDeclaredAngularLifecycleInterfaces(
-          classDeclaration,
+          parent,
         );
         const methodName = (key as TSESTree.Identifier)
           .name as AngularLifecycleMethodKeys;

--- a/packages/eslint-plugin/src/utils/create-eslint-rule.ts
+++ b/packages/eslint-plugin/src/utils/create-eslint-rule.ts
@@ -12,14 +12,8 @@ type RequiredParserServices = {
   [k in keyof ParserServices]: Exclude<ParserServices[k], undefined>;
 };
 
-/**
- * TODO: Expose via @typescript-eslint/experimental-utils
- */
-export function getParserServices<
-  TMessageIds extends string,
-  TOptions extends any[]
->(
-  context: TSESLint.RuleContext<TMessageIds, TOptions>,
+export function getParserServices(
+  context: Readonly<TSESLint.RuleContext<string, readonly unknown[]>>,
 ): RequiredParserServices {
   if (
     !context.parserServices ||
@@ -44,14 +38,8 @@ type NodeMaps = {
   >]: NonNullable<ParserServices[k]>;
 };
 
-/**
- * TODO: Expose via @typescript-eslint/experimental-utils
- */
-export function getNodeMaps<
-  _TMessageIds extends string,
-  _TOptions extends any[]
->(
-  context: any, // RuleContext<TMessageIds, TOptions>
+export function getNodeMaps(
+  context: Readonly<TSESLint.RuleContext<string, readonly unknown[]>>,
 ): NodeMaps {
   if (
     !context.parserServices ||

--- a/packages/eslint-plugin/src/utils/utils.ts
+++ b/packages/eslint-plugin/src/utils/utils.ts
@@ -193,10 +193,6 @@ export function isCallExpression(
   return node.type === AST_NODE_TYPES.CallExpression;
 }
 
-export function isIdentifier(node: TSESTree.Node): node is TSESTree.Identifier {
-  return node.type === AST_NODE_TYPES.Identifier;
-}
-
 export function isMemberExpression(
   node: TSESTree.Node,
 ): node is TSESTree.MemberExpression {
@@ -326,7 +322,7 @@ export function getImplementsRemoveFix(
 
   const identifier = classImplements
     .map(({ expression }) => expression)
-    .filter(isIdentifier)
+    .filter(ASTUtils.isIdentifier)
     .find(({ name }) => name === interfaceName);
 
   if (!identifier) return undefined;
@@ -493,10 +489,7 @@ export const getDecorator = (
   node: TSESTree.ClassDeclaration,
   decoratorName: string,
 ): TSESTree.Decorator | undefined => {
-  if (!node.decorators) {
-    return undefined;
-  }
-  return node.decorators.find(
+  return node.decorators?.find(
     (decorator) =>
       isCallExpression(decorator.expression) &&
       decorator.expression.arguments &&
@@ -514,59 +507,46 @@ export const getAngularClassDecorator = ({
     .find(isAngularClassDecorator);
 };
 
-export const getDecoratorArgument = (
-  decorator: TSESTree.Decorator,
-): TSESTree.ObjectExpression | undefined => {
-  const { expression } = decorator;
-  if (
-    !isCallExpression(expression) ||
-    !expression.arguments ||
-    expression.arguments.length === 0
-  ) {
+export const getDecoratorArgument = ({
+  expression,
+}: TSESTree.Decorator): TSESTree.ObjectExpression | undefined => {
+  if (!isCallExpression(expression) || expression.arguments.length === 0) {
     return undefined;
   }
-  const arg = expression.arguments[0];
+  const [arg] = expression.arguments;
   return isObjectExpression(arg) && arg.properties ? arg : undefined;
 };
 
-export const getDecoratorName = (
-  decorator: TSESTree.Decorator,
-): string | undefined => {
-  const { expression } = decorator;
+export const getDecoratorName = ({
+  expression,
+}: TSESTree.Decorator): string | undefined => {
+  if (ASTUtils.isIdentifier(expression)) return expression.name;
 
-  if (isIdentifier(expression)) return expression.name;
-
-  if (isCallExpression(expression) && isIdentifier(expression.callee)) {
-    return expression.callee.name;
-  }
-
-  return undefined;
+  return isCallExpression(expression) &&
+    ASTUtils.isIdentifier(expression.callee)
+    ? expression.callee.name
+    : undefined;
 };
 
 export const getPipeDecorator = (
   node: TSESTree.ClassDeclaration,
 ): TSESTree.Decorator | undefined => getDecorator(node, 'Pipe');
 
-export const getSymbolName = (
-  expression: TSESTree.TSClassImplements,
-): string => {
-  const { expression: childExpression } = expression;
-
-  // TODO: Investigate "as any"
-  return isMemberExpression(childExpression)
-    ? (childExpression.property as any).name
-    : (childExpression as any).name;
-};
-
 export const getDeclaredInterfaces = (
   node: TSESTree.ClassDeclaration,
 ): TSESTree.TSClassImplements[] => {
-  return node.implements || [];
+  return node.implements ?? [];
 };
 
 export const getDeclaredInterfaceNames = (
   node: TSESTree.ClassDeclaration,
-): string[] => getDeclaredInterfaces(node).map(getSymbolName);
+): readonly string[] =>
+  getDeclaredInterfaces(node)
+    .map(({ expression }) =>
+      isMemberExpression(expression) ? expression.property : expression,
+    )
+    .filter(ASTUtils.isIdentifier)
+    .map(({ name }) => name);
 
 export const getDeclaredInterfaceName = (
   node: TSESTree.ClassDeclaration,
@@ -588,6 +568,7 @@ export const getDeclaredAngularLifecycleMethods = (
 ): readonly AngularLifecycleMethodKeys[] =>
   getDeclaredMethods(node)
     .map(getMethodName)
+    .filter(isNotNullOrUndefined)
     .filter(isAngularLifecycleMethod) as readonly AngularLifecycleMethodKeys[];
 
 export const ANGULAR_LIFECYCLE_INTERFACES: ReadonlySet<AngularLifecycleInterfaceKeys> = new Set(
@@ -630,7 +611,7 @@ export const isAngularInnerClassDecorator = (
  * }
  */
 export function getClassPropertyName({ key }: TSESTree.ClassProperty): string {
-  if (isIdentifier(key)) {
+  if (ASTUtils.isIdentifier(key)) {
     return key.name;
   }
 
@@ -645,44 +626,31 @@ export const getDecoratorProperty = (
   decorator: TSESTree.Decorator,
   name: string,
 ): TSESTree.Property | undefined => {
-  const arg = getDecoratorArgument(decorator);
-
-  if (!arg || !isObjectExpression(arg)) return undefined;
-
-  const properties = arg.properties as TSESTree.Property[];
-  const property = properties.find(
-    (prop) => prop.key && isIdentifier(prop.key) && prop.key.name === name,
-  );
-
-  if (!property || !isProperty(property)) return undefined;
-
-  return property;
+  return getDecoratorArgument(decorator)
+    ?.properties.filter(isProperty)
+    .find(({ key }) => ASTUtils.isIdentifier(key) && key.name === name);
 };
 
 export const getDecoratorPropertyValue = (
   decorator: TSESTree.Decorator,
   name: string,
-): TSESTree.Expression | TSESTree.Literal | undefined => {
-  const property = getDecoratorProperty(decorator, name);
-  if (!property) {
-    return undefined;
-  }
-
-  /**
-   * TODO: Investigate as any
-   */
-  return property.value as any;
+): TSESTree.Property['value'] | undefined => {
+  return getDecoratorProperty(decorator, name)?.value;
 };
 
-export const getDeclaredMethods = (node: TSESTree.ClassDeclaration) => {
-  return node.body.body.filter(isMethodDefinition);
+export const getDeclaredMethods = ({
+  body: { body },
+}: TSESTree.ClassDeclaration): readonly TSESTree.MethodDefinition[] => {
+  return body.filter(isMethodDefinition);
 };
 
-export const getMethodName = (node: TSESTree.MethodDefinition): string => {
-  if (isLiteral(node.key)) {
-    return node.key.value as string;
+export const getMethodName = (
+  node: TSESTree.MethodDefinition,
+): string | undefined => {
+  if (isLiteralWithStringValue(node.key)) {
+    return node.key.value;
   }
-  return (node.key as TSESTree.Identifier).name;
+  return ASTUtils.isIdentifier(node.key) ? node.key.name : undefined;
 };
 
 export const getLifecycleInterfaceByMethodName = (
@@ -693,14 +661,11 @@ export const getLifecycleInterfaceByMethodName = (
 /**
  * Enforces the invariant that the input is an array.
  */
-export function arrayify<T>(arg?: T | T[]): T[] {
+export function arrayify<T>(arg?: T | readonly T[]): readonly T[] {
   if (Array.isArray(arg)) {
     return arg;
-  } else if (arg != undefined) {
-    return [arg];
-  } else {
-    return [];
   }
+  return (arg ? [arg] : []) as readonly T[];
 }
 
 // Needed because in the current Typescript version (TS 3.3.3333), Boolean() cannot be used to perform a null check.
@@ -750,8 +715,10 @@ export const SelectorValidator = {
   },
 };
 
-export const kebabToCamelCase = (value: string) =>
-  value.replace(/-[a-zA-Z]/g, (x) => x[1].toUpperCase());
+export const kebabToCamelCase = (value: string): string =>
+  value.replace(/-[a-zA-Z]/g, ({ 1: letterAfterDash }) =>
+    letterAfterDash.toUpperCase(),
+  );
 
 export function isImportedFrom(
   identifier: TSESTree.Identifier,
@@ -787,5 +754,5 @@ export const toHumanReadableText = (items: readonly string[]): string => {
     .join(', ')} or "${[...items].pop()}"`;
 };
 
-export const toPattern = (value: readonly unknown[]) =>
+export const toPattern = (value: readonly unknown[]): RegExp =>
   RegExp(`^(${value.join('|')})$`);

--- a/packages/eslint-plugin/src/utils/utils.ts
+++ b/packages/eslint-plugin/src/utils/utils.ts
@@ -1,9 +1,10 @@
 import type { TSESLint, TSESTree } from '@typescript-eslint/experimental-utils';
 import { ASTUtils } from '@typescript-eslint/experimental-utils';
+import { AST_NODE_TYPES } from '@typescript-eslint/types';
 
 export const objectKeys = Object.keys as <T>(
   o: T,
-) => ReadonlyArray<Extract<keyof T, string>>;
+) => readonly Extract<keyof T, string>[];
 
 export enum AngularClassDecorators {
   Component = 'Component',
@@ -189,65 +190,65 @@ export const ANGULAR_CLASS_DECORATOR_MAPPER: ReadonlyMap<
 export function isCallExpression(
   node: TSESTree.Node,
 ): node is TSESTree.CallExpression {
-  return node.type === 'CallExpression';
+  return node.type === AST_NODE_TYPES.CallExpression;
 }
 
 export function isIdentifier(node: TSESTree.Node): node is TSESTree.Identifier {
-  return node.type === 'Identifier';
+  return node.type === AST_NODE_TYPES.Identifier;
 }
 
 export function isMemberExpression(
   node: TSESTree.Node,
 ): node is TSESTree.MemberExpression {
-  return node.type === 'MemberExpression';
+  return node.type === AST_NODE_TYPES.MemberExpression;
 }
 
 export function isClassDeclaration(
   node: TSESTree.Node,
 ): node is TSESTree.ClassDeclaration {
-  return node.type === 'ClassDeclaration';
+  return node.type === AST_NODE_TYPES.ClassDeclaration;
 }
 
 export function isObjectExpression(
   node: TSESTree.Node,
 ): node is TSESTree.ObjectExpression {
-  return node.type === 'ObjectExpression';
+  return node.type === AST_NODE_TYPES.ObjectExpression;
 }
 
 export function isArrayExpression(
   node: TSESTree.Node,
 ): node is TSESTree.ArrayExpression {
-  return node.type === 'ArrayExpression';
+  return node.type === AST_NODE_TYPES.ArrayExpression;
 }
 
 export function isProperty(node: TSESTree.Node): node is TSESTree.Property {
-  return node.type === 'Property';
+  return node.type === AST_NODE_TYPES.Property;
 }
 
 function isProgram(node: TSESTree.Node): node is TSESTree.Program {
-  return node.type === 'Program';
+  return node.type === AST_NODE_TYPES.Program;
 }
 
 export function isLiteral(node: TSESTree.Node): node is TSESTree.Literal {
-  return node.type === 'Literal';
+  return node.type === AST_NODE_TYPES.Literal;
 }
 
 export function isTemplateLiteral(
   node: TSESTree.Node,
 ): node is TSESTree.TemplateLiteral {
-  return node.type === 'TemplateLiteral';
+  return node.type === AST_NODE_TYPES.TemplateLiteral;
 }
 
 export function isImportDeclaration(
   node: TSESTree.Node,
 ): node is TSESTree.ImportDeclaration {
-  return node.type === 'ImportDeclaration';
+  return node.type === AST_NODE_TYPES.ImportDeclaration;
 }
 
 function isImportSpecifier(
   node: TSESTree.Node,
 ): node is TSESTree.ImportSpecifier {
-  return node.type === 'ImportSpecifier';
+  return node.type === AST_NODE_TYPES.ImportSpecifier;
 }
 
 type LiteralWithStringValue = TSESTree.Literal & {
@@ -262,17 +263,17 @@ type LiteralWithStringValue = TSESTree.Literal & {
 export function isLiteralWithStringValue(
   node: TSESTree.Node,
 ): node is LiteralWithStringValue {
-  return node.type === 'Literal' && typeof node.value === 'string';
+  return isLiteral(node) && typeof node.value === 'string';
 }
 
 export function isMethodDefinition(
   node: TSESTree.Node,
 ): node is TSESTree.MethodDefinition {
-  return node.type === 'MethodDefinition';
+  return node.type === AST_NODE_TYPES.MethodDefinition;
 }
 
 export function isSuper(node: TSESTree.Node): node is TSESTree.Super {
-  return node.type === 'Super';
+  return node.type === AST_NODE_TYPES.Super;
 }
 
 /**
@@ -577,19 +578,17 @@ export const getDeclaredInterfaceName = (
 
 export const getDeclaredAngularLifecycleInterfaces = (
   node: TSESTree.ClassDeclaration,
-): ReadonlyArray<AngularLifecycleInterfaceKeys> =>
+): readonly AngularLifecycleInterfaceKeys[] =>
   getDeclaredInterfaceNames(node).filter(
     isAngularLifecycleInterface,
-  ) as ReadonlyArray<AngularLifecycleInterfaceKeys>;
+  ) as readonly AngularLifecycleInterfaceKeys[];
 
 export const getDeclaredAngularLifecycleMethods = (
   node: TSESTree.ClassDeclaration,
-): ReadonlyArray<AngularLifecycleMethodKeys> =>
+): readonly AngularLifecycleMethodKeys[] =>
   getDeclaredMethods(node)
     .map(getMethodName)
-    .filter(isAngularLifecycleMethod) as ReadonlyArray<
-    AngularLifecycleMethodKeys
-  >;
+    .filter(isAngularLifecycleMethod) as readonly AngularLifecycleMethodKeys[];
 
 export const ANGULAR_LIFECYCLE_INTERFACES: ReadonlySet<AngularLifecycleInterfaceKeys> = new Set(
   angularLifecycleInterfaceKeys,
@@ -630,20 +629,16 @@ export const isAngularInnerClassDecorator = (
  *  ['c'] // Literal
  * }
  */
-export function getClassPropertyName(
-  classProperty: TSESTree.ClassProperty,
-): string {
-  if (classProperty.key.type === 'Identifier') {
-    return classProperty.key.name;
+export function getClassPropertyName({ key }: TSESTree.ClassProperty): string {
+  if (isIdentifier(key)) {
+    return key.name;
   }
 
-  if (classProperty.key.type === 'Literal') {
-    return classProperty.key.raw;
+  if (isLiteral(key)) {
+    return key.raw;
   }
 
-  throw new Error(
-    `Unexpected "ClassProperty.key.type" provided: ${classProperty.key.type}`,
-  );
+  throw new Error(`Unexpected "ClassProperty.key.type" provided: ${key.type}`);
 }
 
 export const getDecoratorProperty = (


### PR DESCRIPTION
1st. commit: add a pattern to ignore vars starting with `_` to suppress some cases we have in repo, like `_ruleName`, `_fileName`;
2nd. commit: add the rule `array-type` that standarize the array type to be used;
3rd. commit: use `AST_NODE_TYPES` enum instead of plain strings in `utils`;
4th. commit: suppress lint warnings, remove some typecasts, remove null-assertions, adjust some typings and use type guard functions for better inference.

~**WIP**: Waiting for the resolution of the related PRs~.