### PR TITLE
refactor(eslint-plugin): [no-outputs-metadata-property] switch to selectors

### DIFF
--- a/packages/eslint-plugin/src/rules/no-outputs-metadata-property.ts
+++ b/packages/eslint-plugin/src/rules/no-outputs-metadata-property.ts
@@ -1,15 +1,10 @@
 import type { TSESTree } from '@typescript-eslint/experimental-utils';
 import { createESLintRule } from '../utils/create-eslint-rule';
 import { COMPONENT_OR_DIRECTIVE_CLASS_DECORATOR } from '../utils/selectors';
-import {
-  AngularInnerClassDecorators,
-  getDecoratorPropertyValue,
-} from '../utils/utils';
 
 type Options = [];
 export type MessageIds = 'noOutputsMetadataProperty';
 export const RULE_NAME = 'no-outputs-metadata-property';
-
 const METADATA_PROPERTY_NAME = 'outputs';
 const STYLE_GUIDE_LINK = 'https://angular.io/styleguide#style-05-12';
 
@@ -18,29 +13,23 @@ export default createESLintRule<Options, MessageIds>({
   meta: {
     type: 'suggestion',
     docs: {
-      description: `Disallows usage of the \`${METADATA_PROPERTY_NAME}\` metadata property. See more at ${STYLE_GUIDE_LINK}.`,
+      description: `Disallows usage of the \`${METADATA_PROPERTY_NAME}\` metadata property. See more at ${STYLE_GUIDE_LINK}`,
       category: 'Best Practices',
       recommended: 'error',
     },
     schema: [],
     messages: {
-      noOutputsMetadataProperty: `Use @${AngularInnerClassDecorators.Output} rather than the \`${METADATA_PROPERTY_NAME}\` metadata property (${STYLE_GUIDE_LINK})`,
+      noOutputsMetadataProperty: `Use \`@Output\` rather than the \`${METADATA_PROPERTY_NAME}\` metadata property (${STYLE_GUIDE_LINK})`,
     },
   },
   defaultOptions: [],
   create(context) {
     return {
-      [COMPONENT_OR_DIRECTIVE_CLASS_DECORATOR](node: TSESTree.Decorator) {
-        const propertyExpression = getDecoratorPropertyValue(
-          node,
-          METADATA_PROPERTY_NAME,
-        );
-        if (!propertyExpression) {
-          return;
-        }
-
+      [`${COMPONENT_OR_DIRECTIVE_CLASS_DECORATOR} Property[key.name="${METADATA_PROPERTY_NAME}"][computed=false]`](
+        node: TSESTree.Property,
+      ) {
         context.report({
-          node: propertyExpression.parent as TSESTree.Property,
+          node,
           messageId: 'noOutputsMetadataProperty',
         });
       },

--- a/packages/eslint-plugin/tests/rules/no-outputs-metadata-property.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-outputs-metadata-property.test.ts
@@ -12,29 +12,51 @@ import rule, { RULE_NAME } from '../../src/rules/no-outputs-metadata-property';
 const ruleTester = new RuleTester({
   parser: '@typescript-eslint/parser',
 });
-
 const messageId: MessageIds = 'noOutputsMetadataProperty';
 
 ruleTester.run(RULE_NAME, rule, {
   valid: [
     `
+    @Directive()
+    class Test {}
+    `,
+    `
+    const options = {};
+    @Component(options)
+    export class Test {}
+    `,
+    `
     @Component({
       selector: 'app-test',
       template: 'Hello'
     })
-    class TestComponent {}
-`,
+    class Test {}
+    `,
     `
     @Directive({
-      selector: 'app-test'
+      selector: 'app-test',
+      queries: {},
     })
-    class TestDirective {}
-`,
+    class Test {}
+    `,
+    `
+    const outputs = 'host';
+    @Component({
+      [outputs]: [],
+    })
+    class Test {}
+    `,
+    `
+    @NgModule({
+      bootstrap: [Foo]
+    })
+    export class Test {}
+    `,
   ],
   invalid: [
     convertAnnotatedSourceToFailureCase({
       description:
-        'it should fail if "outputs" metadata property is used in @Component',
+        'it should fail if "outputs" metadata property is used in `@Component`',
       annotatedSource: `
         @Component({
           outputs: [
@@ -44,13 +66,13 @@ ruleTester.run(RULE_NAME, rule, {
           ~
           selector: 'app-test'
         })
-        class TestComponent {}
+        class Test {}
       `,
       messageId,
     }),
     convertAnnotatedSourceToFailureCase({
       description:
-        'it should fail if "outputs" metadata property is used in @Directive',
+        'it should fail if "outputs" metadata property is used in `@Directive`',
       annotatedSource: `
         @Directive({
           outputs: [
@@ -60,7 +82,72 @@ ruleTester.run(RULE_NAME, rule, {
           ~
           selector: 'app-test'
         })
-        class TestDirective {}
+        class Test {}
+      `,
+      messageId,
+    }),
+    convertAnnotatedSourceToFailureCase({
+      description: 'it should fail if "outputs" metadata property is shorthand',
+      annotatedSource: `
+        @Component({
+          outputs,
+          ~~~~~~~
+        })
+        export class Test {}
+      `,
+      messageId,
+    }),
+    convertAnnotatedSourceToFailureCase({
+      description:
+        'it should fail if "outputs" metadata property has no properties',
+      annotatedSource: `
+        @Component({
+          outputs: [],
+          ~~~~~~~~~~~
+        })
+        export class Test {}
+      `,
+      messageId,
+    }),
+    convertAnnotatedSourceToFailureCase({
+      description:
+        'it should fail if "outputs" metadata property\'s value is a variable',
+      annotatedSource: `
+        const test = [];
+
+        @Component({
+          outputs: test,
+          ~~~~~~~~~~~~~
+        })
+        export class Test {}
+      `,
+      messageId,
+    }),
+    convertAnnotatedSourceToFailureCase({
+      description:
+        'it should fail if "outputs" metadata property\'s value is `undefined`',
+      annotatedSource: `
+        @Component({
+          outputs: undefined,
+          ~~~~~~~~~~~~~~~~~~
+        })
+        export class Test {}
+      `,
+      messageId,
+    }),
+    convertAnnotatedSourceToFailureCase({
+      description:
+        'it should fail if "outputs" metadata property\'s value is a function',
+      annotatedSource: `
+        function outputs() {
+          return [];
+        }
+
+        @Directive({
+          outputs: outputs(),
+          ~~~~~~~~~~~~~~~~~~
+        })
+        export class Test {}
       `,
       messageId,
     }),

--- a/packages/integration-tests/tests/__snapshots__/v1123-multi-project-manual-config.test.ts.snap
+++ b/packages/integration-tests/tests/__snapshots__/v1123-multi-project-manual-config.test.ts.snap
@@ -18,7 +18,7 @@ __ROOT__/v1123-multi-project-manual-config/src/app/app.component.ts
 __ROOT__/v1123-multi-project-manual-config/src/app/example.component.ts
    4:13  error  Strings must use singlequote                                                                                                          @typescript-eslint/quotes
   12:3   error  Use @Input rather than the \`inputs\` metadata property (https://angular.io/styleguide#style-05-12)                                     @angular-eslint/no-inputs-metadata-property
-  13:3   error  Use @Output rather than the \`outputs\` metadata property (https://angular.io/styleguide#style-05-12)                                   @angular-eslint/no-outputs-metadata-property
+  13:3   error  Use `@Output` rather than the \`outputs\` metadata property (https://angular.io/styleguide#style-05-12)                                   @angular-eslint/no-outputs-metadata-property
   14:3   error  Use @HostBinding or @HostListener rather than the \`host\` metadata property (https://angular.io/styleguide#style-06-03)                @angular-eslint/no-host-metadata-property
   18:13  error  Output bindings, including aliases, should not be named \\"on\\", nor prefixed with it (https://angular.io/guide/styleguide#style-05-16)  @angular-eslint/no-output-on-prefix
    6:35  error  Invalid binding syntax. Use [(expr)] instead                                                                                          @angular-eslint/template/banana-in-box


### PR DESCRIPTION
Basically changes the implementation to use selectors. In addition to this, I added some tests to ensure we only report non-computed properties.