### PR TITLE
feat: add outputFile to builder (#349)

### DIFF
--- a/packages/builder/src/schema.d.ts
+++ b/packages/builder/src/schema.d.ts
@@ -13,6 +13,7 @@ export interface Schema extends JsonObject {
   cacheStrategy: 'content' | 'metadata' | null;
   eslintConfig: string | null;
   ignorePath: string | null;
+  outputFile: string | null;
 }
 
 type Formatter =

--- a/packages/builder/src/schema.json
+++ b/packages/builder/src/schema.json
@@ -84,6 +84,10 @@
     "ignorePath": {
       "type": "string",
       "description": "The path of the .eslintignore file."
+    },
+    "outputFile": {
+      "type": "string",
+      "description": "File to write report to."
     }
   },
   "additionalProperties": false,


### PR DESCRIPTION
This adds the `outputFile` to the schema and thus closes #349

For the code style I leaned on to https://github.com/nrwl/nx/blob/c7a5f6d7dd04f85386465dd0b7d86bcc74daa4ba/packages/linter/src/executors/eslint/lint.impl.ts#L108 with the exception that i use the `recursive` option of `mkdirSync` which doesn't require a custom recursive function. (Thx to @FrozenPandaz for the basic functionality!)

What I'm not sure about if it should default to JSON output for the written file. Currently it writes the specified format to the outputFile which could lead to confusion.

If anything is missing / should be changed please tell me :)