### PR TITLE
feat(eslint-plugin): [use-injectable-provided-in] add suggestion

### DIFF
--- a/packages/eslint-plugin/docs/rules/use-injectable-provided-in.md
+++ b/packages/eslint-plugin/docs/rules/use-injectable-provided-in.md
@@ -13,16 +13,25 @@
 
 # `@angular-eslint/use-injectable-provided-in`
 
-"Using the 'providedIn' property makes classes decorated with @Injectable tree shakeable
+Using the `providedIn` property makes `Injectables` tree-shakable
 
 - Type: suggestion
 - Category: Best Practices
+
+- 💡 Provides suggestions on how to fix issues (https://eslint.org/docs/developer-guide/working-with-rules#providing-suggestions)
 
 <br>
 
 ## Rule Options
 
-The rule does not have any configuration options.
+The rule accepts an options object with the following properties:
+
+```ts
+interface Options {
+  ignoreClassNamePattern?: string;
+}
+
+```
 
 <br>
 
@@ -40,6 +49,52 @@ The rule does not have any configuration options.
 class Test {}
 ```
 
+```ts
+@Injectable({})
+~~~~~~~~~~~~~~~
+class Test {}
+```
+
+```ts
+const providedIn = 'anotherProperty';
+@Injectable({ [providedIn]: [] })
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+class Test {}
+```
+
+```ts
+@Injectable({ providedIn: null })
+                          ~~~~
+class Test {}
+```
+
+```ts
+@Injectable({ ['providedIn']: undefined })
+                              ~~~~~~~~~
+class Test {}
+
+@Injectable()
+class HttpPostInterceptor implements HttpInterceptor {}
+```
+
+```ts
+@Injectable({ ['providedIn']: undefined })
+                              ~~~~~~~~~
+class Test {}
+
+@Injectable()
+class ProvidedInNgModule {}
+```
+
+```ts
+@Injectable({ [`providedIn`]: undefined })
+                              ~~~~~~~~~
+class Test {}
+
+@Injectable()
+class TestEffects {}
+```
+
 <br>
 
 ---
@@ -49,15 +104,54 @@ class Test {}
 ✅ - Examples of **correct** code for this rule:
 
 ```ts
+class Test {}
+```
+
+```ts
+const options = {};
+@Injectable(options)
+class Test {}
+```
+
+```ts
 @Injectable({
-  providedIn: 'root'
+  providedIn: `any`,
 })
 class Test {}
 ```
 
 ```ts
 @Injectable({
-  providedIn: SomeModule
+  'providedIn': 'root',
 })
+class Test {}
+```
+
+```ts
+@Injectable({
+  ['providedIn']: SomeModule,
+})
+class Test {}
+```
+
+```ts
+@Injectable({
+  [`providedIn`]: providedIn(),
+})
+class Test {}
+```
+
+```ts
+@Injectable()
+class Test implements HttpInterceptor {}
+```
+
+```ts
+@Injectable()
+class Test implements ng.HttpInterceptor {}
+```
+
+```ts
+@CustomInjectable()
 class Test {}
 ```

--- a/packages/eslint-plugin/src/rules/use-injectable-provided-in.ts
+++ b/packages/eslint-plugin/src/rules/use-injectable-provided-in.ts
@@ -1,9 +1,6 @@
 import type { TSESTree } from '@typescript-eslint/experimental-utils';
 import { createESLintRule } from '../utils/create-eslint-rule';
-import {
-  INJECTABLE_CLASS_DECORATOR,
-  metadataProperty,
-} from '../utils/selectors';
+import { metadataProperty } from '../utils/selectors';
 import { getDecoratorPropertyAddFix, isProperty } from '../utils/utils';
 
 type Options = [];
@@ -30,9 +27,10 @@ export default createESLintRule<Options, MessageIds>({
   },
   defaultOptions: [],
   create(context) {
+    const injectableClassDecorator = `ClassDeclaration:not(:has(TSClassImplements:matches([expression.property.name='HttpInterceptor'], [expression.name='HttpInterceptor']))) > Decorator[expression.callee.name="Injectable"]`;
     const providedInMetadataProperty = metadataProperty('providedIn');
-    const withoutProvidedInDecorator = `${INJECTABLE_CLASS_DECORATOR}:matches([expression.arguments.length=0], [expression.arguments.0.type='ObjectExpression']:not(:has(${providedInMetadataProperty})))`;
-    const nullableProvidedInProperty = `${INJECTABLE_CLASS_DECORATOR} ${providedInMetadataProperty}:matches([value.type='Identifier'][value.name='undefined'], [value.type='Literal'][value.raw='null'])`;
+    const withoutProvidedInDecorator = `${injectableClassDecorator}:matches([expression.arguments.length=0], [expression.arguments.0.type='ObjectExpression']:not(:has(${providedInMetadataProperty})))`;
+    const nullableProvidedInProperty = `${injectableClassDecorator} ${providedInMetadataProperty}:matches([value.type='Identifier'][value.name='undefined'], [value.type='Literal'][value.raw='null'])`;
     const selectors = [
       withoutProvidedInDecorator,
       nullableProvidedInProperty,

--- a/packages/eslint-plugin/src/utils/selectors.ts
+++ b/packages/eslint-plugin/src/utils/selectors.ts
@@ -24,8 +24,8 @@ export const LITERAL_OR_TEMPLATE_ELEMENT = ':matches(Literal, TemplateElement)';
 
 export function metadataProperty<TKey extends string>(
   key: TKey,
-): `Property:matches([key.name='${TKey}'][computed=false], [key.value='${TKey}'], [key.quasis.0.value.raw='${TKey}'])` {
-  return `Property:matches([key.name='${key}'][computed=false], [key.value='${key}'], [key.quasis.0.value.raw='${key}'])`;
+): `Property:matches([key.name=${TKey}][computed=false], [key.value=${TKey}], [key.quasis.0.value.raw=${TKey}])` {
+  return `Property:matches([key.name=${key}][computed=false], [key.value=${key}], [key.quasis.0.value.raw=${key}])`;
 }
 
 export const COMPONENT_SELECTOR_LITERAL = `${COMPONENT_CLASS_DECORATOR} ${metadataProperty(

--- a/packages/eslint-plugin/tests/rules/use-injectable-provided-in/cases.ts
+++ b/packages/eslint-plugin/tests/rules/use-injectable-provided-in/cases.ts
@@ -29,6 +29,16 @@ export const valid = [
     })
     class Test {}
   `,
+  // https://github.com/angular-eslint/angular-eslint/issues/236
+  `
+    @Injectable()
+    class Test implements HttpInterceptor {}
+  `,
+  // https://github.com/angular-eslint/angular-eslint/issues/236
+  `
+    @Injectable()
+    class Test implements ng.HttpInterceptor {}
+  `,
   `
     @CustomInjectable()
     class Test {}

--- a/packages/eslint-plugin/tests/rules/use-injectable-provided-in/cases.ts
+++ b/packages/eslint-plugin/tests/rules/use-injectable-provided-in/cases.ts
@@ -2,30 +2,130 @@ import { convertAnnotatedSourceToFailureCase } from '@angular-eslint/utils';
 import type { MessageIds } from '../../../src/rules/use-injectable-provided-in';
 
 const messageId: MessageIds = 'useInjectableProvidedIn';
+const suggestInjector: MessageIds = 'suggestInjector';
 
 export const valid = [
+  `class Test {}`,
+  `
+    const options = {};
+    @Injectable(options)
+    class Test {}
+  `,
   `
     @Injectable({
-      providedIn: 'root'
+      providedIn: \`any\`,
     })
     class Test {}
-`,
+  `,
   `
     @Injectable({
-      providedIn: SomeModule
+      'providedIn': 'root',
     })
     class Test {}
-`,
+  `,
+  `
+    @Injectable({
+      providedIn: SomeModule,
+    })
+    class Test {}
+  `,
+  `
+    @CustomInjectable()
+    class Test {}
+  `,
 ];
 
 export const invalid = [
   convertAnnotatedSourceToFailureCase({
-    description: 'it should fail if providedIn property is not set',
+    description: 'should fail if `@Injectable` has no arguments',
     annotatedSource: `
-        @Injectable()
-        ~~~~~~~~~~~~~
-        class Test {}
-      `,
+      @Injectable()
+      ~~~~~~~~~~~~~
+      class Test {}
+    `,
     messageId,
+    suggestions: (['any', 'platform', 'root'] as const).map((injector) => ({
+      messageId: suggestInjector,
+      output: `
+      @Injectable({providedIn: '${injector}'})
+      
+      class Test {}
+    `,
+      data: { injector },
+    })),
+  }),
+  convertAnnotatedSourceToFailureCase({
+    description: "should fail if `@Injectable`'s argument has no properties",
+    annotatedSource: `
+      @Injectable({})
+      ~~~~~~~~~~~~~~~
+      class Test {}
+    `,
+    messageId,
+    suggestions: (['any', 'platform', 'root'] as const).map((injector) => ({
+      messageId: suggestInjector,
+      output: `
+      @Injectable({providedIn: '${injector}'})
+      
+      class Test {}
+    `,
+      data: { injector },
+    })),
+  }),
+  convertAnnotatedSourceToFailureCase({
+    description: 'should fail if `@Injectable` has no `providedIn`',
+    annotatedSource: `
+      const providedIn = 'anotherProperty';
+      @Injectable({ [providedIn]: [] })
+      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      class Test {}
+    `,
+    messageId,
+    suggestions: (['any', 'platform', 'root'] as const).map((injector) => ({
+      messageId: suggestInjector,
+      output: `
+      const providedIn = 'anotherProperty';
+      @Injectable({ providedIn: '${injector}',[providedIn]: [] })
+      
+      class Test {}
+    `,
+      data: { injector },
+    })),
+  }),
+  convertAnnotatedSourceToFailureCase({
+    description: 'should fail if `providedIn` is set to `null`',
+    annotatedSource: `
+      @Injectable({ providedIn: null })
+                    ~~~~~~~~~~~~~~~~
+      class Test {}
+    `,
+    messageId,
+    suggestions: (['any', 'platform', 'root'] as const).map((injector) => ({
+      messageId: suggestInjector,
+      output: `
+      @Injectable({ providedIn: '${injector}' })
+                    
+      class Test {}
+    `,
+      data: { injector },
+    })),
+  }),
+  convertAnnotatedSourceToFailureCase({
+    description: 'should fail if `providedIn` is set to `undefined`',
+    annotatedSource: `
+      @Injectable({ 'providedIn': undefined })
+                    ~~~~~~~~~~~~~~~~~~~~~~~
+      class Test {}
+    `,
+    messageId,
+    suggestions: (['any', 'platform', 'root'] as const).map((injector) => ({
+      messageId: suggestInjector,
+      output: `
+      @Injectable({ 'providedIn': '${injector}' })
+                    
+      class Test {}
+    `,
+      data: { injector },
+    })),
   }),
 ];


### PR DESCRIPTION
**1st. commit**: adds suggestions that covers the most common values and also fixes some false negatives like when we use `null` as value or when we use a computed argument to `@Injectable` decorator and false positives when we use `'providedIn'` as a `Literal`;
**2nd. commit**: ignore classes that implements `HttpInterceptor` (see #236);
**3rd. commit**: add option to ignore classes given a pattern (see #236).

Closes #236.