### PR TITLE
fix(eslint-plugin): [no-output-on-prefix] handle `getters` and `outputs` metadata property

### DIFF
--- a/packages/eslint-plugin/src/rules/no-output-on-prefix.ts
+++ b/packages/eslint-plugin/src/rules/no-output-on-prefix.ts
@@ -1,12 +1,16 @@
 import type { TSESTree } from '@typescript-eslint/experimental-utils';
 import { createESLintRule } from '../utils/create-eslint-rule';
-import { OUTPUT_DECORATOR } from '../utils/selectors';
+import {
+  OUTPUTS_METADATA_PROPERTY,
+  OUTPUT_ALIAS,
+  OUTPUT_PROPERTY_OR_GETTER,
+} from '../utils/selectors';
+import { getRawText } from '../utils/utils';
 
 type Options = [];
 export type MessageIds = 'noOutputOnPrefix';
 export const RULE_NAME = 'no-output-on-prefix';
 const STYLE_GUIDE_LINK = 'https://angular.io/guide/styleguide#style-05-16';
-const OUTPUT_ON_PATTERN = /^on((?![a-z])|(?=$))/;
 
 export default createESLintRule<Options, MessageIds>({
   name: RULE_NAME,
@@ -24,14 +28,31 @@ export default createESLintRule<Options, MessageIds>({
   },
   defaultOptions: [],
   create(context) {
-    const outputAliasSelector = `ClassProperty ${OUTPUT_DECORATOR} :matches(Literal[value=${OUTPUT_ON_PATTERN}], TemplateElement[value.raw=${OUTPUT_ON_PATTERN}])`;
-    const outputPropertySelector = `ClassProperty[computed=false]:has(${OUTPUT_DECORATOR}) > :matches(Identifier[name=${OUTPUT_ON_PATTERN}], Literal[value=${OUTPUT_ON_PATTERN}])`;
-    const selectors = [outputAliasSelector, outputPropertySelector].join(',');
+    const outputOnPattern = /^on(([^a-z])|(?=$))/;
+    const selectors = [
+      OUTPUTS_METADATA_PROPERTY,
+      OUTPUT_ALIAS,
+      OUTPUT_PROPERTY_OR_GETTER,
+    ].join(',');
 
     return {
       [selectors](
-        node: TSESTree.Identifier | TSESTree.Literal | TSESTree.TemplateElement,
+        node:
+          | TSESTree.Identifier
+          | TSESTree.StringLiteral
+          | TSESTree.TemplateElement,
       ) {
+        const [propertyName, aliasName] = getRawText(node)
+          .replace(/\s/g, '')
+          .split(':');
+
+        if (
+          !outputOnPattern.test(propertyName) &&
+          !outputOnPattern.test(aliasName)
+        ) {
+          return;
+        }
+
         context.report({
           node,
           messageId: 'noOutputOnPrefix',

--- a/packages/integration-tests/tests/__snapshots__/v1123-multi-project-manual-config.test.ts.snap
+++ b/packages/integration-tests/tests/__snapshots__/v1123-multi-project-manual-config.test.ts.snap
@@ -20,7 +20,7 @@ __ROOT__/v1123-multi-project-manual-config/src/app/example.component.ts
   12:3   error  Use @Input rather than the \`inputs\` metadata property (https://angular.io/styleguide#style-05-12)                                     @angular-eslint/no-inputs-metadata-property
   13:3   error  Use @Output rather than the \`outputs\` metadata property (https://angular.io/styleguide#style-05-12)                                   @angular-eslint/no-outputs-metadata-property
   14:3   error  Use @HostBinding or @HostListener rather than the \`host\` metadata property (https://angular.io/styleguide#style-06-03)                @angular-eslint/no-host-metadata-property
-  18:13  error  Output bindings, including aliases, should not be named \\"on\\", nor prefixed with it (https://angular.io/guide/styleguide#style-05-16)  @angular-eslint/no-output-on-prefix
+  18:13  error  Output bindings, including aliases, should not be named or prefixed with \\"on\\" (https://angular.io/guide/styleguide#style-05-16)  @angular-eslint/no-output-on-prefix
    6:35  error  Invalid binding syntax. Use [(expr)] instead                                                                                          @angular-eslint/template/banana-in-box
    8:15  error  Invalid binding syntax. Use [(expr)] instead                                                                                          @angular-eslint/template/banana-in-box
    8:29  error  Invalid binding syntax. Use [(expr)] instead                                                                                          @angular-eslint/template/banana-in-box

--- a/packages/integration-tests/tests/__snapshots__/v1123-multi-project-manual-config.test.ts.snap
+++ b/packages/integration-tests/tests/__snapshots__/v1123-multi-project-manual-config.test.ts.snap
@@ -20,7 +20,7 @@ __ROOT__/v1123-multi-project-manual-config/src/app/example.component.ts
   12:3   error  Use @Input rather than the \`inputs\` metadata property (https://angular.io/styleguide#style-05-12)                                     @angular-eslint/no-inputs-metadata-property
   13:3   error  Use @Output rather than the \`outputs\` metadata property (https://angular.io/styleguide#style-05-12)                                   @angular-eslint/no-outputs-metadata-property
   14:3   error  Use @HostBinding or @HostListener rather than the \`host\` metadata property (https://angular.io/styleguide#style-06-03)                @angular-eslint/no-host-metadata-property
-  18:13  error  Output bindings, including aliases, should not be named or prefixed with \\"on\\" (https://angular.io/guide/styleguide#style-05-16)  @angular-eslint/no-output-on-prefix
+  18:13  error  Output bindings, including aliases, should not be named \\"on\\", nor prefixed with it (https://angular.io/guide/styleguide#style-05-16)  @angular-eslint/no-output-on-prefix
    6:35  error  Invalid binding syntax. Use [(expr)] instead                                                                                          @angular-eslint/template/banana-in-box
    8:15  error  Invalid binding syntax. Use [(expr)] instead                                                                                          @angular-eslint/template/banana-in-box
    8:29  error  Invalid binding syntax. Use [(expr)] instead                                                                                          @angular-eslint/template/banana-in-box


### PR DESCRIPTION
This PR implements the checks for both `getters` and `outputs` metadata property for `no-output-on-prefix` rule.