### PR TITLE
fix(eslint-plugin): [use-pipe-transform-interface] handle type imports properly in fix

### DIFF
--- a/packages/eslint-plugin/src/rules/use-pipe-transform-interface.ts
+++ b/packages/eslint-plugin/src/rules/use-pipe-transform-interface.ts
@@ -1,10 +1,9 @@
 import type { TSESTree } from '@typescript-eslint/experimental-utils';
 import { createESLintRule } from '../utils/create-eslint-rule';
-import { PIPE_CLASS_DECORATOR } from '../utils/selectors';
 import {
-  getDeclaredInterfaceName,
   getImplementsSchemaFixer,
   getImportAddFix,
+  isNotNullOrUndefined,
 } from '../utils/utils';
 
 type Options = [];
@@ -17,7 +16,7 @@ export default createESLintRule<Options, MessageIds>({
   meta: {
     type: 'suggestion',
     docs: {
-      description: `Ensures that Pipes implement \`${PIPE_TRANSFORM}\` interface`,
+      description: `Ensures that \`Pipes\` implement \`${PIPE_TRANSFORM}\` interface`,
       category: 'Best Practices',
       recommended: 'error',
     },
@@ -30,11 +29,9 @@ export default createESLintRule<Options, MessageIds>({
   defaultOptions: [],
   create(context) {
     return {
-      [PIPE_CLASS_DECORATOR]({
+      [`ClassDeclaration:not(:has(TSClassImplements:matches([expression.name='${PIPE_TRANSFORM}'], [expression.property.name='${PIPE_TRANSFORM}']))) > Decorator[expression.callee.name='Pipe']`]({
         parent: classDeclaration,
       }: TSESTree.Decorator & { parent: TSESTree.ClassDeclaration }) {
-        if (getDeclaredInterfaceName(classDeclaration, PIPE_TRANSFORM)) return;
-
         context.report({
           node: classDeclaration.id ?? classDeclaration,
           messageId: 'usePipeTransformInterface',
@@ -53,7 +50,7 @@ export default createESLintRule<Options, MessageIds>({
                 implementsNodeReplace,
                 implementsTextReplace,
               ),
-            ];
+            ].filter(isNotNullOrUndefined);
           },
         });
       },

--- a/packages/eslint-plugin/src/utils/utils.ts
+++ b/packages/eslint-plugin/src/utils/utils.ts
@@ -404,7 +404,7 @@ export function getImportAddFix(
   moduleName: string,
   importedName: string,
   fixer: TSESLint.RuleFixer,
-): TSESLint.RuleFix {
+): TSESLint.RuleFix | undefined {
   const importDeclarations = getImportDeclarations(node, moduleName);
 
   if (!importDeclarations?.length) {
@@ -413,6 +413,13 @@ export function getImportAddFix(
       `import { ${importedName} } from '${moduleName}';\n`,
     );
   }
+
+  const importDeclarationSpecifier = getImportDeclarationSpecifier(
+    importDeclarations,
+    importedName,
+  );
+
+  if (importDeclarationSpecifier) return undefined;
 
   const firstImportDeclaration = importDeclarations[0];
   const lastImportSpecifier = getLast(firstImportDeclaration.specifiers);

--- a/packages/eslint-plugin/tests/rules/use-pipe-transform-interface.test.ts
+++ b/packages/eslint-plugin/tests/rules/use-pipe-transform-interface.test.ts
@@ -18,31 +18,34 @@ ruleTester.run(RULE_NAME, rule, {
   valid: [
     `
     @Component({ template: 'test' })
-    export class TestComponent {}
-
+    class Test {}
+    `,
+    `
     @Pipe({ name: 'test' })
-    export class TestPipe implements PipeTransform {
+    class Test implements PipeTransform {
       transform(value: string) {}
     }
-    
+    `,
+    `
     @OtherDecorator() @Pipe({ name: 'test' })
-    export class TestPipe implements PipeTransform {
+    class Test implements PipeTransform {
       transform(value: string) {}
     }
-    
+    `,
+    `
     @Pipe({ name: 'test' })
-    export class TestPipe implements ng.PipeTransform {
+    class Test implements ng.PipeTransform {
       transform(value: string) {}
     }
     `,
   ],
   invalid: [
     convertAnnotatedSourceToFailureCase({
-      description: 'it should fail if a Pipe has no interface implemented',
+      description: 'should fail if a `Pipe` has no interface implemented',
       annotatedSource: `
         @Pipe({ name: 'test' })
-        export class TestPipe {
-                     ~~~~~~~~
+        class Test {
+              ~~~~
           transform(value: string) {}
         }
       `,
@@ -50,62 +53,62 @@ ruleTester.run(RULE_NAME, rule, {
       annotatedOutput: `import { PipeTransform } from '@angular/core';
 
         @Pipe({ name: 'test' })
-        export class TestPipe implements PipeTransform {
-                     ~~~~~~~~
+        class Test implements PipeTransform {
+              ~~~~
           transform(value: string) {}
         }
       `,
     }),
     convertAnnotatedSourceToFailureCase({
       description:
-        'it should fail if a Pipe implements a interface, but not the PipeTransform',
+        'should fail if a `Pipe` implements a interface, but not the `PipeTransform`',
       annotatedSource: `
         import { HttpClient } from '@angular/common/http';
+        import type { PipeTransform } from '@angular/core';
         import { Component,
           Pipe,
           Directive } from '@angular/core';
 
         @Pipe({ name: 'test' })
-        export class TestPipe implements AnInterface {
-                     ~~~~~~~~
+        class Test implements AnInterface {
+              ~~~~
           transform(value: string) {}
         }
       `,
       messageId,
       annotatedOutput: `
         import { HttpClient } from '@angular/common/http';
+        import type { PipeTransform } from '@angular/core';
         import { Component,
           Pipe,
-          Directive, PipeTransform } from '@angular/core';
+          Directive } from '@angular/core';
 
         @Pipe({ name: 'test' })
-        export class TestPipe implements AnInterface, PipeTransform {
-                     ~~~~~~~~
+        class Test implements AnInterface, PipeTransform {
+              ~~~~
           transform(value: string) {}
         }
       `,
     }),
     convertAnnotatedSourceToFailureCase({
       description:
-        'it should fail if a Pipe implements interfaces, but not the PipeTransform',
+        'should fail if a `Pipe` implements interfaces, but not the `PipeTransform`',
       annotatedSource: `
         import type { OnInit } from '@angular/core';
-        import { Pipe } from '@angular/core';
 
         @OtherDecorator() @Pipe({ name: 'test' })
-        export class TestPipe implements AnInterface, AnotherInterface {
-                     ~~~~~~~~
+        class Test implements AnInterface, AnotherInterface {
+              ~~~~
           transform(value: string) {}
         }
       `,
       messageId,
       annotatedOutput: `
         import type { OnInit, PipeTransform } from '@angular/core';
-        import { Pipe } from '@angular/core';
 
         @OtherDecorator() @Pipe({ name: 'test' })
-        export class TestPipe implements AnInterface, AnotherInterface, PipeTransform {
-                     ~~~~~~~~
+        class Test implements AnInterface, AnotherInterface, PipeTransform {
+              ~~~~
           transform(value: string) {}
         }
       `,


### PR DESCRIPTION
This PR aims to fix a problem with import duplication in `fix`.

If we have an import `type` statement, the `fix` ignores it and duplicate `PipeTransform` in a common import statement.