### PR TITLE
refactor(eslint-plugin): [no-inputs-metadata-property] switch to selectors

### DIFF
--- a/packages/eslint-plugin/src/rules/no-inputs-metadata-property.ts
+++ b/packages/eslint-plugin/src/rules/no-inputs-metadata-property.ts
@@ -1,15 +1,13 @@
 import type { TSESTree } from '@typescript-eslint/experimental-utils';
 import { createESLintRule } from '../utils/create-eslint-rule';
-import { COMPONENT_OR_DIRECTIVE_CLASS_DECORATOR } from '../utils/selectors';
 import {
-  AngularInnerClassDecorators,
-  getDecoratorPropertyValue,
-} from '../utils/utils';
+  COMPONENT_OR_DIRECTIVE_CLASS_DECORATOR,
+  INPUTS_METADATA_PROPERTY,
+} from '../utils/selectors';
 
 type Options = [];
 export type MessageIds = 'noInputsMetadataProperty';
 export const RULE_NAME = 'no-inputs-metadata-property';
-
 const METADATA_PROPERTY_NAME = 'inputs';
 const STYLE_GUIDE_LINK = 'https://angular.io/styleguide#style-05-12';
 
@@ -18,29 +16,23 @@ export default createESLintRule<Options, MessageIds>({
   meta: {
     type: 'suggestion',
     docs: {
-      description: `Disallows usage of the \`${METADATA_PROPERTY_NAME}\` metadata property. See more at ${STYLE_GUIDE_LINK}.`,
+      description: `Disallows usage of the \`${METADATA_PROPERTY_NAME}\` metadata property. See more at ${STYLE_GUIDE_LINK}`,
       category: 'Best Practices',
       recommended: 'error',
     },
     schema: [],
     messages: {
-      noInputsMetadataProperty: `Use @${AngularInnerClassDecorators.Input} rather than the \`${METADATA_PROPERTY_NAME}\` metadata property (${STYLE_GUIDE_LINK})`,
+      noInputsMetadataProperty: `Use \`@Input\` rather than the \`${METADATA_PROPERTY_NAME}\` metadata property (${STYLE_GUIDE_LINK})`,
     },
   },
   defaultOptions: [],
   create(context) {
     return {
-      [COMPONENT_OR_DIRECTIVE_CLASS_DECORATOR](node: TSESTree.Decorator) {
-        const propertyExpression = getDecoratorPropertyValue(
-          node,
-          METADATA_PROPERTY_NAME,
-        );
-        if (!propertyExpression) {
-          return;
-        }
-
+      [`${COMPONENT_OR_DIRECTIVE_CLASS_DECORATOR} ${INPUTS_METADATA_PROPERTY}[computed=false]`](
+        node: TSESTree.PropertyNonComputedName,
+      ) {
         context.report({
-          node: propertyExpression.parent as TSESTree.Property,
+          node,
           messageId: 'noInputsMetadataProperty',
         });
       },

--- a/packages/eslint-plugin/src/utils/selectors.ts
+++ b/packages/eslint-plugin/src/utils/selectors.ts
@@ -16,10 +16,32 @@ export const INJECTABLE_CLASS_DECORATOR =
 export const MODULE_CLASS_DECORATOR =
   'ClassDeclaration > Decorator[expression.callee.name="NgModule"]';
 
+export const INPUT_DECORATOR = 'Decorator[expression.callee.name="Input"]';
+
 export const OUTPUT_DECORATOR = 'Decorator[expression.callee.name="Output"]';
 
-export const OUTPUTS_METADATA_PROPERTY = `${COMPONENT_OR_DIRECTIVE_CLASS_DECORATOR} Property[key.name='outputs'] > ArrayExpression :matches(Literal, TemplateElement)`;
+export const LITERAL_OR_TEMPLATE_ELEMENT = ':matches(Literal, TemplateElement)';
 
-export const OUTPUT_ALIAS = `:matches(ClassProperty, MethodDefinition[kind='get']) ${OUTPUT_DECORATOR} :matches(Literal, TemplateElement)`;
+export const SELECTOR_METADATA_PROPERTY =
+  'Property:matches([key.name="selector"], [key.value="selector"])';
+
+export const COMPONENT_SELECTOR_LITERAL = `${COMPONENT_CLASS_DECORATOR} ${SELECTOR_METADATA_PROPERTY} ${LITERAL_OR_TEMPLATE_ELEMENT}`;
+
+export const DIRECTIVE_SELECTOR_LITERAL = `${DIRECTIVE_CLASS_DECORATOR} ${SELECTOR_METADATA_PROPERTY} ${LITERAL_OR_TEMPLATE_ELEMENT}`;
+
+export const COMPONENT_OR_DIRECTIVE_SELECTOR_LITERAL = `:matches(${COMPONENT_SELECTOR_LITERAL}, ${DIRECTIVE_SELECTOR_LITERAL})`;
+
+export const INPUTS_METADATA_PROPERTY =
+  'Property:matches([key.name="inputs"], [key.value="inputs"])';
+
+export const INPUTS_METADATA_PROPERTY_LITERAL = `${COMPONENT_OR_DIRECTIVE_CLASS_DECORATOR} ${INPUTS_METADATA_PROPERTY} > ArrayExpression ${LITERAL_OR_TEMPLATE_ELEMENT}`;
+
+export const INPUT_ALIAS = `:matches(ClassProperty, MethodDefinition[kind='set']) ${INPUT_DECORATOR} ${LITERAL_OR_TEMPLATE_ELEMENT}`;
+
+export const INPUT_PROPERTY_OR_SETTER = `:matches(ClassProperty, MethodDefinition[kind='set'])[computed=false]:has(${INPUT_DECORATOR}) > :matches(Identifier, Literal)`;
+
+export const OUTPUTS_METADATA_PROPERTY = `${COMPONENT_OR_DIRECTIVE_CLASS_DECORATOR} Property[key.name='outputs'] > ArrayExpression ${LITERAL_OR_TEMPLATE_ELEMENT}`;
+
+export const OUTPUT_ALIAS = `:matches(ClassProperty, MethodDefinition[kind='get']) ${OUTPUT_DECORATOR} ${LITERAL_OR_TEMPLATE_ELEMENT}`;
 
 export const OUTPUT_PROPERTY_OR_GETTER = `:matches(ClassProperty, MethodDefinition[kind='get'])[computed=false]:has(${OUTPUT_DECORATOR}) > :matches(Identifier, Literal)`;

--- a/packages/eslint-plugin/tests/rules/no-inputs-metadata-property.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-inputs-metadata-property.test.ts
@@ -12,29 +12,56 @@ import rule, { RULE_NAME } from '../../src/rules/no-inputs-metadata-property';
 const ruleTester = new RuleTester({
   parser: '@typescript-eslint/parser',
 });
-
 const messageId: MessageIds = 'noInputsMetadataProperty';
 
 ruleTester.run(RULE_NAME, rule, {
   valid: [
+    `class Test {}`,
     `
-    @Component({
+    @Component()
+    class Test {}
+    `,
+    `
+    @Directive({})
+    class Test {}
+    `,
+    `
+    const options = {};
+    @Component(options)
+    class Test {}
+    `,
+    `
+    @Directive({
       selector: 'app-test',
       template: 'Hello'
     })
-    class TestComponent {}
-`,
+    class Test {}
+    `,
     `
-    @Directive({
-      selector: 'app-test'
+    @Component({
+      selector: 'app-test',
+      queries: {},
     })
-    class TestDirective {}
-`,
+    class Test {}
+    `,
+    `
+    const inputs = 'providers';
+    @Directive({
+      [inputs]: [],
+    })
+    class Test {}
+    `,
+    `
+    @NgModule({
+      bootstrap: [Foo]
+    })
+    class Test {}
+    `,
   ],
   invalid: [
     convertAnnotatedSourceToFailureCase({
       description:
-        'it should fail if "inputs" metadata property is used in @Component',
+        'should fail if `inputs` metadata property is used in `@Component`',
       annotatedSource: `
         @Component({
           inputs: [
@@ -44,13 +71,13 @@ ruleTester.run(RULE_NAME, rule, {
           ~
           selector: 'app-test'
         })
-        class TestComponent {}
+        class Test {}
       `,
       messageId,
     }),
     convertAnnotatedSourceToFailureCase({
       description:
-        'it should fail if "inputs" metadata property is used in @Directive',
+        'should fail if `inputs` metadata property is used in `@Directive`',
       annotatedSource: `
         @Directive({
           inputs: [
@@ -60,7 +87,71 @@ ruleTester.run(RULE_NAME, rule, {
           ~
           selector: 'app-test'
         })
-        class TestDirective {}
+        class Test {}
+      `,
+      messageId,
+    }),
+    convertAnnotatedSourceToFailureCase({
+      description: 'should fail if `inputs` metadata property is shorthand',
+      annotatedSource: `
+        @Component({
+          inputs,
+          ~~~~~~
+        })
+        class Test {}
+      `,
+      messageId,
+    }),
+    convertAnnotatedSourceToFailureCase({
+      description:
+        'should fail if `inputs` metadata property has no properties',
+      annotatedSource: `
+        @Component({
+          inputs: [],
+          ~~~~~~~~~~
+        })
+        class Test {}
+      `,
+      messageId,
+    }),
+    convertAnnotatedSourceToFailureCase({
+      description:
+        "should fail if `inputs` metadata property's value is a variable",
+      annotatedSource: `
+        const test = [];
+        @Component({
+          inputs: test,
+          ~~~~~~~~~~~~
+        })
+        class Test {}
+      `,
+      messageId,
+    }),
+    convertAnnotatedSourceToFailureCase({
+      description:
+        "should fail if `inputs` metadata property's value is `undefined`",
+      annotatedSource: `
+        @Component({
+          inputs: undefined,
+          ~~~~~~~~~~~~~~~~~
+        })
+        class Test {}
+      `,
+      messageId,
+    }),
+    convertAnnotatedSourceToFailureCase({
+      description:
+        "should fail if `inputs` metadata property's key is `Literal` and its value is a function",
+      annotatedSource: `
+        function inputs() {
+          return [];
+        }
+
+        @Directive({
+          'inputs': inputs(),
+          ~~~~~~~~~~~~~~~~~~
+        })
+        class Test {}
       `,
       messageId,
     }),

--- a/packages/eslint-plugin/tests/rules/no-pipe-impure.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-pipe-impure.test.ts
@@ -23,6 +23,10 @@ ruleTester.run(RULE_NAME, rule, {
     class Test {}
     `,
     `
+    @Pipe({})
+    class Test {}
+    `,
+    `
     const options = {};
     @Pipe(options)
     class Test {}
@@ -30,6 +34,12 @@ ruleTester.run(RULE_NAME, rule, {
     `
     @Pipe({
       name: 'test',
+    })
+    class Test {}
+    `,
+    `
+    @Pipe({
+      pure: true
     })
     class Test {}
     `,

--- a/packages/integration-tests/tests/__snapshots__/v1123-multi-project-manual-config.test.ts.snap
+++ b/packages/integration-tests/tests/__snapshots__/v1123-multi-project-manual-config.test.ts.snap
@@ -17,7 +17,7 @@ __ROOT__/v1123-multi-project-manual-config/src/app/app.component.ts
 
 __ROOT__/v1123-multi-project-manual-config/src/app/example.component.ts
    4:13  error  Strings must use singlequote                                                                                                          @typescript-eslint/quotes
-  12:3   error  Use @Input rather than the \`inputs\` metadata property (https://angular.io/styleguide#style-05-12)                                     @angular-eslint/no-inputs-metadata-property
+  12:3   error  Use `@Input` rather than the \`inputs\` metadata property (https://angular.io/styleguide#style-05-12)                                     @angular-eslint/no-inputs-metadata-property
   13:3   error  Use \`@Output\` rather than the \`outputs\` metadata property (https://angular.io/styleguide#style-05-12)                                 @angular-eslint/no-outputs-metadata-property
   14:3   error  Use @HostBinding or @HostListener rather than the \`host\` metadata property (https://angular.io/styleguide#style-06-03)                @angular-eslint/no-host-metadata-property
   18:13  error  Output bindings, including aliases, should not be named \\"on\\", nor prefixed with it (https://angular.io/guide/styleguide#style-05-16)  @angular-eslint/no-output-on-prefix


### PR DESCRIPTION
Basically changes the implementation to use selectors. In addition to this, I added some tests to ensure we only report non-computed properties.