### PR TITLE
fix(eslint-plugin): handle literal `outputs` properly for [*-output-*] rules

### DIFF
--- a/packages/eslint-plugin/src/rules/no-inputs-metadata-property.ts
+++ b/packages/eslint-plugin/src/rules/no-inputs-metadata-property.ts
@@ -2,7 +2,7 @@ import type { TSESTree } from '@typescript-eslint/experimental-utils';
 import { createESLintRule } from '../utils/create-eslint-rule';
 import {
   COMPONENT_OR_DIRECTIVE_CLASS_DECORATOR,
-  INPUTS_METADATA_PROPERTY,
+  metadataProperty,
 } from '../utils/selectors';
 
 type Options = [];
@@ -28,9 +28,9 @@ export default createESLintRule<Options, MessageIds>({
   defaultOptions: [],
   create(context) {
     return {
-      [`${COMPONENT_OR_DIRECTIVE_CLASS_DECORATOR} ${INPUTS_METADATA_PROPERTY}[computed=false]`](
-        node: TSESTree.PropertyNonComputedName,
-      ) {
+      [`${COMPONENT_OR_DIRECTIVE_CLASS_DECORATOR} ${metadataProperty(
+        METADATA_PROPERTY_NAME,
+      )}`](node: TSESTree.PropertyNonComputedName) {
         context.report({
           node,
           messageId: 'noInputsMetadataProperty',

--- a/packages/eslint-plugin/src/rules/no-output-native.ts
+++ b/packages/eslint-plugin/src/rules/no-output-native.ts
@@ -2,7 +2,7 @@ import type { TSESTree } from '@typescript-eslint/experimental-utils';
 import { createESLintRule } from '../utils/create-eslint-rule';
 import { getNativeEventNames } from '../utils/get-native-event-names';
 import {
-  OUTPUTS_METADATA_PROPERTY,
+  OUTPUTS_METADATA_PROPERTY_LITERAL,
   OUTPUT_ALIAS,
   OUTPUT_PROPERTY_OR_GETTER,
 } from '../utils/selectors';
@@ -32,17 +32,14 @@ export default createESLintRule<Options, MessageIds>({
   create(context) {
     const nativeEventNames = getNativeEventNames();
     const selectors = [
-      OUTPUTS_METADATA_PROPERTY,
+      OUTPUTS_METADATA_PROPERTY_LITERAL,
       OUTPUT_ALIAS,
       OUTPUT_PROPERTY_OR_GETTER,
     ].join(',');
 
     return {
       [selectors](
-        node:
-          | TSESTree.Identifier
-          | TSESTree.StringLiteral
-          | TSESTree.TemplateElement,
+        node: TSESTree.Identifier | TSESTree.Literal | TSESTree.TemplateElement,
       ) {
         const [propertyName, aliasName] = getRawText(node)
           .replace(/\s/g, '')

--- a/packages/eslint-plugin/src/rules/no-output-on-prefix.ts
+++ b/packages/eslint-plugin/src/rules/no-output-on-prefix.ts
@@ -1,7 +1,7 @@
 import type { TSESTree } from '@typescript-eslint/experimental-utils';
 import { createESLintRule } from '../utils/create-eslint-rule';
 import {
-  OUTPUTS_METADATA_PROPERTY,
+  OUTPUTS_METADATA_PROPERTY_LITERAL,
   OUTPUT_ALIAS,
   OUTPUT_PROPERTY_OR_GETTER,
 } from '../utils/selectors';
@@ -30,17 +30,14 @@ export default createESLintRule<Options, MessageIds>({
   create(context) {
     const outputOnPattern = /^on(([^a-z])|(?=$))/;
     const selectors = [
-      OUTPUTS_METADATA_PROPERTY,
+      OUTPUTS_METADATA_PROPERTY_LITERAL,
       OUTPUT_ALIAS,
       OUTPUT_PROPERTY_OR_GETTER,
     ].join(',');
 
     return {
       [selectors](
-        node:
-          | TSESTree.Identifier
-          | TSESTree.StringLiteral
-          | TSESTree.TemplateElement,
+        node: TSESTree.Identifier | TSESTree.Literal | TSESTree.TemplateElement,
       ) {
         const [propertyName, aliasName] = getRawText(node)
           .replace(/\s/g, '')

--- a/packages/eslint-plugin/src/rules/no-output-rename.ts
+++ b/packages/eslint-plugin/src/rules/no-output-rename.ts
@@ -2,8 +2,8 @@ import type { TSESTree } from '@typescript-eslint/experimental-utils';
 import { ASTUtils } from '@typescript-eslint/experimental-utils';
 import { createESLintRule } from '../utils/create-eslint-rule';
 import {
-  COMPONENT_OR_DIRECTIVE_CLASS_DECORATOR,
-  OUTPUTS_METADATA_PROPERTY,
+  COMPONENT_OR_DIRECTIVE_SELECTOR_LITERAL,
+  OUTPUTS_METADATA_PROPERTY_LITERAL,
   OUTPUT_ALIAS,
 } from '../utils/selectors';
 import {
@@ -47,14 +47,14 @@ export default createESLintRule<Options, MessageIds>({
     let selectors: ReadonlySet<string> = new Set();
 
     return {
-      [`${COMPONENT_OR_DIRECTIVE_CLASS_DECORATOR} Property[key.name='selector'] :matches(Literal, TemplateElement)`](
-        node: TSESTree.StringLiteral | TSESTree.TemplateElement,
+      [COMPONENT_OR_DIRECTIVE_SELECTOR_LITERAL](
+        node: TSESTree.Literal | TSESTree.TemplateElement,
       ) {
         selectors = new Set(
           withoutBracketsAndWhitespaces(getRawText(node)).split(','),
         );
       },
-      [OUTPUT_ALIAS](node: TSESTree.StringLiteral | TSESTree.TemplateElement) {
+      [OUTPUT_ALIAS](node: TSESTree.Literal | TSESTree.TemplateElement) {
         const classPropertyOrMethodDefinition = getNearestNodeFrom(
           node,
           isClassPropertyOrMethodDefinition,
@@ -99,8 +99,8 @@ export default createESLintRule<Options, MessageIds>({
           });
         }
       },
-      [OUTPUTS_METADATA_PROPERTY](
-        node: TSESTree.StringLiteral | TSESTree.TemplateElement,
+      [OUTPUTS_METADATA_PROPERTY_LITERAL](
+        node: TSESTree.Literal | TSESTree.TemplateElement,
       ) {
         const [propertyName, aliasName] = withoutBracketsAndWhitespaces(
           getRawText(node),

--- a/packages/eslint-plugin/src/rules/no-outputs-metadata-property.ts
+++ b/packages/eslint-plugin/src/rules/no-outputs-metadata-property.ts
@@ -1,6 +1,9 @@
 import type { TSESTree } from '@typescript-eslint/experimental-utils';
 import { createESLintRule } from '../utils/create-eslint-rule';
-import { COMPONENT_OR_DIRECTIVE_CLASS_DECORATOR } from '../utils/selectors';
+import {
+  COMPONENT_OR_DIRECTIVE_CLASS_DECORATOR,
+  metadataProperty,
+} from '../utils/selectors';
 
 type Options = [];
 export type MessageIds = 'noOutputsMetadataProperty';
@@ -25,9 +28,9 @@ export default createESLintRule<Options, MessageIds>({
   defaultOptions: [],
   create(context) {
     return {
-      [`${COMPONENT_OR_DIRECTIVE_CLASS_DECORATOR} Property[key.name="${METADATA_PROPERTY_NAME}"][computed=false]`](
-        node: TSESTree.Property,
-      ) {
+      [`${COMPONENT_OR_DIRECTIVE_CLASS_DECORATOR} ${metadataProperty(
+        METADATA_PROPERTY_NAME,
+      )}`](node: TSESTree.Property) {
         context.report({
           node,
           messageId: 'noOutputsMetadataProperty',

--- a/packages/eslint-plugin/src/utils/selectors.ts
+++ b/packages/eslint-plugin/src/utils/selectors.ts
@@ -22,25 +22,33 @@ export const OUTPUT_DECORATOR = 'Decorator[expression.callee.name="Output"]';
 
 export const LITERAL_OR_TEMPLATE_ELEMENT = ':matches(Literal, TemplateElement)';
 
-export const SELECTOR_METADATA_PROPERTY =
-  'Property:matches([key.name="selector"], [key.value="selector"])';
+export function metadataProperty<TKey extends string>(
+  key: TKey,
+): `Property:matches([key.name='${TKey}'][computed=false], [key.value='${TKey}'], [key.quasis.0.value.raw='${TKey}'])` {
+  return `Property:matches([key.name='${key}'][computed=false], [key.value='${key}'], [key.quasis.0.value.raw='${key}'])`;
+}
 
-export const COMPONENT_SELECTOR_LITERAL = `${COMPONENT_CLASS_DECORATOR} ${SELECTOR_METADATA_PROPERTY} ${LITERAL_OR_TEMPLATE_ELEMENT}`;
+export const COMPONENT_SELECTOR_LITERAL = `${COMPONENT_CLASS_DECORATOR} ${metadataProperty(
+  'selector',
+)} ${LITERAL_OR_TEMPLATE_ELEMENT}`;
 
-export const DIRECTIVE_SELECTOR_LITERAL = `${DIRECTIVE_CLASS_DECORATOR} ${SELECTOR_METADATA_PROPERTY} ${LITERAL_OR_TEMPLATE_ELEMENT}`;
+export const DIRECTIVE_SELECTOR_LITERAL = `${DIRECTIVE_CLASS_DECORATOR} ${metadataProperty(
+  'selector',
+)} ${LITERAL_OR_TEMPLATE_ELEMENT}`;
 
 export const COMPONENT_OR_DIRECTIVE_SELECTOR_LITERAL = `:matches(${COMPONENT_SELECTOR_LITERAL}, ${DIRECTIVE_SELECTOR_LITERAL})`;
 
-export const INPUTS_METADATA_PROPERTY =
-  'Property:matches([key.name="inputs"], [key.value="inputs"])';
-
-export const INPUTS_METADATA_PROPERTY_LITERAL = `${COMPONENT_OR_DIRECTIVE_CLASS_DECORATOR} ${INPUTS_METADATA_PROPERTY} > ArrayExpression ${LITERAL_OR_TEMPLATE_ELEMENT}`;
+export const INPUTS_METADATA_PROPERTY_LITERAL = `${COMPONENT_OR_DIRECTIVE_CLASS_DECORATOR} ${metadataProperty(
+  'inputs',
+)} > ArrayExpression ${LITERAL_OR_TEMPLATE_ELEMENT}`;
 
 export const INPUT_ALIAS = `:matches(ClassProperty, MethodDefinition[kind='set']) ${INPUT_DECORATOR} ${LITERAL_OR_TEMPLATE_ELEMENT}`;
 
 export const INPUT_PROPERTY_OR_SETTER = `:matches(ClassProperty, MethodDefinition[kind='set'])[computed=false]:has(${INPUT_DECORATOR}) > :matches(Identifier, Literal)`;
 
-export const OUTPUTS_METADATA_PROPERTY = `${COMPONENT_OR_DIRECTIVE_CLASS_DECORATOR} Property[key.name='outputs'] > ArrayExpression ${LITERAL_OR_TEMPLATE_ELEMENT}`;
+export const OUTPUTS_METADATA_PROPERTY_LITERAL = `${COMPONENT_OR_DIRECTIVE_CLASS_DECORATOR} ${metadataProperty(
+  'outputs',
+)} > ArrayExpression ${LITERAL_OR_TEMPLATE_ELEMENT}`;
 
 export const OUTPUT_ALIAS = `:matches(ClassProperty, MethodDefinition[kind='get']) ${OUTPUT_DECORATOR} ${LITERAL_OR_TEMPLATE_ELEMENT}`;
 

--- a/packages/eslint-plugin/tests/rules/no-output-native.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-output-native.test.ts
@@ -16,6 +16,7 @@ const messageId: MessageIds = 'noOutputNative';
 
 ruleTester.run(RULE_NAME, rule, {
   valid: [
+    `class Test {}`,
     `
     @Page({
       outputs: ['play', popstate, \`online\`, 'obsolete: obsol', 'store: storage'],
@@ -78,7 +79,21 @@ ruleTester.run(RULE_NAME, rule, {
     `
     @Component({
       selector: 'foo',
-      outputs: [\`test: ${'foo'}\`]
+      'outputs': [\`test: ${'foo'}\`]
+    })
+    class Test {}
+    `,
+    `
+    @Directive({
+      selector: 'foo',
+      ['outputs']: [\`test: ${'foo'}\`]
+    })
+    class Test {}
+    `,
+    `
+    @Component({
+      'selector': 'foo',
+      [\`outputs\`]: [\`test: ${'foo'}\`]
     })
     class Test {}
     `,
@@ -94,11 +109,11 @@ ruleTester.run(RULE_NAME, rule, {
   invalid: [
     convertAnnotatedSourceToFailureCase({
       description:
-        'should fail if output metadata property is named "pagehide" in `@Component`',
+        'should fail if `outputs` metadata property is `Literal` and named "pagehide" in `@Component`',
       annotatedSource: `
         @Component({
-          outputs: ['pagehide']
-                    ~~~~~~~~~~
+          'outputs': ['pagehide']
+                      ~~~~~~~~~~
         })
         class Test {}
       `,
@@ -106,12 +121,12 @@ ruleTester.run(RULE_NAME, rule, {
     }),
     convertAnnotatedSourceToFailureCase({
       description:
-        'should fail if output metadata property is aliased as "copy" in `@Directive`',
+        'should fail if `outputs` metadata property is computed `Literal` and aliased as "copy" in `@Directive`',
       annotatedSource: `
         @Directive({
           inputs: ['abort'],
-          outputs: [boundary, \`test: copy\`],
-                              ~~~~~~~~~~~~
+          ['outputs']: [boundary, \`test: copy\`],
+                                  ~~~~~~~~~~~~
         })
         class Test {}
       `,
@@ -119,9 +134,22 @@ ruleTester.run(RULE_NAME, rule, {
     }),
     convertAnnotatedSourceToFailureCase({
       description:
-        'should fail if output metadata property is named "orientationchange" in `@Component`',
+        'should fail if `outputs` metadata property is computed `TemplateLiteral` and aliased as "copy" in `@Component`',
       annotatedSource: `
         @Component({
+          inputs: ['abort'],
+          [\`outputs\`]: [boundary, \`test: copy\`],
+                                  ~~~~~~~~~~~~
+        })
+        class Test {}
+      `,
+      messageId,
+    }),
+    convertAnnotatedSourceToFailureCase({
+      description:
+        'should fail if `outputs` metadata property is named "orientationchange" in `@Directive`',
+      annotatedSource: `
+        @Directive({
           outputs: ['orientationchange: orientation'],
                     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
         })
@@ -131,9 +159,9 @@ ruleTester.run(RULE_NAME, rule, {
     }),
     convertAnnotatedSourceToFailureCase({
       description:
-        'should fail if output property is named "change" in `@Directive`',
+        'should fail if output property is named "change" in `@Component`',
       annotatedSource: `
-        @Directive()
+        @Component()
         class Test {
           @Output() change: EventEmitter<any> = new EventEmitter<{}>();
                     ~~~~~~
@@ -143,9 +171,9 @@ ruleTester.run(RULE_NAME, rule, {
     }),
     convertAnnotatedSourceToFailureCase({
       description:
-        'should fail if output property is named "\'change\'" in `@Component`',
+        'should fail if output property is named "\'change\'" in `@Directive`',
       annotatedSource: `
-        @Component()
+        @Directive()
         class Test {
           @Output() @Custom('change') 'change' = new EventEmitter<void>();
                                       ~~~~~~~~
@@ -155,9 +183,9 @@ ruleTester.run(RULE_NAME, rule, {
     }),
     convertAnnotatedSourceToFailureCase({
       description:
-        'should fail if output property is aliased as "`change`" in `@Directive`',
+        'should fail if output property is aliased as "`change`" in `@Component`',
       annotatedSource: `
-        @Directive()
+        @Component()
         class Test {
           @Custom() @Output(\`change\`) _change = getOutput();
                             ~~~~~~~~
@@ -167,9 +195,9 @@ ruleTester.run(RULE_NAME, rule, {
     }),
     convertAnnotatedSourceToFailureCase({
       description:
-        'should fail if output property is aliased as "change" in `@Component`',
+        'should fail if output property is aliased as "change" in `@Directive`',
       annotatedSource: `
-        @Component()
+        @Directive()
         class Test {
           @Output('change') _change = (this.subject$ as Subject<{blur: boolean}>).pipe();
                   ~~~~~~~~
@@ -179,9 +207,9 @@ ruleTester.run(RULE_NAME, rule, {
     }),
     convertAnnotatedSourceToFailureCase({
       description:
-        'should fail if output getter is named "\'cut\'" in `@Directive`',
+        'should fail if output getter is named "\'cut\'" in `@Component`',
       annotatedSource: `
-        @Directive()
+        @Component()
         class Test {
           @Output('getter') get 'cut'() {}
                                 ~~~~~
@@ -191,9 +219,9 @@ ruleTester.run(RULE_NAME, rule, {
     }),
     convertAnnotatedSourceToFailureCase({
       description:
-        'should fail if output getter is aliased as "devicechange" in `@Component`',
+        'should fail if output getter is aliased as "devicechange" in `@Directive`',
       annotatedSource: `
-        @Component()
+        @Directive()
         class Test {
           @Output(\`${'devicechange'}\`) get getter() {}
                   ~~~~~~~~~~~~~~

--- a/packages/eslint-plugin/tests/rules/no-output-on-prefix.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-output-on-prefix.test.ts
@@ -16,6 +16,7 @@ const messageId: MessageIds = 'noOutputOnPrefix';
 
 ruleTester.run(RULE_NAME, rule, {
   valid: [
+    `class Test {}`,
     `
     @Page({
       outputs: ['on', onChange, \`onLine\`, 'on: on2', 'offline: on', ...onCheck, onOutput()],
@@ -76,7 +77,21 @@ ruleTester.run(RULE_NAME, rule, {
     `
     @Component({
       selector: 'foo',
-      outputs: [\`test: ${'foo'}\`]
+      'outputs': [\`test: ${'foo'}\`]
+    })
+    class Test {}
+    `,
+    `
+    @Directive({
+      selector: 'foo',
+      ['outputs']: [\`test: ${'foo'}\`]
+    })
+    class Test {}
+    `,
+    `
+    @Component({
+      'selector': 'foo',
+      [\`outputs\`]: [\`test: ${'foo'}\`]
     })
     class Test {}
     `,
@@ -92,7 +107,7 @@ ruleTester.run(RULE_NAME, rule, {
   invalid: [
     convertAnnotatedSourceToFailureCase({
       description:
-        'should fail if output metadata property is named "on" in `@Component`',
+        'should fail if `outputs` metadata property is named "on" in `@Component`',
       annotatedSource: `
         @Component({
           outputs: ['on']
@@ -104,12 +119,12 @@ ruleTester.run(RULE_NAME, rule, {
     }),
     convertAnnotatedSourceToFailureCase({
       description:
-        'should fail if output metadata property is aliased as "on" in `@Directive`',
+        'should fail if `outputs` metadata property is `Literal` and aliased as "on" in `@Directive`',
       annotatedSource: `
         @Directive({
           inputs: [onCredit],
-          outputs: [onLevel, \`test: on\`, onFunction()],
-                             ~~~~~~~~~~
+          'outputs': [onLevel, \`test: on\`, onFunction()],
+                               ~~~~~~~~~~
         })
         class Test {}
       `,
@@ -117,11 +132,11 @@ ruleTester.run(RULE_NAME, rule, {
     }),
     convertAnnotatedSourceToFailureCase({
       description:
-        'should fail if output metadata property is named "onTest" in `@Component`',
+        'should fail if `outputs` metadata property is computed `Literal` and named "onTest" in `@Component`',
       annotatedSource: `
         @Component({
-          outputs: ['onTest: test', ...onArray],
-                    ~~~~~~~~~~~~~~
+          ['outputs']: ['onTest: test', ...onArray],
+                        ~~~~~~~~~~~~~~
         })
         class Test {}
       `,
@@ -129,9 +144,21 @@ ruleTester.run(RULE_NAME, rule, {
     }),
     convertAnnotatedSourceToFailureCase({
       description:
-        'should fail if output property is named "on" in `@Directive`',
+        'should fail if `outputs` metadata property is computed `TemplateLiteral` and named "onTest" in `@Directive`',
       annotatedSource: `
-        @Directive()
+        @Directive({
+          [\`outputs\`]: ['onTest: test', ...onArray],
+                        ~~~~~~~~~~~~~~
+        })
+        class Test {}
+      `,
+      messageId,
+    }),
+    convertAnnotatedSourceToFailureCase({
+      description:
+        'should fail if output property is named "on" in `@Component`',
+      annotatedSource: `
+        @Component()
         class Test {
           @Output() on: EventEmitter<any> = new EventEmitter<{}>();
                     ~~
@@ -141,9 +168,9 @@ ruleTester.run(RULE_NAME, rule, {
     }),
     convertAnnotatedSourceToFailureCase({
       description:
-        'should fail if output property is named with "\'on\'" prefix in `@Component`',
+        'should fail if output property is named with "\'on\'" prefix in `@Directive`',
       annotatedSource: `
-        @Component()
+        @Directive()
         class Test {
           @Output() @Custom('on') 'onPrefix' = new EventEmitter<void>();
                                   ~~~~~~~~~~
@@ -153,9 +180,9 @@ ruleTester.run(RULE_NAME, rule, {
     }),
     convertAnnotatedSourceToFailureCase({
       description:
-        'should fail if output property is aliased as "`on`" in `@Directive`',
+        'should fail if output property is aliased as "`on`" in `@Component`',
       annotatedSource: `
-        @Directive()
+        @Component()
         class Test {
           @Custom() @Output(\`on\`) _on = getOutput();
                             ~~~~
@@ -165,9 +192,9 @@ ruleTester.run(RULE_NAME, rule, {
     }),
     convertAnnotatedSourceToFailureCase({
       description:
-        'should fail if output property is aliased with "on" prefix in `@Component`',
+        'should fail if output property is aliased with "on" prefix in `@Directive`',
       annotatedSource: `
-        @Component()
+        @Directive()
         class Test {
           @Output('onPrefix') _on = (this.subject$ as Subject<{on: boolean}>).pipe();
                   ~~~~~~~~~~
@@ -177,9 +204,9 @@ ruleTester.run(RULE_NAME, rule, {
     }),
     convertAnnotatedSourceToFailureCase({
       description:
-        'should fail if output getter is named with "on" prefix in `@Directive`',
+        'should fail if output getter is named with "on" prefix in `@Component`',
       annotatedSource: `
-        @Directive()
+        @Component()
         class Test {
           @Output('getter') get 'on-getter'() {}
                                 ~~~~~~~~~~~
@@ -189,9 +216,9 @@ ruleTester.run(RULE_NAME, rule, {
     }),
     convertAnnotatedSourceToFailureCase({
       description:
-        'should fail if output getter is aliased with "on" prefix in `@Component`',
+        'should fail if output getter is aliased with "on" prefix in `@Directive`',
       annotatedSource: `
-        @Component()
+        @Directive()
         class Test {
           @Output(\`${'onGetter'}\`) get getter() {}
                   ~~~~~~~~~~

--- a/packages/eslint-plugin/tests/rules/no-outputs-metadata-property.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-outputs-metadata-property.test.ts
@@ -16,32 +16,37 @@ const messageId: MessageIds = 'noOutputsMetadataProperty';
 
 ruleTester.run(RULE_NAME, rule, {
   valid: [
+    `class Test {}`,
     `
-    @Directive()
+    @Component()
+    class Test {}
+    `,
+    `
+    @Directive({})
     class Test {}
     `,
     `
     const options = {};
     @Component(options)
-    export class Test {}
+    class Test {}
     `,
     `
-    @Component({
+    @Directive({
       selector: 'app-test',
       template: 'Hello'
     })
     class Test {}
     `,
     `
-    @Directive({
+    @Component({
       selector: 'app-test',
       queries: {},
     })
     class Test {}
     `,
     `
-    const outputs = 'host';
-    @Component({
+    const outputs = 'providers';
+    @Directive({
       [outputs]: [],
     })
     class Test {}
@@ -50,13 +55,13 @@ ruleTester.run(RULE_NAME, rule, {
     @NgModule({
       bootstrap: [Foo]
     })
-    export class Test {}
+    class Test {}
     `,
   ],
   invalid: [
     convertAnnotatedSourceToFailureCase({
       description:
-        'it should fail if "outputs" metadata property is used in `@Component`',
+        'should fail if `outputs` metadata property is used in `@Component`',
       annotatedSource: `
         @Component({
           outputs: [
@@ -72,7 +77,7 @@ ruleTester.run(RULE_NAME, rule, {
     }),
     convertAnnotatedSourceToFailureCase({
       description:
-        'it should fail if "outputs" metadata property is used in `@Directive`',
+        'should fail if `outputs` metadata property is used in `@Directive`',
       annotatedSource: `
         @Directive({
           outputs: [
@@ -87,67 +92,66 @@ ruleTester.run(RULE_NAME, rule, {
       messageId,
     }),
     convertAnnotatedSourceToFailureCase({
-      description: 'it should fail if "outputs" metadata property is shorthand',
+      description: 'should fail if `outputs` metadata property is shorthand',
       annotatedSource: `
         @Component({
           outputs,
           ~~~~~~~
         })
-        export class Test {}
+        class Test {}
       `,
       messageId,
     }),
     convertAnnotatedSourceToFailureCase({
       description:
-        'it should fail if "outputs" metadata property has no properties',
+        'should fail if `outputs` metadata property has no properties',
       annotatedSource: `
-        @Component({
+        @Directive({
           outputs: [],
           ~~~~~~~~~~~
         })
-        export class Test {}
+        class Test {}
       `,
       messageId,
     }),
     convertAnnotatedSourceToFailureCase({
       description:
-        'it should fail if "outputs" metadata property\'s value is a variable',
+        "should fail if `outputs` metadata property's key is `Literal` and its value is a variable",
       annotatedSource: `
         const test = [];
-
         @Component({
-          outputs: test,
-          ~~~~~~~~~~~~~
+          'outputs': test,
+          ~~~~~~~~~~~~~~~
         })
-        export class Test {}
+        class Test {}
       `,
       messageId,
     }),
     convertAnnotatedSourceToFailureCase({
       description:
-        'it should fail if "outputs" metadata property\'s value is `undefined`',
+        "should fail if `outputs` metadata property's key is computed `Literal` and its value is `undefined`",
       annotatedSource: `
-        @Component({
-          outputs: undefined,
-          ~~~~~~~~~~~~~~~~~~
+        @Directive({
+          ['outputs']: undefined,
+          ~~~~~~~~~~~~~~~~~~~~~~
         })
-        export class Test {}
+        class Test {}
       `,
       messageId,
     }),
     convertAnnotatedSourceToFailureCase({
       description:
-        'it should fail if "outputs" metadata property\'s value is a function',
+        "should fail if `outputs` metadata property's key is computed `TemplateLiteral` and its value is a function",
       annotatedSource: `
         function outputs() {
           return [];
         }
 
-        @Directive({
-          outputs: outputs(),
-          ~~~~~~~~~~~~~~~~~~
+        @Component({
+          [\`outputs\`]: outputs(),
+          ~~~~~~~~~~~~~~~~~~~~~~
         })
-        export class Test {}
+        class Test {}
       `,
       messageId,
     }),


### PR DESCRIPTION
I completely forgot to add support for literal `'outputs'` (and also in others 😢) in the previous PRs. Now, properties like these are reported:

```ts
@Component({ 'outputs': [...] })
class Test {}

@Component({ ['outputs']: [...] })
class Test {}

@Component({ [`outputs`]: [...] })
class Test {}
```

PS: As it's a small change I chose to create a single PR with separated commits for each rule... but, if necessary, I can open separated PRs.