### PR TITLE
refactor(utils): change return type of fixer utilities

### DIFF
--- a/packages/eslint-plugin-template/src/rules/eqeqeq.ts
+++ b/packages/eslint-plugin-template/src/rules/eqeqeq.ts
@@ -110,10 +110,10 @@ const getFix = ({
   start: number;
   end: number;
   fixer: TSESLint.RuleFixer;
-}): TSESLint.RuleFix | TSESLint.RuleFix[] => {
+}): TSESLint.RuleFix | null => {
   const { source } = getNearestNodeFrom(node, isASTWithSource) ?? {};
 
-  if (!source) return [];
+  if (!source) return null;
 
   return fixer.insertTextAfterRange(
     [start + getSpanLength(left) + 1, end - getSpanLength(right) - 1],

--- a/packages/eslint-plugin-template/src/utils/get-nearest-node-from.ts
+++ b/packages/eslint-plugin-template/src/utils/get-nearest-node-from.ts
@@ -15,10 +15,10 @@ export function getNearestNodeFrom<T extends ASTOrNodeWithParent>(
 ): T | null {
   while (parent && !isProgram(parent)) {
     if (predicate(parent)) {
-      return (parent as unknown) as T;
+      return parent;
     }
 
-    parent = parent.parent as ASTOrNodeWithParent | undefined;
+    parent = parent.parent;
   }
 
   return null;

--- a/packages/eslint-plugin/src/rules/no-empty-lifecycle-method.ts
+++ b/packages/eslint-plugin/src/rules/no-empty-lifecycle-method.ts
@@ -6,6 +6,7 @@ import {
   getImplementsRemoveFix,
   getImportDeclarations,
   getImportRemoveFix,
+  isNotNullOrUndefined,
   toPattern,
 } from '../utils/utils';
 
@@ -54,13 +55,12 @@ export default createESLintRule<Options, MessageIds>({
             {
               messageId: 'suggestRemoveLifecycleMethod',
               fix: (fixer) => {
-                const importDeclarations = getImportDeclarations(
-                  node,
-                  '@angular/core',
-                );
+                const importDeclarations =
+                  getImportDeclarations(node, '@angular/core') ?? [];
                 const interfaceName = node.key.name.replace(/^ng+/, '');
 
-                return [fixer.remove(node)].concat(
+                return [
+                  fixer.remove(node),
                   getImplementsRemoveFix(
                     sourceCode,
                     node.parent.parent,
@@ -69,11 +69,11 @@ export default createESLintRule<Options, MessageIds>({
                   ),
                   getImportRemoveFix(
                     sourceCode,
-                    importDeclarations ?? [],
+                    importDeclarations,
                     interfaceName,
                     fixer,
                   ),
-                );
+                ].filter(isNotNullOrUndefined);
               },
             },
           ],

--- a/packages/eslint-plugin/src/utils/utils.ts
+++ b/packages/eslint-plugin/src/utils/utils.ts
@@ -282,7 +282,7 @@ export function isSuper(node: TSESTree.Node): node is TSESTree.Super {
 export function getNearestNodeFrom<T extends TSESTree.Node>(
   { parent }: TSESTree.Node,
   predicate: (parent: TSESTree.Node) => parent is T,
-): T | undefined {
+): T | null {
   while (parent && !isProgram(parent)) {
     if (predicate(parent)) {
       return parent;
@@ -291,7 +291,7 @@ export function getNearestNodeFrom<T extends TSESTree.Node>(
     parent = parent.parent;
   }
 
-  return undefined;
+  return null;
 }
 
 export function getImportDeclarations(

--- a/packages/eslint-plugin/src/utils/utils.ts
+++ b/packages/eslint-plugin/src/utils/utils.ts
@@ -282,16 +282,16 @@ export function isSuper(node: TSESTree.Node): node is TSESTree.Super {
 export function getNearestNodeFrom<T extends TSESTree.Node>(
   { parent }: TSESTree.Node,
   predicate: (parent: TSESTree.Node) => parent is T,
-): T | null {
+): T | undefined {
   while (parent && !isProgram(parent)) {
     if (predicate(parent)) {
-      return (parent as unknown) as T;
+      return parent;
     }
 
-    parent = parent.parent as TSESTree.Node | undefined;
+    parent = parent.parent;
   }
 
-  return null;
+  return undefined;
 }
 
 export function getImportDeclarations(
@@ -301,7 +301,7 @@ export function getImportDeclarations(
   let parentNode: TSESTree.Node | undefined = node;
 
   while ((parentNode = parentNode.parent)) {
-    if (parentNode.type !== 'Program') continue;
+    if (!isProgram(parentNode)) continue;
 
     return parentNode.body.filter(
       (node): node is TSESTree.ImportDeclaration =>
@@ -317,17 +317,17 @@ export function getImplementsRemoveFix(
   classDeclaration: TSESTree.ClassDeclaration,
   interfaceName: string,
   fixer: TSESLint.RuleFixer,
-): TSESLint.RuleFix | TSESLint.RuleFix[] {
+): TSESLint.RuleFix | undefined {
   const { implements: classImplements } = classDeclaration;
 
-  if (!classImplements) return [];
+  if (!classImplements) return undefined;
 
   const identifier = classImplements
     .map(({ expression }) => expression)
     .filter(isIdentifier)
     .find(({ name }) => name === interfaceName);
 
-  if (!identifier) return [];
+  if (!identifier) return undefined;
 
   const isFirstInterface = classImplements[0].expression === identifier;
   const isLastInterface =
@@ -352,14 +352,12 @@ export function getImplementsRemoveFix(
 
   const tokenBeforeInterface = sourceCode.getTokenBefore(identifier);
 
-  if (tokenBeforeInterface) {
-    return fixer.removeRange([
-      tokenBeforeInterface.range[0],
-      identifier.range[1],
-    ]);
-  }
+  if (!tokenBeforeInterface) return undefined;
 
-  return [];
+  return fixer.removeRange([
+    tokenBeforeInterface.range[0],
+    identifier.range[1],
+  ]);
 }
 
 function getImportDeclarationSpecifier(
@@ -414,11 +412,11 @@ export function getImportRemoveFix(
   importDeclarations: readonly TSESTree.ImportDeclaration[],
   importedName: string,
   fixer: TSESLint.RuleFixer,
-): TSESLint.RuleFix | TSESLint.RuleFix[] {
+): TSESLint.RuleFix | undefined {
   const { importDeclaration, importSpecifier } =
     getImportDeclarationSpecifier(importDeclarations, importedName) ?? {};
 
-  if (!importDeclaration || !importSpecifier) return [];
+  if (!importDeclaration || !importSpecifier) return undefined;
 
   const isFirstImportSpecifier =
     importDeclaration.specifiers[0] === importSpecifier;
@@ -443,14 +441,12 @@ export function getImportRemoveFix(
 
   const tokenBeforeImportSpecifier = sourceCode.getTokenBefore(importSpecifier);
 
-  if (tokenBeforeImportSpecifier) {
-    return fixer.removeRange([
-      tokenBeforeImportSpecifier.range[0],
-      importSpecifier.range[1],
-    ]);
-  }
+  if (!tokenBeforeImportSpecifier) return undefined;
 
-  return [];
+  return fixer.removeRange([
+    tokenBeforeImportSpecifier.range[0],
+    importSpecifier.range[1],
+  ]);
 }
 
 export function getImplementsSchemaFixer(


### PR DESCRIPTION
Currently, if it isn't possible to determine a fix in utility functions, we simply return an empty `array` (`TSESLint.RuleFix[]`) and this can be a little confuse, as we need to encapsulate the fixers in `arrays` and use `.concat` (which accepts either a single item or an `array`). See https://github.com/angular-eslint/angular-eslint/pull/501#discussion_r641589200.

In this PR, the proposal is to return `undefined` instead and whenever we use it in `report#fix` (which accepts `IterableIterator<RuleFix> | TSESLint.RuleFix | TSESLint.RuleFix[] | null`), we call the` isNotNullOrUndefined` helper to extract only the _non-undefined_ fixes from the `array` and make the compiler happy.