### PR TITLE
refactor(eslint-plugin): [prefer-output-readonly] use computed selector

### DIFF
--- a/packages/eslint-plugin/src/rules/prefer-output-readonly.ts
+++ b/packages/eslint-plugin/src/rules/prefer-output-readonly.ts
@@ -1,5 +1,6 @@
 import type { TSESTree } from '@typescript-eslint/experimental-utils';
 import { createESLintRule } from '../utils/create-eslint-rule';
+import { OUTPUT_DECORATOR } from '../utils/selectors';
 
 type Options = [];
 export type MessageIds = 'preferOutputReadonly' | 'suggestAddReadonlyModifier';
@@ -11,7 +12,7 @@ export default createESLintRule<Options, MessageIds>({
     type: 'suggestion',
     docs: {
       description:
-        'Prefer to declare `@Output` as readonly since they are not supposed to be reassigned',
+        'Prefer to declare `@Output` as `readonly` since they are not supposed to be reassigned',
       category: 'Best Practices',
       recommended: false,
       suggestion: true,
@@ -19,14 +20,14 @@ export default createESLintRule<Options, MessageIds>({
     schema: [],
     messages: {
       preferOutputReadonly:
-        'Prefer to declare `@Output` as readonly since they are not supposed to be reassigned',
-      suggestAddReadonlyModifier: 'Add readonly modifier',
+        'Prefer to declare `@Output` as `readonly` since they are not supposed to be reassigned',
+      suggestAddReadonlyModifier: 'Add `readonly` modifier',
     },
   },
   defaultOptions: [],
   create(context) {
     return {
-      'ClassProperty[readonly=undefined] > Decorator[expression.callee.name="Output"]'({
+      [`ClassProperty:not([readonly]) > ${OUTPUT_DECORATOR}`]({
         parent: { key },
       }: TSESTree.Decorator & { parent: TSESTree.ClassProperty }) {
         context.report({

--- a/packages/eslint-plugin/tests/rules/prefer-output-readonly.test.ts
+++ b/packages/eslint-plugin/tests/rules/prefer-output-readonly.test.ts
@@ -19,6 +19,11 @@ ruleTester.run(RULE_NAME, rule, {
   valid: [
     `
     class Test {
+      testEmitter = new EventEmitter<string>();
+    }
+    `,
+    `
+    class Test {
       @Output() readonly testEmitter = new EventEmitter<string>();
     }
     `,


### PR DESCRIPTION
A minor refactor to make use of the shared selector `OUTPUT_DECORATOR`. I also took the opportunity to add a test to make sure it only reports properties with the expected decorator.