### PR TITLE
fix(eslint-plugin): properly handle computed literals for some rules

### DIFF
--- a/packages/eslint-plugin/docs/rules/no-input-prefix.md
+++ b/packages/eslint-plugin/docs/rules/no-input-prefix.md
@@ -55,22 +55,30 @@ class Test {}
 ```ts
 @Directive({
   outputs: [onCredit],
-  inputs: [onLevel, `test: on`, onFunction()],
-                    ~~~~~~~~~~
+  'inputs': [onLevel, `test: on`, onFunction()],
+                      ~~~~~~~~~~
 })
 class Test {}
 ```
 
 ```ts
 @Component({
-  'inputs': ['onTest: test', ...onArray],
-             ~~~~~~~~~~~~~~
+  ['inputs']: ['onTest: test', ...onArray],
+               ~~~~~~~~~~~~~~
 })
 class Test {}
 ```
 
 ```ts
-@Directive()
+@Directive({
+  [`inputs`]: ['onTest: test', ...onArray],
+               ~~~~~~~~~~~~~~
+})
+class Test {}
+```
+
+```ts
+@Component()
 class Test {
   @Input() on: EventEmitter<any> = new EventEmitter<{}>();
            ~~
@@ -78,7 +86,7 @@ class Test {
 ```
 
 ```ts
-@Component()
+@Directive()
 class Test {
   @Input() @Custom('on') 'onPrefix' = new EventEmitter<void>();
                          ~~~~~~~~~~
@@ -86,7 +94,7 @@ class Test {
 ```
 
 ```ts
-@Directive()
+@Component()
 class Test {
   @Custom() @Input(`on`) _on = getInput();
                    ~~~~
@@ -94,7 +102,7 @@ class Test {
 ```
 
 ```ts
-@Component()
+@Directive()
 class Test {
   @Input('onPrefix') _on = (this.subject$ as Subject<{on: boolean}>).pipe();
          ~~~~~~~~~~
@@ -102,7 +110,7 @@ class Test {
 ```
 
 ```ts
-@Directive()
+@Component()
 class Test {
   @Input('setter') set 'on-setter'() {}
                        ~~~~~~~~~~~

--- a/packages/eslint-plugin/docs/rules/no-input-rename.md
+++ b/packages/eslint-plugin/docs/rules/no-input-rename.md
@@ -60,16 +60,24 @@ class Test {}
 ```ts
 @Directive({
   outputs: ['abort'],
-  inputs: [boundary, `test: copy`, 'check: check'],
-                     ~~~~~~~~~~~~
+  'inputs': [boundary, `test: copy`, 'check: check'],
+                       ~~~~~~~~~~~~
 })
 class Test {}
 ```
 
 ```ts
 @Component({
-  'inputs': ['orientation: orientation'],
-             ~~~~~~~~~~~~~~~~~~~~~~~~~~
+  ['inputs']: ['orientation: orientation'],
+               ~~~~~~~~~~~~~~~~~~~~~~~~~~
+})
+class Test {}
+```
+
+```ts
+@Directive({
+  [`inputs`]: ['orientation: orientation'],
+               ~~~~~~~~~~~~~~~~~~~~~~~~~~
 })
 class Test {}
 ```

--- a/packages/eslint-plugin/docs/rules/no-inputs-metadata-property.md
+++ b/packages/eslint-plugin/docs/rules/no-inputs-metadata-property.md
@@ -67,7 +67,7 @@ class Test {}
 ```
 
 ```ts
-@Component({
+@Directive({
   inputs: [],
   ~~~~~~~~~~
 })
@@ -77,16 +77,16 @@ class Test {}
 ```ts
 const test = [];
 @Component({
-  inputs: test,
-  ~~~~~~~~~~~~
+  'inputs': test,
+  ~~~~~~~~~~~~~~
 })
 class Test {}
 ```
 
 ```ts
