### PR TITLE
fix(eslint-plugin): [no-input-rename] handle alias and `inputs` metadata property

### DIFF
--- a/packages/eslint-plugin/src/utils/get-aria-attribute-keys.ts
+++ b/packages/eslint-plugin/src/utils/get-aria-attribute-keys.ts
@@ -1,0 +1,56 @@
+let ariaAttributeKeys: ReadonlySet<string> | null = null;
+
+export function getAriaAttributeKeys(): ReadonlySet<string> {
+  return (
+    ariaAttributeKeys ??
+    (ariaAttributeKeys = new Set<string>([
+      // Source: https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques
+      'aria-activedescendant',
+      'aria-atomic',
+      'aria-autocomplete',
+      'aria-busy',
+      'aria-checked',
+      'aria-colcount',
+      'aria-colindex',
+      'aria-colspan',
+      'aria-controls',
+      'aria-current',
+      'aria-describedby',
+      'aria-details',
+      'aria-disabled',
+      'aria-dragged',
+      'aria-dropeffect',
+      'aria-errormessage',
+      'aria-expanded',
+      'aria-flowto',
+      'aria-haspopup',
+      'aria-hidden',
+      'aria-invalid',
+      'aria-label',
+      'aria-labelledby',
+      'aria-level',
+      'aria-live',
+      'aria-modal',
+      'aria-multiline',
+      'aria-multiselectable',
+      'aria-orientation',
+      'aria-owns',
+      'aria-placeholder',
+      'aria-posinset',
+      'aria-pressed',
+      'aria-readonly',
+      'aria-relevant',
+      'aria-required',
+      'aria-rowcount',
+      'aria-rowindex',
+      'aria-rowspan',
+      'aria-selected',
+      'aria-setsize',
+      'aria-sort',
+      'aria-valuemax',
+      'aria-valuemin',
+      'aria-valuenow',
+      'aria-valuetext',
+    ]))
+  );
+}

--- a/packages/eslint-plugin/src/utils/selectors.ts
+++ b/packages/eslint-plugin/src/utils/selectors.ts
@@ -16,10 +16,32 @@ export const INJECTABLE_CLASS_DECORATOR =
 export const MODULE_CLASS_DECORATOR =
   'ClassDeclaration > Decorator[expression.callee.name="NgModule"]';
 
+export const INPUT_DECORATOR = 'Decorator[expression.callee.name="Input"]';
+
 export const OUTPUT_DECORATOR = 'Decorator[expression.callee.name="Output"]';
 
-export const OUTPUTS_METADATA_PROPERTY = `${COMPONENT_OR_DIRECTIVE_CLASS_DECORATOR} Property[key.name='outputs'] > ArrayExpression :matches(Literal, TemplateElement)`;
+export const LITERAL_OR_TEMPLATE_ELEMENT = ':matches(Literal, TemplateElement)';
 
-export const OUTPUT_ALIAS = `:matches(ClassProperty, MethodDefinition[kind='get']) ${OUTPUT_DECORATOR} :matches(Literal, TemplateElement)`;
+export const SELECTOR_METADATA_PROPERTY =
+  'Property:matches([key.name="selector"], [key.value="selector"])';
+
+export const COMPONENT_SELECTOR_LITERAL = `${COMPONENT_CLASS_DECORATOR} ${SELECTOR_METADATA_PROPERTY} ${LITERAL_OR_TEMPLATE_ELEMENT}`;
+
+export const DIRECTIVE_SELECTOR_LITERAL = `${DIRECTIVE_CLASS_DECORATOR} ${SELECTOR_METADATA_PROPERTY} ${LITERAL_OR_TEMPLATE_ELEMENT}`;
+
+export const COMPONENT_OR_DIRECTIVE_SELECTOR_LITERAL = `:matches(${COMPONENT_SELECTOR_LITERAL}, ${DIRECTIVE_SELECTOR_LITERAL})`;
+
+export const INPUTS_METADATA_PROPERTY =
+  'Property:matches([key.name="inputs"], [key.value="inputs"])';
+
+export const INPUTS_METADATA_PROPERTY_LITERAL = `${COMPONENT_OR_DIRECTIVE_CLASS_DECORATOR} ${INPUTS_METADATA_PROPERTY} > ArrayExpression ${LITERAL_OR_TEMPLATE_ELEMENT}`;
+
+export const INPUT_ALIAS = `:matches(ClassProperty, MethodDefinition[kind='set']) ${INPUT_DECORATOR} ${LITERAL_OR_TEMPLATE_ELEMENT}`;
+
+export const INPUT_PROPERTY_OR_SETTER = `:matches(ClassProperty, MethodDefinition[kind='set'])[computed=false]:has(${INPUT_DECORATOR}) > :matches(Identifier, Literal)`;
+
+export const OUTPUTS_METADATA_PROPERTY = `${COMPONENT_OR_DIRECTIVE_CLASS_DECORATOR} Property[key.name='outputs'] > ArrayExpression ${LITERAL_OR_TEMPLATE_ELEMENT}`;
+
+export const OUTPUT_ALIAS = `:matches(ClassProperty, MethodDefinition[kind='get']) ${OUTPUT_DECORATOR} ${LITERAL_OR_TEMPLATE_ELEMENT}`;
 
 export const OUTPUT_PROPERTY_OR_GETTER = `:matches(ClassProperty, MethodDefinition[kind='get'])[computed=false]:has(${OUTPUT_DECORATOR}) > :matches(Identifier, Literal)`;

--- a/packages/eslint-plugin/src/utils/utils.ts
+++ b/packages/eslint-plugin/src/utils/utils.ts
@@ -759,20 +759,29 @@ export const toPattern = (value: readonly unknown[]): RegExp =>
   RegExp(`^(${value.join('|')})$`);
 
 export function getRawText(
-  node: TSESTree.Identifier | TSESTree.StringLiteral | TSESTree.TemplateElement,
+  node:
+    | TSESTree.Identifier
+    | TSESTree.Literal
+    | TSESTree.TemplateElement
+    | TSESTree.TemplateLiteral,
 ): string {
   if (ASTUtils.isIdentifier(node)) {
     return node.name;
   }
 
-  return isStringLiteral(node) ? node.value : node.value.raw;
+  if (isLiteral(node)) {
+    return String(node.value);
+  }
+
+  const templateElement = isTemplateLiteral(node) ? node.quasis[0] : node;
+  return templateElement.value.raw;
 }
 
 export function getReplacementText(
-  node: TSESTree.StringLiteral | TSESTree.TemplateElement,
+  node: TSESTree.Literal | TSESTree.TemplateElement | TSESTree.TemplateLiteral,
   text: string,
 ): string {
-  return isStringLiteral(node) ? `'${text}'` : `\`${text}\``;
+  return isLiteral(node) ? `'${text}'` : `\`${text}\``;
 }
 
 export function capitalize<T extends string>(text: T): Capitalize<T> {


### PR DESCRIPTION
Following the same we did in #568, this PR implements the checks for both alias and `inputs` metadata property for `no-input-rename` rule.

In addittion to this, I've added suggestion and fix (in case of property name === alias name).