-@Component({
-  inputs: undefined,
-  ~~~~~~~~~~~~~~~~~
+@Directive({
+  ['inputs']: undefined,
+  ~~~~~~~~~~~~~~~~~~~~~
 })
 class Test {}
 ```
@@ -96,9 +96,9 @@ function inputs() {
   return [];
 }
 
-@Directive({
-  'inputs': inputs(),
-  ~~~~~~~~~~~~~~~~~~
+@Component({
+  [`inputs`]: inputs(),
+  ~~~~~~~~~~~~~~~~~~~~
 })
 class Test {}
 ```

--- a/packages/eslint-plugin/docs/rules/no-pipe-impure.md
+++ b/packages/eslint-plugin/docs/rules/no-pipe-impure.md
@@ -56,8 +56,17 @@ class Test {}
 ```ts
 @Pipe({
   name: 'test',
-  'pure': !true
-  ~~~~~~~~~~~~~
+  ['pure']: !true
+  ~~~~~~~~~~~~~~~
+})
+class Test {}
+```
+
+```ts
+@Pipe({
+  name: 'test',
+  [`pure`]: false
+  ~~~~~~~~~~~~~~~
 })
 class Test {}
 ```
@@ -106,14 +115,14 @@ class Test {}
 
 ```ts
 @Pipe({
-  pure: !0,
+  'pure': !0,
 })
 class Test {}
 ```
 
 ```ts
 @Pipe({
-  pure: !!isPure(),
+  ['pure']: !!isPure(),
 })
 class Test {}
 ```
@@ -140,7 +149,7 @@ function isPure() {
 }
 
 @Pipe({
-  pure: isPure(),
+  [`pure`]: isPure(),
 })
 class Test {}
 ```

--- a/packages/eslint-plugin/docs/rules/use-component-view-encapsulation.md
+++ b/packages/eslint-plugin/docs/rules/use-component-view-encapsulation.md
@@ -44,13 +44,37 @@ class Test {}
 ```
 
 ```ts
-import { ViewEncapsulation } from '@angular/core';
+import type { ViewEncapsulation } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 
 @Component({
   selector: 'app-foo-bar',
   'encapsulation': ViewEncapsulation.None
                                      ~~~~
+})
+class Test {}
+```
+
+```ts
+import { ViewEncapsulation } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+
+@Component({
+  selector: 'app-foo-bar',
+  ['encapsulation']: ViewEncapsulation.None
+                                       ~~~~
+})
+class Test {}
+```
+
+```ts
+import { ViewEncapsulation } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+
+@Component({
+  selector: 'app-foo-bar',
+  [`encapsulation`]: ViewEncapsulation.None
+                                       ~~~~
 })
 class Test {}
 ```
@@ -73,7 +97,7 @@ class Test {}
 
 ```ts
 @Component({
-  encapsulation: ViewEncapsulation.Native,
+  'encapsulation': ViewEncapsulation.Native,
   selector: 'app-foo-bar',
 })
 class Test {}
@@ -81,7 +105,7 @@ class Test {}
 
 ```ts
 @Component({
-  encapsulation: ViewEncapsulation.ShadowDom,
+  ['encapsulation']: ViewEncapsulation.ShadowDom,
 })
 class Test {}
 ```
@@ -92,7 +116,7 @@ function encapsulation() {
 }
 
 @Component({
-  encapsulation: encapsulation()
+  [`encapsulation`]: encapsulation()
 })
 class Test {}
 ```

--- a/packages/eslint-plugin/src/rules/no-inputs-metadata-property.ts
+++ b/packages/eslint-plugin/src/rules/no-inputs-metadata-property.ts
@@ -30,7 +30,7 @@ export default createESLintRule<Options, MessageIds>({
     return {
       [`${COMPONENT_OR_DIRECTIVE_CLASS_DECORATOR} ${metadataProperty(
         METADATA_PROPERTY_NAME,
-      )}`](node: TSESTree.PropertyNonComputedName) {
+      )}`](node: TSESTree.Property) {
         context.report({
           node,
           messageId: 'noInputsMetadataProperty',

--- a/packages/eslint-plugin/src/rules/no-pipe-impure.ts
+++ b/packages/eslint-plugin/src/rules/no-pipe-impure.ts
@@ -1,6 +1,6 @@
 import type { TSESTree } from '@typescript-eslint/experimental-utils';
 import { createESLintRule } from '../utils/create-eslint-rule';
-import { PIPE_CLASS_DECORATOR } from '../utils/selectors';
+import { metadataProperty, PIPE_CLASS_DECORATOR } from '../utils/selectors';
 import { getNodeToCommaRemoveFix } from '../utils/utils';
 
 type Options = [];
@@ -29,8 +29,10 @@ export default createESLintRule<Options, MessageIds>({
     const sourceCode = context.getSourceCode();
 
     return {
-      [`${PIPE_CLASS_DECORATOR} ObjectExpression > Property:matches([key.name='pure'], [key.value='pure']):matches([value.value=false], [value.operator='!'][value.argument.value=true])[computed=false]`](
-        node: TSESTree.Property & { parent: TSESTree.ObjectExpression },
+      [`${PIPE_CLASS_DECORATOR} ${metadataProperty(
+        'pure',
+      )}:matches([value.value=false], [value.operator='!'][value.argument.value=true])`](
+        node: TSESTree.Property,
       ) {
         context.report({
           node,

--- a/packages/eslint-plugin/src/rules/use-component-view-encapsulation.ts
+++ b/packages/eslint-plugin/src/rules/use-component-view-encapsulation.ts
@@ -1,6 +1,9 @@
 import type { TSESTree } from '@typescript-eslint/experimental-utils';
 import { createESLintRule } from '../utils/create-eslint-rule';
-import { COMPONENT_CLASS_DECORATOR } from '../utils/selectors';
+import {
+  COMPONENT_CLASS_DECORATOR,
+  metadataProperty,
+} from '../utils/selectors';
 import {
   getImportDeclarations,
   getImportRemoveFix,
@@ -35,7 +38,9 @@ export default createESLintRule<Options, MessageIds>({
     const sourceCode = context.getSourceCode();
 
     return {
-      [`${COMPONENT_CLASS_DECORATOR} Property:matches([key.name='encapsulation'], [key.value='encapsulation']) > MemberExpression[object.name='ViewEncapsulation'] > Identifier[name='None']`](
+      [`${COMPONENT_CLASS_DECORATOR} ${metadataProperty(
+        'encapsulation',
+      )} > MemberExpression[object.name='ViewEncapsulation'] > Identifier[name='None']`](
         node: TSESTree.Identifier & {
           parent: TSESTree.MemberExpression & { parent: TSESTree.Property };
         },

--- a/packages/eslint-plugin/tests/rules/no-input-prefix/cases.ts
+++ b/packages/eslint-plugin/tests/rules/no-input-prefix/cases.ts
@@ -14,7 +14,7 @@ export const valid = [
         inputs: ['on', onChange, \`onLine\`, 'on: on2', 'offline: on', ...onCheck, onInput()],
       })
       class Test {}
-      `,
+    `,
     options: [{ prefixes: ['on'] }],
   },
   {
@@ -23,7 +23,7 @@ export const valid = [
       class Test {
         on = new EventEmitter();
       }
-      `,
+    `,
     options: [{ prefixes: ['on'] }],
   },
   {
@@ -32,7 +32,7 @@ export const valid = [
       class Test {
         @Input() buttonChange = new EventEmitter<'on'>();
       }
-      `,
+    `,
     options: [{ prefixes: ['on'] }],
   },
   {
@@ -41,7 +41,7 @@ export const valid = [
       class Test {
         @Input() On = new EventEmitter<{ on: onType }>();
       }
-      `,
+    `,
     options: [{ prefixes: ['on'] }],
   },
   {
@@ -50,7 +50,7 @@ export const valid = [
       class Test {
         @Input(\`one\`) ontype = new EventEmitter<{ bar: string, on: boolean }>();
       }
-      `,
+    `,
     options: [{ prefixes: ['on'] }],
   },
   {
@@ -59,7 +59,7 @@ export const valid = [
       class Test {
         @Input('oneProp') common = new EventEmitter<ComplextOn>();
       }
-      `,
+    `,
     options: [{ prefixes: ['on'] }],
   },
   {
@@ -68,7 +68,7 @@ export const valid = [
       class Test<On> {
         @Input() ON = new EventEmitter<On>();
       }
-      `,
+    `,
     options: [{ prefixes: ['on'] }],
   },
   {
@@ -78,7 +78,7 @@ export const valid = [
       class Test {
         @Input(on) touchMove: EventEmitter<{ action: 'on' | 'off' }> = new EventEmitter<{ action: 'on' | 'off' }>();
       }
-      `,
+    `,
     options: [{ prefixes: ['on'] }],
   },
   {
@@ -89,7 +89,7 @@ export const valid = [
       class Test {
         @Input(test) [on]: EventEmitter<OnTest>;
       }
-      `,
+    `,
     options: [{ prefixes: ['on'] }],
   },
   `
@@ -98,7 +98,21 @@ export const valid = [
       'inputs': [\`test: ${'foo'}\`]
     })
     class Test {}
-    `,
+  `,
+  `
+    @Directive({
+      selector: 'foo',
+      ['inputs']: [\`test: ${'foo'}\`]
+    })
+    class Test {}
+  `,
+  `
+    @Component({
+      selector: 'foo',
+      [\`inputs\`]: [\`test: ${'foo'}\`]
+    })
+    class Test {}
+  `,
   `
     @Directive({
       selector: 'foo',
@@ -106,7 +120,7 @@ export const valid = [
     class Test {
       @Input() set 'setter'() {}
     }
-    `,
+  `,
 ];
 
 export const invalid = [
@@ -114,124 +128,138 @@ export const invalid = [
     description:
       'should fail if `inputs` metadata property is named "on" in `@Component`',
     annotatedSource: `
-        @Component({
-          inputs: ['on']
-                   ~~~~
-        })
-        class Test {}
-      `,
+      @Component({
+        inputs: ['on']
+                 ~~~~
+      })
+      class Test {}
+    `,
     messageId,
     options: [{ prefixes: ['on'] }],
     data: { prefixes: '"on"' },
   }),
   convertAnnotatedSourceToFailureCase({
     description:
-      'should fail if `inputs` metadata property is aliased as "on" in `@Directive`',
+      'should fail if `inputs` metadata property is `Literal` and aliased as "on" in `@Directive`',
     annotatedSource: `
-        @Directive({
-          outputs: [onCredit],
-          inputs: [onLevel, \`test: on\`, onFunction()],
+      @Directive({
+        outputs: [onCredit],
+        'inputs': [onLevel, \`test: on\`, onFunction()],
                             ~~~~~~~~~~
-        })
-        class Test {}
-      `,
+      })
+      class Test {}
+    `,
     messageId,
     options: [{ prefixes: ['on'] }],
     data: { prefixes: '"on"' },
   }),
   convertAnnotatedSourceToFailureCase({
     description:
-      'should fail if `inputs` metadata property is `Literal` and named "onTest" in `@Component`',
+      'should fail if `inputs` metadata property is computed `Literal` and named "onTest" in `@Component`',
     annotatedSource: `
-        @Component({
-          'inputs': ['onTest: test', ...onArray],
+      @Component({
+        ['inputs']: ['onTest: test', ...onArray],
                      ~~~~~~~~~~~~~~
-        })
-        class Test {}
-      `,
-    messageId,
-    options: [{ prefixes: ['on'] }],
-    data: { prefixes: '"on"' },
-  }),
-  convertAnnotatedSourceToFailureCase({
-    description: 'should fail if input property is named "on" in `@Directive`',
-    annotatedSource: `
-        @Directive()
-        class Test {
-          @Input() on: EventEmitter<any> = new EventEmitter<{}>();
-                   ~~
-        }
-      `,
+      })
+      class Test {}
+    `,
     messageId,
     options: [{ prefixes: ['on'] }],
     data: { prefixes: '"on"' },
   }),
   convertAnnotatedSourceToFailureCase({
     description:
-      'should fail if input property is named with "\'on\'" prefix in `@Component`',
+      'should fail if `inputs` metadata property is computed `TemplateLiteral` and named "onTest" in `@Directive`',
     annotatedSource: `
-        @Component()
-        class Test {
-          @Input() @Custom('on') 'onPrefix' = new EventEmitter<void>();
-                                 ~~~~~~~~~~
-        }
-      `,
+      @Directive({
+        [\`inputs\`]: ['onTest: test', ...onArray],
+                     ~~~~~~~~~~~~~~
+      })
+      class Test {}
+    `,
+    messageId,
+    options: [{ prefixes: ['on'] }],
+    data: { prefixes: '"on"' },
+  }),
+  convertAnnotatedSourceToFailureCase({
+    description: 'should fail if input property is named "on" in `@Component`',
+    annotatedSource: `
+      @Component()
+      class Test {
+        @Input() on: EventEmitter<any> = new EventEmitter<{}>();
+                 ~~
+      }
+    `,
     messageId,
     options: [{ prefixes: ['on'] }],
     data: { prefixes: '"on"' },
   }),
   convertAnnotatedSourceToFailureCase({
     description:
-      'should fail if input property is aliased as "`on`" in `@Directive`',
+      'should fail if input property is named with "\'on\'" prefix in `@Directive`',
     annotatedSource: `
-        @Directive()
-        class Test {
-          @Custom() @Input(\`on\`) _on = getInput();
-                           ~~~~
-        }
-      `,
+      @Directive()
+      class Test {
+        @Input() @Custom('on') 'onPrefix' = new EventEmitter<void>();
+                               ~~~~~~~~~~
+      }
+    `,
     messageId,
     options: [{ prefixes: ['on'] }],
     data: { prefixes: '"on"' },
   }),
   convertAnnotatedSourceToFailureCase({
     description:
-      'should fail if input property is aliased with "on" prefix in `@Component`',
+      'should fail if input property is aliased as "`on`" in `@Component`',
     annotatedSource: `
-        @Component()
-        class Test {
-          @Input('onPrefix') _on = (this.subject$ as Subject<{on: boolean}>).pipe();
-                 ~~~~~~~~~~
-        }
-      `,
+      @Component()
+      class Test {
+        @Custom() @Input(\`on\`) _on = getInput();
+                         ~~~~
+      }
+    `,
     messageId,
     options: [{ prefixes: ['on'] }],
     data: { prefixes: '"on"' },
   }),
   convertAnnotatedSourceToFailureCase({
     description:
-      'should fail if input setter is named with "on" prefix in `@Directive`',
+      'should fail if input property is aliased with "on" prefix in `@Directive`',
     annotatedSource: `
-        @Directive()
-        class Test {
-          @Input('setter') set 'on-setter'() {}
-                               ~~~~~~~~~~~
-        }
-      `,
+      @Directive()
+      class Test {
+        @Input('onPrefix') _on = (this.subject$ as Subject<{on: boolean}>).pipe();
+               ~~~~~~~~~~
+      }
+    `,
     messageId,
     options: [{ prefixes: ['on'] }],
     data: { prefixes: '"on"' },
   }),
   convertAnnotatedSourceToFailureCase({
     description:
-      'should fail if input setter is aliased with "on" prefix in `@Component`',
+      'should fail if input setter is named with "on" prefix in `@Component`',
     annotatedSource: `
-        @Component()
-        class Test {
-          @Input(\`${'onSetter'}\`) set setter() {}
-                 ~~~~~~~~~~
-        }
-      `,
+      @Component()
+      class Test {
+        @Input('setter') set 'on-setter'() {}
+                             ~~~~~~~~~~~
+      }
+    `,
+    messageId,
+    options: [{ prefixes: ['on'] }],
+    data: { prefixes: '"on"' },
+  }),
+  convertAnnotatedSourceToFailureCase({
+    description:
+      'should fail if input setter is aliased with "on" prefix in `@Directive`',
+    annotatedSource: `
+      @Directive()
+      class Test {
+        @Input(\`${'onSetter'}\`) set setter() {}
+               ~~~~~~~~~~
+      }
+    `,
     messageId,
     options: [{ prefixes: ['on'] }],
     data: { prefixes: '"on"' },
@@ -240,12 +268,12 @@ export const invalid = [
     description:
       'should fail if input property is named with prefix "on" and aliased as "on" without `@Component` or `@Directive`',
     annotatedSource: `
-        @Injectable()
-        class Test {
-          @Input('on') isPrefix = this.getInput();
-                 ~~~~  ^^^^^^^^
-        }
-      `,
+      @Injectable()
+      class Test {
+        @Input('on') isPrefix = this.getInput();
+               ~~~~  ^^^^^^^^
+      }
+    `,
     messages: [
       { char: '~', messageId, data: { prefixes: '"on", "is" or "should"' } },
       { char: '^', messageId, data: { prefixes: '"on", "is" or "should"' } },

--- a/packages/eslint-plugin/tests/rules/no-input-rename/cases.ts
+++ b/packages/eslint-plugin/tests/rules/no-input-rename/cases.ts
@@ -13,49 +13,49 @@ export const valid = [
       inputs: ['play', popstate, \`online\`, 'obsolete: obsol', 'store: storage'],
     })
     class Test {}
-    `,
+  `,
   `
     @Component()
     class Test {
       change = new EventEmitter();
     }
-    `,
+  `,
   `
     @Directive()
     class Test {
       @Input() buttonChange = new EventEmitter<'change'>();
     }
-    `,
+  `,
   `
     @Component({
       inputs,
     })
     class Test {}
-    `,
+  `,
   `
     @Directive({
       inputs: [...test],
     })
     class Test {}
-    `,
+  `,
   `
     @Component({
       inputs: func(),
     })
     class Test {}
-    `,
+  `,
   `
     @Directive({
       inputs: [func(), 'a'],
     })
     class Test {}
-    `,
+  `,
   `
     @Component({})
     class Test {
       @Input() set setter(setter: string) {}
     }
-    `,
+  `,
   {
     code: `
       @Component({
@@ -73,7 +73,7 @@ export const valid = [
     class Test {
       @Input(change) touchMove: EventEmitter<{ action: 'click' | 'close' }> = new EventEmitter<{ action: 'click' | 'close' }>();
     }
-    `,
+  `,
   `
     const blur = 'blur';
     const click = 'click';
@@ -81,7 +81,7 @@ export const valid = [
     class Test {
       @Input(blur) [click]: EventEmitter<Blur>;
     }
-    `,
+  `,
   `
     @Component({
       selector: 'foo[bar]'
@@ -89,14 +89,28 @@ export const valid = [
     class Test {
       @Input() bar: string;
     }
-    `,
+  `,
   `
     @Directive({
       'selector': 'foo',
       'inputs': [\`test: ${'foo'}\`]
     })
     class Test {}
-    `,
+  `,
+  `
+    @Component({
+      'selector': 'foo',
+      ['inputs']: [\`test: ${'foo'}\`]
+    })
+    class Test {}
+  `,
+  `
+    @Directive({
+      'selector': 'foo',
+      [\`inputs\`]: [\`test: ${'foo'}\`]
+    })
+    class Test {}
+  `,
   `
     @Component({
       selector: '[foo], test',
@@ -104,7 +118,7 @@ export const valid = [
     class Test {
       @Input('foo') label: string;
     }
-    `,
+  `,
   `
     @Directive({
       selector: 'foo'
@@ -112,7 +126,7 @@ export const valid = [
     class Test {
       @Input('aria-label') ariaLabel: string;
     }
-    `,
+  `,
   {
     code: `
       @Component({
@@ -131,7 +145,7 @@ export const valid = [
     class Test {
       @Input('fooMyColor') myColor: string;
     }
-    `,
+  `,
 ];
 
 export const invalid = [
@@ -139,12 +153,12 @@ export const invalid = [
     description:
       'should fail if `inputs` metadata property is aliased in `@Component`',
     annotatedSource: `
-        @Component({
-          inputs: ['a: b']
-                   ~~~~~~
-        })
-        class Test {}
-      `,
+      @Component({
+        inputs: ['a: b']
+                 ~~~~~~
+      })
+      class Test {}
+    `,
     messageId,
     suggestions: (
       [
@@ -154,25 +168,25 @@ export const invalid = [
     ).map(([messageId, name]) => ({
       messageId,
       output: `
-        @Component({
-          inputs: ['${name}']
-                   
-        })
-        class Test {}
-      `,
+      @Component({
+        inputs: ['${name}']
+                 
+      })
+      class Test {}
+    `,
     })),
   }),
   convertAnnotatedSourceToFailureCase({
     description:
-      'should fail if `inputs` metadata property is aliased in `@Directive`',
+      'should fail if `inputs` metadata property is literal and aliased in `@Directive`',
     annotatedSource: `
-        @Directive({
-          outputs: ['abort'],
-          inputs: [boundary, \`test: copy\`, 'check: check'],
+      @Directive({
+        outputs: ['abort'],
+        'inputs': [boundary, \`test: copy\`, 'check: check'],
                              ~~~~~~~~~~~~
-        })
-        class Test {}
-      `,
+      })
+      class Test {}
+    `,
     messageId,
     options: [{ allowedNames: ['check', 'test'] }],
     suggestions: (
@@ -183,43 +197,62 @@ export const invalid = [
     ).map(([messageId, name]) => ({
       messageId,
       output: `
-        @Directive({
-          outputs: ['abort'],
-          inputs: [boundary, \`${name}\`, 'check: check'],
+      @Directive({
+        outputs: ['abort'],
+        'inputs': [boundary, \`${name}\`, 'check: check'],
                              
-        })
-        class Test {}
-      `,
+      })
+      class Test {}
+    `,
     })),
   }),
   convertAnnotatedSourceToFailureCase({
     description:
-      'should fail if `inputs` metadata property is `Literal` and aliased with the same name in `@Component`',
+      'should fail if `inputs` metadata property is computed `Literal` and aliased with the same name in `@Component`',
     annotatedSource: `
-        @Component({
-          'inputs': ['orientation: orientation'],
+      @Component({
+        ['inputs']: ['orientation: orientation'],
                      ~~~~~~~~~~~~~~~~~~~~~~~~~~
-        })
-        class Test {}
-      `,
+      })
+      class Test {}
+    `,
     messageId,
     annotatedOutput: `
-        @Component({
-          'inputs': ['orientation'],
+      @Component({
+        ['inputs']: ['orientation'],
+                     ~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      })
+      class Test {}
+    `,
+  }),
+  convertAnnotatedSourceToFailureCase({
+    description:
+      'should fail if `inputs` metadata property is computed `TemplateLiteral` and aliased with the same name in `@Directive`',
+    annotatedSource: `
+      @Directive({
+        [\`inputs\`]: ['orientation: orientation'],
                      ~~~~~~~~~~~~~~~~~~~~~~~~~~
-        })
-        class Test {}
-      `,
+      })
+      class Test {}
+    `,
+    messageId,
+    annotatedOutput: `
+      @Directive({
+        [\`inputs\`]: ['orientation'],
+                     ~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      })
+      class Test {}
+    `,
   }),
   convertAnnotatedSourceToFailureCase({
     description: 'should fail if input property is aliased with backticks',
     annotatedSource: `
-        @Component()
-        class Test {
-          @Custom() @Input(\`change\`) _change = getInput();
-                           ~~~~~~~~
-        }
-      `,
+      @Component()
+      class Test {
+        @Custom() @Input(\`change\`) _change = getInput();
+                         ~~~~~~~~
+      }
+    `,
     messageId,
     suggestions: (
       [
@@ -229,43 +262,43 @@ export const invalid = [
     ).map(([messageId, propertyName]) => ({
       messageId,
       output: `
-        @Component()
-        class Test {
-          @Custom() @Input() ${propertyName} = getInput();
-                           
-        }
-      `,
+      @Component()
+      class Test {
+        @Custom() @Input() ${propertyName} = getInput();
+                         
+      }
+    `,
     })),
   }),
   convertAnnotatedSourceToFailureCase({
     description: 'should fail if input property is aliased',
     annotatedSource: `
-        @Directive()
-        class Test {
-          @Input('change') change = (this.subject$ as Subject<{blur: boolean}>).pipe();
-                 ~~~~~~~~
-        }
-      `,
+      @Directive()
+      class Test {
+        @Input('change') change = (this.subject$ as Subject<{blur: boolean}>).pipe();
+               ~~~~~~~~
+      }
+    `,
     messageId,
     annotatedOutput: `
-        @Directive()
-        class Test {
-          @Input() change = (this.subject$ as Subject<{blur: boolean}>).pipe();
-                 ~~~~~~~~
-        }
-      `,
+      @Directive()
+      class Test {
+        @Input() change = (this.subject$ as Subject<{blur: boolean}>).pipe();
+               ~~~~~~~~
+      }
+    `,
   }),
   convertAnnotatedSourceToFailureCase({
     description: 'should fail if input setter is aliased',
     annotatedSource: `
-        @Component()
-        class Test {
-          @Input(\`${'devicechange'}\`) set setter(setter: string) {}
-                 ~~~~~~~~~~~~~~
+      @Component()
+      class Test {
+        @Input(\`${'devicechange'}\`) set setter(setter: string) {}
+               ~~~~~~~~~~~~~~
 
-          @Input('allowedName') test: string;
-        }
-      `,
+        @Input('allowedName') test: string;
+      }
+    `,
     messageId,
     options: [{ allowedNames: ['allowedName'] }],
     suggestions: (
@@ -276,27 +309,27 @@ export const invalid = [
     ).map(([messageId, propertyName]) => ({
       messageId,
       output: `
-        @Component()
-        class Test {
-          @Input() set ${propertyName}(setter: string) {}
-                 
+      @Component()
+      class Test {
+        @Input() set ${propertyName}(setter: string) {}
+               
 
-          @Input('allowedName') test: string;
-        }
-      `,
+        @Input('allowedName') test: string;
+      }
+    `,
     })),
   }),
   convertAnnotatedSourceToFailureCase({
     description: `should fail if a input 'aria-*' alias name does not match the property name`,
     annotatedSource: `
-        @Directive({
-          selector: 'foo'
-        })
-        class Test {
-          @Input('aria-invalid') ariaBusy: string;
-                 ~~~~~~~~~~~~~~
-        }
-      `,
+      @Directive({
+        selector: 'foo'
+      })
+      class Test {
+        @Input('aria-invalid') ariaBusy: string;
+               ~~~~~~~~~~~~~~
+      }
+    `,
     messageId,
     suggestions: (
       [
@@ -306,27 +339,27 @@ export const invalid = [
     ).map(([messageId, propertyName]) => ({
       messageId,
       output: `
-        @Directive({
-          selector: 'foo'
-        })
-        class Test {
-          @Input() ${propertyName}: string;
-                 
-        }
-      `,
+      @Directive({
+        selector: 'foo'
+      })
+      class Test {
+        @Input() ${propertyName}: string;
+               
+      }
+    `,
     })),
   }),
   convertAnnotatedSourceToFailureCase({
-    description: `should fail if input alias is prefixed by directive's selector, but the suffix does not match the property name`,
+    description: `should fail if input alias is prefixed by component's selector, but the suffix does not match the property name`,
     annotatedSource: `
-        @Component({
-          selector: 'foo'
-        })
-        class Test {
-          @Input('fooColor') colors: string;
-                 ~~~~~~~~~~
-        }
-      `,
+      @Component({
+        selector: 'foo'
+      })
+      class Test {
+        @Input('fooColor') colors: string;
+               ~~~~~~~~~~
+      }
+    `,
     messageId,
     suggestions: (
       [
@@ -336,28 +369,28 @@ export const invalid = [
     ).map(([messageId, propertyName]) => ({
       messageId,
       output: `
-        @Component({
-          selector: 'foo'
-        })
-        class Test {
-          @Input() ${propertyName}: string;
-                 
-        }
-      `,
+      @Component({
+        selector: 'foo'
+      })
+      class Test {
+        @Input() ${propertyName}: string;
+               
+      }
+    `,
     })),
   }),
   convertAnnotatedSourceToFailureCase({
     description:
       'should fail if input alias is not strictly equal to the selector plus the property name in `camelCase` form',
     annotatedSource: `
-        @Directive({
-          'selector': 'foo'
-        })
-        class Test {
-          @Input('foocolor') color: string;
-                 ~~~~~~~~~~
-        }
-      `,
+      @Directive({
+        'selector': 'foo'
+      })
+      class Test {
+        @Input('foocolor') color: string;
+               ~~~~~~~~~~
+      }
+    `,
     messageId,
     suggestions: (
       [
@@ -367,31 +400,31 @@ export const invalid = [
     ).map(([messageId, propertyName]) => ({
       messageId,
       output: `
-        @Directive({
-          'selector': 'foo'
-        })
-        class Test {
-          @Input() ${propertyName}: string;
-                 
-        }
-      `,
+      @Directive({
+        'selector': 'foo'
+      })
+      class Test {
+        @Input() ${propertyName}: string;
+               
+      }
+    `,
     })),
   }),
   convertAnnotatedSourceToFailureCase({
     description:
       'should fail if input property is aliased without `@Component` or `@Directive` decorator',
     annotatedSource: `
-        @Component({
-          selector: 'click',
-        })
-        class Test {}
+      @Component({
+        selector: 'click',
+      })
+      class Test {}
 
-        @Injectable()
-        class Test {
-          @Input('click') blur = this.getInput();
-                 ~~~~~~~
-        }
-      `,
+      @Injectable()
+      class Test {
+        @Input('click') blur = this.getInput();
+               ~~~~~~~
+      }
+    `,
     messageId,
     suggestions: (
       [
@@ -401,17 +434,17 @@ export const invalid = [
     ).map(([messageId, propertyName]) => ({
       messageId,
       output: `
-        @Component({
-          selector: 'click',
-        })
-        class Test {}
+      @Component({
+        selector: 'click',
+      })
+      class Test {}
 
-        @Injectable()
-        class Test {
-          @Input() ${propertyName} = this.getInput();
-                 
-        }
-      `,
+      @Injectable()
+      class Test {
+        @Input() ${propertyName} = this.getInput();
+               
+      }
+    `,
     })),
   }),
 ];

--- a/packages/eslint-plugin/tests/rules/no-inputs-metadata-property/cases.ts
+++ b/packages/eslint-plugin/tests/rules/no-inputs-metadata-property/cases.ts
@@ -8,43 +8,43 @@ export const valid = [
   `
     @Component()
     class Test {}
-    `,
+  `,
   `
     @Directive({})
     class Test {}
-    `,
+  `,
   `
     const options = {};
     @Component(options)
     class Test {}
-    `,
+  `,
   `
     @Directive({
       selector: 'app-test',
       template: 'Hello'
     })
     class Test {}
-    `,
+  `,
   `
     @Component({
       selector: 'app-test',
       queries: {},
     })
     class Test {}
-    `,
+  `,
   `
     const inputs = 'providers';
     @Directive({
       [inputs]: [],
     })
     class Test {}
-    `,
+  `,
   `
     @NgModule({
       bootstrap: [Foo]
     })
     class Test {}
-    `,
+  `,
 ];
 
 export const invalid = [
@@ -52,95 +52,95 @@ export const invalid = [
     description:
       'should fail if `inputs` metadata property is used in `@Component`',
     annotatedSource: `
-        @Component({
-          inputs: [
-          ~~~~~~~~~
-            'id: foo'
-          ],
-          ~
-          selector: 'app-test'
-        })
-        class Test {}
-      `,
+      @Component({
+        inputs: [
+        ~~~~~~~~~
+          'id: foo'
+        ],
+        ~
+        selector: 'app-test'
+      })
+      class Test {}
+    `,
     messageId,
   }),
   convertAnnotatedSourceToFailureCase({
     description:
       'should fail if `inputs` metadata property is used in `@Directive`',
     annotatedSource: `
-        @Directive({
-          inputs: [
-          ~~~~~~~~~
-            'id: foo'
-          ],
-          ~
-          selector: 'app-test'
-        })
-        class Test {}
-      `,
+      @Directive({
+        inputs: [
+        ~~~~~~~~~
+          'id: foo'
+        ],
+        ~
+        selector: 'app-test'
+      })
+      class Test {}
+    `,
     messageId,
   }),
   convertAnnotatedSourceToFailureCase({
     description: 'should fail if `inputs` metadata property is shorthand',
     annotatedSource: `
-        @Component({
-          inputs,
-          ~~~~~~
-        })
-        class Test {}
-      `,
+      @Component({
+        inputs,
+        ~~~~~~
+      })
+      class Test {}
+    `,
     messageId,
   }),
   convertAnnotatedSourceToFailureCase({
     description: 'should fail if `inputs` metadata property has no properties',
     annotatedSource: `
-        @Component({
-          inputs: [],
-          ~~~~~~~~~~
-        })
-        class Test {}
-      `,
+      @Directive({
+        inputs: [],
+        ~~~~~~~~~~
+      })
+      class Test {}
+    `,
     messageId,
   }),
   convertAnnotatedSourceToFailureCase({
     description:
-      "should fail if `inputs` metadata property's value is a variable",
+      "should fail if `inputs` metadata property's key is `Literal` and its value is a variable",
     annotatedSource: `
-        const test = [];
-        @Component({
-          inputs: test,
-          ~~~~~~~~~~~~
-        })
-        class Test {}
-      `,
+      const test = [];
+      @Component({
+        'inputs': test,
+        ~~~~~~~~~~~~~~
+      })
+      class Test {}
+    `,
     messageId,
   }),
   convertAnnotatedSourceToFailureCase({
     description:
-      "should fail if `inputs` metadata property's value is `undefined`",
+      "should fail if `inputs` metadata property's key is computed `Literal` and its value is `undefined`",
     annotatedSource: `
-        @Component({
-          inputs: undefined,
-          ~~~~~~~~~~~~~~~~~
-        })
-        class Test {}
-      `,
+      @Directive({
+        ['inputs']: undefined,
+        ~~~~~~~~~~~~~~~~~~~~~
+      })
+      class Test {}
+    `,
     messageId,
   }),
   convertAnnotatedSourceToFailureCase({
     description:
-      "should fail if `inputs` metadata property's key is `Literal` and its value is a function",
+      "should fail if `inputs` metadata property's key is computed `TemplateLiteral` and its value is a function",
     annotatedSource: `
-        function inputs() {
-          return [];
-        }
+      function inputs() {
+        return [];
+      }
 
-        @Directive({
-          'inputs': inputs(),
-          ~~~~~~~~~~~~~~~~~~
-        })
-        class Test {}
-      `,
+      @Component({
+        [\`inputs\`]: inputs(),
+        ~~~~~~~~~~~~~~~~~~~~
+      })
+      class Test {}
+    `,
     messageId,
   }),
 ];

--- a/packages/eslint-plugin/tests/rules/no-pipe-impure/cases.ts
+++ b/packages/eslint-plugin/tests/rules/no-pipe-impure/cases.ts
@@ -9,145 +9,171 @@ export const valid = [
   `
     @Pipe()
     class Test {}
-    `,
+  `,
   `
     @Pipe({})
     class Test {}
-    `,
+  `,
   `
     const options = {};
     @Pipe(options)
     class Test {}
-    `,
+  `,
   `
     @Pipe({
       name: 'test',
     })
     class Test {}
-    `,
+  `,
   `
     @Pipe({
       pure: true
     })
     class Test {}
-    `,
+  `,
   `
     @Pipe({
-      pure: !0,
+      'pure': !0,
     })
     class Test {}
-    `,
+  `,
   `
     @Pipe({
-      pure: !!isPure(),
+      ['pure']: !!isPure(),
     })
     class Test {}
-    `,
+  `,
   `
     const pure = 'pure';
     @Pipe({
       [pure]: false
     })
     class Test {}
-    `,
+  `,
   `
     const pure = false;
     @Pipe({
       pure,
     })
     class Test {}
-    `,
+  `,
   `
     function isPure() {
       return false;
     }
 
     @Pipe({
-      pure: isPure(),
+      [\`pure\`]: isPure(),
     })
     class Test {}
-    `,
+  `,
   `
     @NgModule({
       bootstrap: [Foo]
     })
     class Test {}
-    `,
+  `,
 ];
 
 export const invalid = [
   convertAnnotatedSourceToFailureCase({
     description: 'should fail if `pure` property is set to `false`',
     annotatedSource: `
-        @Pipe({
-          pure: false
-          ~~~~~~~~~~~
-        })
-        class Test {}
-      `,
+      @Pipe({
+        pure: false
+        ~~~~~~~~~~~
+      })
+      class Test {}
+    `,
     messageId,
     suggestions: [
       {
         messageId: suggestRemovePipeImpure,
         output: `
-        @Pipe({
-          
-          
-        })
-        class Test {}
-      `,
+      @Pipe({
+        
+        
+      })
+      class Test {}
+    `,
       },
     ],
   }),
   convertAnnotatedSourceToFailureCase({
     description:
-      'should fail if `pure` property is literal and is set to `false`',
+      "should fail if `pure` metadata property's key is `Literal` and its value is set to `false`",
     annotatedSource: `
-        @Pipe({
-          name: 'test',
-          'pure': false,
-          ~~~~~~~~~~~~~
-        })
-        class Test {}
-      `,
+      @Pipe({
+        name: 'test',
+        'pure': false,
+        ~~~~~~~~~~~~~
+      })
+      class Test {}
+    `,
     messageId,
     suggestions: [
       {
         messageId: suggestRemovePipeImpure,
         output: `
-        @Pipe({
-          name: 'test',
-          
-          
-        })
-        class Test {}
-      `,
+      @Pipe({
+        name: 'test',
+        
+        
+      })
+      class Test {}
+    `,
       },
     ],
   }),
   convertAnnotatedSourceToFailureCase({
     description:
-      'should fail if `pure` property is literal and is set to `!true`',
+      "should fail if `pure` metadata property's key is computed `TemplateLiteral` and its value is set to `!true`",
     annotatedSource: `
-        @Pipe({
-          name: 'test',
-          'pure': !true
-          ~~~~~~~~~~~~~
-        })
-        class Test {}
-      `,
+      @Pipe({
+        name: 'test',
+        ['pure']: !true
+        ~~~~~~~~~~~~~~~
+      })
+      class Test {}
+    `,
     messageId,
     suggestions: [
       {
         messageId: suggestRemovePipeImpure,
         output: `
-        @Pipe({
-          name: 'test',
-          
-          
-        })
-        class Test {}
-      `,
+      @Pipe({
+        name: 'test',
+        
+        
+      })
+      class Test {}
+    `,
+      },
+    ],
+  }),
+  convertAnnotatedSourceToFailureCase({
+    description:
+      "should fail if `pure` metadata property's key is computed `TemplateLiteral` and its value is set to `false`",
+    annotatedSource: `
+      @Pipe({
+        name: 'test',
+        [\`pure\`]: false
+        ~~~~~~~~~~~~~~~
+      })
+      class Test {}
+    `,
+    messageId,
+    suggestions: [
+      {
+        messageId: suggestRemovePipeImpure,
+        output: `
+      @Pipe({
+        name: 'test',
+        
+        
+      })
+      class Test {}
+    `,
       },
     ],
   }),

--- a/packages/eslint-plugin/tests/rules/use-component-view-encapsulation/cases.ts
+++ b/packages/eslint-plugin/tests/rules/use-component-view-encapsulation/cases.ts
@@ -12,130 +12,194 @@ export const valid = [
       selector: 'app-foo-bar'
     })
     class Test {}
-    `,
+  `,
   `
     @Component({
-      encapsulation: ViewEncapsulation.Native,
+      'encapsulation': ViewEncapsulation.Native,
       selector: 'app-foo-bar',
     })
     class Test {}
-    `,
+  `,
   `
     @Component({
-      encapsulation: ViewEncapsulation.ShadowDom,
+      ['encapsulation']: ViewEncapsulation.ShadowDom,
     })
     class Test {}
-    `,
+  `,
   `
     function encapsulation() {
       return ViewEncapsulation.None;
     }
 
     @Component({
-      encapsulation: encapsulation()
+      [\`encapsulation\`]: encapsulation()
     })
     class Test {}
-    `,
+  `,
   `
     const encapsulation = 'templateUrl';
     @Component({
       [encapsulation]: '../a.html'
     })
     class Test {}
-    `,
+  `,
   `
     const encapsulation = 'templateUrl';
     @Component({
       encapsulation
     })
     class Test {}
-    `,
+  `,
   `
     const test = 'test';
     @Component({
       encapsulation: test,
     })
     class Test {}
-    `,
+  `,
   `
     @Component({
       encapsulation: undefined,
     })
     class Test {}
-    `,
+  `,
   `
     @Component({})
     class Test {}
-    `,
+  `,
   `
     const options = {};
     @Component(options)
     class Test {}
-    `,
+  `,
   `
     @NgModule({
       bootstrap: [Foo]
     })
     class Test {}
-    `,
+  `,
 ];
 
 export const invalid = [
   convertAnnotatedSourceToFailureCase({
     description:
-      'should fail if `encapsulation` is set to `ViewEncapsulation.None`',
+      'should fail if `encapsulation` metadata property is set to `ViewEncapsulation.None`',
     annotatedSource: `
-        @Component({
-          encapsulation: ViewEncapsulation.None,
-                                           ~~~~
-          selector: 'app-foo-bar',
-        })
-        class Test {}
-      `,
+      @Component({
+        encapsulation: ViewEncapsulation.None,
+                                         ~~~~
+        selector: 'app-foo-bar',
+      })
+      class Test {}
+    `,
     messageId,
     suggestions: [
       {
         messageId: suggestRemoveViewEncapsulationNone,
         output: `
-        @Component({
-          
-                                           
-          selector: 'app-foo-bar',
-        })
-        class Test {}
-      `,
+      @Component({
+        
+                                         
+        selector: 'app-foo-bar',
+      })
+      class Test {}
+    `,
       },
     ],
   }),
   convertAnnotatedSourceToFailureCase({
     description:
-      'should fail if `encapsulation` is set to `ViewEncapsulation.None` and the suggestions should remove it along with its import',
+      "should fail if `encapsulation` property's key is `Literal` and its value is set to `ViewEncapsulation.None`",
     annotatedSource: `
-        import { ViewEncapsulation } from '@angular/core';
-        import { HttpClient } from '@angular/common/http';
+      import type { ViewEncapsulation } from '@angular/core';
+      import { HttpClient } from '@angular/common/http';
 
-        @Component({
-          selector: 'app-foo-bar',
-          'encapsulation': ViewEncapsulation.None
-                                             ~~~~
-        })
-        class Test {}
-      `,
+      @Component({
+        selector: 'app-foo-bar',
+        'encapsulation': ViewEncapsulation.None
+                                           ~~~~
+      })
+      class Test {}
+    `,
     messageId,
     suggestions: [
       {
         messageId: suggestRemoveViewEncapsulationNone,
         output: `
-        
-        import { HttpClient } from '@angular/common/http';
+      
+      import { HttpClient } from '@angular/common/http';
 
-        @Component({
-          selector: 'app-foo-bar',
-          
+      @Component({
+        selector: 'app-foo-bar',
+        
+                                           
+      })
+      class Test {}
+    `,
+      },
+    ],
+  }),
+  convertAnnotatedSourceToFailureCase({
+    description:
+      "should fail if `encapsulation` property's key is computed `Literal` and its value is set to `ViewEncapsulation.None`",
+    annotatedSource: `
+      import { ViewEncapsulation } from '@angular/core';
+      import { HttpClient } from '@angular/common/http';
+
+      @Component({
+        selector: 'app-foo-bar',
+        ['encapsulation']: ViewEncapsulation.None
+                                             ~~~~
+      })
+      class Test {}
+    `,
+    messageId,
+    suggestions: [
+      {
+        messageId: suggestRemoveViewEncapsulationNone,
+        output: `
+      
+      import { HttpClient } from '@angular/common/http';
+
+      @Component({
+        selector: 'app-foo-bar',
+        
                                              
-        })
-        class Test {}
-      `,
+      })
+      class Test {}
+    `,
+      },
+    ],
+  }),
+  convertAnnotatedSourceToFailureCase({
+    description:
+      "should fail if `encapsulation` property's key is computed `TemplateLiteral` and its value is set to `ViewEncapsulation.None`",
+    annotatedSource: `
+      import { ViewEncapsulation } from '@angular/core';
+      import { HttpClient } from '@angular/common/http';
+
+      @Component({
+        selector: 'app-foo-bar',
+        [\`encapsulation\`]: ViewEncapsulation.None
+                                             ~~~~
+      })
+      class Test {}
+    `,
+    messageId,
+    suggestions: [
+      {
+        messageId: suggestRemoveViewEncapsulationNone,
+        output: `
+      
+      import { HttpClient } from '@angular/common/http';
+
+      @Component({
+        selector: 'app-foo-bar',
+        
+                                             
+      })
+      class Test {}
+    `,
       },
     ],
   }),


### PR DESCRIPTION
With this, computed literals are now reported in the following rules:

- `no-inputs-metadata-property`;
- `no-input-prefix`;
- `no-input-rename`;
- `no-pipe-impure`;
- `use-view-encapsulation`.