### PR TITLE
fix(eslint-plugin): [no-empty-lifecycle-method] incorrect suggestions and correct reports

### DIFF
--- a/packages/eslint-plugin/docs/rules/no-empty-lifecycle-method.md
+++ b/packages/eslint-plugin/docs/rules/no-empty-lifecycle-method.md
@@ -46,7 +46,7 @@ class Test {
 
 ```ts
 @Directive()
-class Test {
+class Test extends BaseDirective {
   ngAfterContentInit() {}
   ~~~~~~~~~~~~~~~~~~~~~~~
 }
@@ -54,17 +54,17 @@ class Test {
 
 ```ts
 @Injectable()
-class Test {
-  ngAfterViewChecked() {}
-  ~~~~~~~~~~~~~~~~~~~~~~~
+class Test extends BaseTest implements AfterViewChecked, OnDestroy {
+  'ngAfterViewChecked'() {}
+  ~~~~~~~~~~~~~~~~~~~~~~~~~
 }
 ```
 
 ```ts
 @NgModule()
 class Test {
-  ngAfterViewInit() {}
-  ~~~~~~~~~~~~~~~~~~~~
+  ['ngAfterViewInit']() {}
+  ~~~~~~~~~~~~~~~~~~~~~~~~
 }
 ```
 
@@ -76,8 +76,8 @@ import {
 } from '@angular/core';
 @Pipe()
 class Test {
-  ngDoBootstrap() {}
-  ~~~~~~~~~~~~~~~~~~
+  [`ngDoBootstrap`]() {}
+  ~~~~~~~~~~~~~~~~~~~~~~
 }
 ```
 
@@ -90,8 +90,8 @@ import {
 @Component()
 class Test
     implements AfterViewChecked,
-               AfterViewInit,
-               DoCheck {
+                AfterViewInit,
+                DoCheck {
   ngDoCheck() {}
   ~~~~~~~~~~~~~~
 }
@@ -107,9 +107,9 @@ class Test implements OnChanges, AfterContentInit {
 ```
 
 ```ts
-import {OnDestroy} from '@angular/core';
+import * as ng from '@angular/core';
 @Injectable()
-class Test implements OnDestroy {
+class Test implements ng.OnDestroy {
   ngOnDestroy() {}
   ~~~~~~~~~~~~~~~~
 }
@@ -119,6 +119,14 @@ class Test implements OnDestroy {
 import {DoBootstrap, OnInit} from '@angular/core';
 @NgModule()
 class Test implements OnInit, DoBootstrap {
+  ngOnInit() {}
+  ~~~~~~~~~~~~~
+}
+```
+
+```ts
+@Component()
+class Test extends BaseComponent<unknown> implements OnInit {
   ngOnInit() {}
   ~~~~~~~~~~~~~
 }
@@ -192,6 +200,13 @@ class Test {
 @NgModule()
 class Test {
   ngOnInit() { console.log('OnInit'); }
+}
+```
+
+```ts
+@Component()
+class Test {
+  [ngOnInit]() {}
 }
 ```
 

--- a/packages/eslint-plugin/docs/rules/no-empty-lifecycle-method.md
+++ b/packages/eslint-plugin/docs/rules/no-empty-lifecycle-method.md
@@ -119,6 +119,13 @@ class Test implements ng.OnDestroy {
 import {DoBootstrap, OnInit} from '@angular/core';
 @NgModule()
 class Test implements OnInit, DoBootstrap {
+  ngOnInit() {
+    this.init();
+  }
+}
+
+@NgModule()
+class Test2 implements OnInit, DoBootstrap {
   ngOnInit() {}
   ~~~~~~~~~~~~~
 }

--- a/packages/eslint-plugin/src/rules/no-conflicting-lifecycle.ts
+++ b/packages/eslint-plugin/src/rules/no-conflicting-lifecycle.ts
@@ -10,8 +10,9 @@ import {
   AngularLifecycleMethods,
   getDeclaredAngularLifecycleInterfaces,
   getDeclaredAngularLifecycleMethods,
-  getDeclaredInterfaces,
   getDeclaredMethods,
+  getInterfaceName,
+  getInterfaces,
   isAngularLifecycleInterface,
   isAngularLifecycleMethod,
 } from '../utils/utils';
@@ -59,11 +60,12 @@ export default createESLintRule<Options, MessageIds>({
 
       if (!hasInterfaceConflictingLifecycle) return;
 
-      const declaredInterfaces = getDeclaredInterfaces(node);
+      const declaredInterfaces = getInterfaces(node);
       const declaredAngularLifecycleInterfacesNodes = declaredInterfaces.filter(
-        (node) =>
-          ASTUtils.isIdentifier(node.expression) &&
-          isAngularLifecycleInterface(node.expression.name),
+        (node) => {
+          const interfaceName = getInterfaceName(node);
+          return interfaceName && isAngularLifecycleInterface(interfaceName);
+        },
       );
 
       for (const interFaceNode of declaredAngularLifecycleInterfacesNodes) {

--- a/packages/eslint-plugin/src/rules/no-empty-lifecycle-method.ts
+++ b/packages/eslint-plugin/src/rules/no-empty-lifecycle-method.ts
@@ -58,6 +58,12 @@ export default createESLintRule<Options, MessageIds>({
                 const importDeclarations =
                   getImportDeclarations(node, '@angular/core') ?? [];
                 const interfaceName = getRawText(node).replace(/^ng+/, '');
+                const text = sourceCode.getText();
+                const totalInterfaceOccurrences = getTotalInterfaceOccurrences(
+                  text,
+                  interfaceName,
+                );
+                const totalInterfaceOccurrencesSafeForRemoval = 2;
 
                 return [
                   fixer.remove(node),
@@ -67,12 +73,15 @@ export default createESLintRule<Options, MessageIds>({
                     interfaceName,
                     fixer,
                   ),
-                  getImportRemoveFix(
-                    sourceCode,
-                    importDeclarations,
-                    interfaceName,
-                    fixer,
-                  ),
+                  totalInterfaceOccurrences <=
+                  totalInterfaceOccurrencesSafeForRemoval
+                    ? getImportRemoveFix(
+                        sourceCode,
+                        importDeclarations,
+                        interfaceName,
+                        fixer,
+                      )
+                    : null,
                 ].filter(isNotNullOrUndefined);
               },
             },
@@ -82,3 +91,13 @@ export default createESLintRule<Options, MessageIds>({
     };
   },
 });
+
+function stripSpecialCharacters(text: string) {
+  return text.replace(/[\W]/g, '');
+}
+
+function getTotalInterfaceOccurrences(text: string, interfaceName: string) {
+  return text
+    .split(' ')
+    .filter((item) => stripSpecialCharacters(item) === interfaceName).length;
+}

--- a/packages/eslint-plugin/src/rules/no-empty-lifecycle-method.ts
+++ b/packages/eslint-plugin/src/rules/no-empty-lifecycle-method.ts
@@ -1,11 +1,12 @@
 import type { TSESTree } from '@typescript-eslint/experimental-utils';
 import { createESLintRule } from '../utils/create-eslint-rule';
+import { methodDefinition } from '../utils/selectors';
 import {
   ANGULAR_LIFECYCLE_METHODS,
-  getAngularClassDecorator,
   getImplementsRemoveFix,
   getImportDeclarations,
   getImportRemoveFix,
+  getRawText,
   isNotNullOrUndefined,
   toPattern,
 } from '../utils/utils';
@@ -40,14 +41,13 @@ export default createESLintRule<Options, MessageIds>({
     ]);
 
     return {
-      [`ClassDeclaration > ClassBody > MethodDefinition[key.name=${angularLifecycleMethodsPattern}][value.body.body.length=0]`](
+      [`ClassDeclaration:has(Decorator[expression.callee.name=/^(Component|Directive|Injectable|NgModule|Pipe)$/]) > ClassBody > ${methodDefinition(
+        angularLifecycleMethodsPattern,
+      )}[value.body.body.length=0]`](
         node: TSESTree.MethodDefinition & {
-          key: TSESTree.Identifier;
           parent: TSESTree.ClassBody & { parent: TSESTree.ClassDeclaration };
         },
       ) {
-        if (!getAngularClassDecorator(node.parent.parent)) return;
-
         context.report({
           node,
           messageId: 'noEmptyLifecycleMethod',
@@ -57,7 +57,7 @@ export default createESLintRule<Options, MessageIds>({
               fix: (fixer) => {
                 const importDeclarations =
                   getImportDeclarations(node, '@angular/core') ?? [];
-                const interfaceName = node.key.name.replace(/^ng+/, '');
+                const interfaceName = getRawText(node).replace(/^ng+/, '');
 
                 return [
                   fixer.remove(node),

--- a/packages/eslint-plugin/src/utils/selectors.ts
+++ b/packages/eslint-plugin/src/utils/selectors.ts
@@ -22,10 +22,20 @@ export const OUTPUT_DECORATOR = 'Decorator[expression.callee.name="Output"]';
 
 export const LITERAL_OR_TEMPLATE_ELEMENT = ':matches(Literal, TemplateElement)';
 
+export function metadataProperty(key: RegExp): string;
 export function metadataProperty<TKey extends string>(
   key: TKey,
-): `Property:matches([key.name=${TKey}][computed=false], [key.value=${TKey}], [key.quasis.0.value.raw=${TKey}])` {
+): `Property:matches([key.name=${TKey}][computed=false], [key.value=${TKey}], [key.quasis.0.value.raw=${TKey}])`;
+export function metadataProperty(key: RegExp | string): string {
   return `Property:matches([key.name=${key}][computed=false], [key.value=${key}], [key.quasis.0.value.raw=${key}])`;
+}
+
+export function methodDefinition(key: RegExp): string;
+export function methodDefinition<TKey extends string>(
+  key: TKey,
+): `MethodDefinition:matches([key.name=${TKey}][computed=false], [key.value=${TKey}], [key.quasis.0.value.raw=${TKey}])`;
+export function methodDefinition(key: RegExp | string): string {
+  return `MethodDefinition:matches([key.name=${key}][computed=false], [key.value=${key}], [key.quasis.0.value.raw=${key}])`;
 }
 
 export const COMPONENT_SELECTOR_LITERAL = `${COMPONENT_CLASS_DECORATOR} ${metadataProperty(

--- a/packages/eslint-plugin/tests/rules/no-empty-lifecycle-method/cases.ts
+++ b/packages/eslint-plugin/tests/rules/no-empty-lifecycle-method/cases.ts
@@ -10,296 +10,325 @@ export const valid = [
     class Test {
       ngAfterContentChecked() { console.log('AfterContentChecked'); }
     }
-    `,
+  `,
   `
     @Directive()
     class Test {
       ngAfterContentInit() { console.log('AfterContentInit'); }
     }
-    `,
+  `,
   `
     @Injectable()
     class Test {
       ngAfterViewChecked() { console.log('AfterViewChecked'); }
     }
-    `,
+  `,
   `
     @NgModule()
     class Test {
       ngAfterViewInit() { console.log('AfterViewInit'); }
     }
-    `,
+  `,
   `
     @Pipe()
     class Test {
       ngDoBootstrap() { console.log('DoBootstrap'); }
     }
-    `,
+  `,
   `
     @Component()
     class Test {
       ngDoCheck() { console.log('DoCheck'); }
     }
-    `,
+  `,
   `
     @Directive()
     class Test {
       ngOnChanges() { console.log('OnChanges'); }
     }
-    `,
+  `,
   `
     @Injectable()
     class Test {
       ngOnDestroy() { console.log('OnDestroy'); }
     }
-    `,
+  `,
   `
     @NgModule()
     class Test {
       ngOnInit() { console.log('OnInit'); }
     }
-    `,
+  `,
+  `
+    @Component()
+    class Test {
+      [ngOnInit]() {}
+    }
+  `,
   `
     class Test {
       ngOnInit() {}
     }
-    `,
+  `,
 ];
-
 export const invalid = [
   convertAnnotatedSourceToFailureCase({
-    description: 'should fail if ngAfterContentChecked() method is empty',
+    description: 'should fail if `ngAfterContentChecked()` method is empty',
     annotatedSource: `
-        @Component()
-        class Test {
-          ngAfterContentChecked() {}
-          ~~~~~~~~~~~~~~~~~~~~~~~~~~
-        }
-      `,
+      @Component()
+      class Test {
+        ngAfterContentChecked() {}
+        ~~~~~~~~~~~~~~~~~~~~~~~~~~
+      }
+    `,
     messageId,
     suggestions: [
       {
         messageId: suggestRemoveLifecycleMethod,
         output: `
-        @Component()
-        class Test {
-          
-          
-        }
-      `,
-      },
-    ],
-  }),
-  convertAnnotatedSourceToFailureCase({
-    description: 'should fail if ngAfterContentInit() method is empty',
-    annotatedSource: `
-        @Directive()
-        class Test {
-          ngAfterContentInit() {}
-          ~~~~~~~~~~~~~~~~~~~~~~~
-        }
-      `,
-    messageId,
-    suggestions: [
-      {
-        messageId: suggestRemoveLifecycleMethod,
-        output: `
-        @Directive()
-        class Test {
-          
-          
-        }
-      `,
-      },
-    ],
-  }),
-  convertAnnotatedSourceToFailureCase({
-    description: 'should fail if ngAfterViewChecked() method is empty',
-    annotatedSource: `
-        @Injectable()
-        class Test {
-          ngAfterViewChecked() {}
-          ~~~~~~~~~~~~~~~~~~~~~~~
-        }
-      `,
-    messageId,
-    suggestions: [
-      {
-        messageId: suggestRemoveLifecycleMethod,
-        output: `
-        @Injectable()
-        class Test {
-          
-          
-        }
-      `,
-      },
-    ],
-  }),
-  convertAnnotatedSourceToFailureCase({
-    description: 'should fail if ngAfterViewInit() method is empty',
-    annotatedSource: `
-        @NgModule()
-        class Test {
-          ngAfterViewInit() {}
-          ~~~~~~~~~~~~~~~~~~~~
-        }
-      `,
-    messageId,
-    suggestions: [
-      {
-        messageId: suggestRemoveLifecycleMethod,
-        output: `
-        @NgModule()
-        class Test {
-          
-          
-        }
-      `,
-      },
-    ],
-  }),
-  convertAnnotatedSourceToFailureCase({
-    description: 'should fail if ngDoBootstrap() method is empty',
-    annotatedSource: `
-        import { HttpInterceptor } from '@angular/common/http';
-        import {
-          DoCheck,
-          DoBootstrap
-        } from '@angular/core';
-        @Pipe()
-        class Test {
-          ngDoBootstrap() {}
-          ~~~~~~~~~~~~~~~~~~
-        }
-      `,
-    messageId,
-    suggestions: [
-      {
-        messageId: suggestRemoveLifecycleMethod,
-        output: `
-        import { HttpInterceptor } from '@angular/common/http';
-        import {
-          DoCheck
-        } from '@angular/core';
-        @Pipe()
-        class Test {
-          
-          
-        }
-      `,
-      },
-    ],
-  }),
-  convertAnnotatedSourceToFailureCase({
-    description: 'should fail if ngDoCheck() method is empty',
-    annotatedSource: `
-        import {
-          AfterViewChecked,
-          DoCheck,
-          AfterViewInit,
-        } from '@angular/core';
-        @Component()
-        class Test 
-            implements AfterViewChecked,
-                       AfterViewInit,
-                       DoCheck {
-          ngDoCheck() {}
-          ~~~~~~~~~~~~~~
-        }
-      `,
-    messageId,
-    suggestions: [
-      {
-        messageId: suggestRemoveLifecycleMethod,
-        output: `
-        import {
-          AfterViewChecked,
-          AfterViewInit,
-        } from '@angular/core';
-        @Component()
-        class Test 
-            implements AfterViewChecked,
-                       AfterViewInit {
-          
-          
-        }
-      `,
-      },
-    ],
-  }),
-  convertAnnotatedSourceToFailureCase({
-    description: 'should fail if ngOnChanges() method is empty',
-    annotatedSource: `
-        import {OnChanges, AfterContentInit} from '@angular/core';
-        @Directive()
-        class Test implements OnChanges, AfterContentInit {
-          ngOnChanges() {}
-          ~~~~~~~~~~~~~~~~
-        }
-      `,
-    messageId,
-    suggestions: [
-      {
-        messageId: suggestRemoveLifecycleMethod,
-        output: `
-        import { AfterContentInit} from '@angular/core';
-        @Directive()
-        class Test implements  AfterContentInit {
-          
-          
-        }
-      `,
-      },
-    ],
-  }),
-  convertAnnotatedSourceToFailureCase({
-    description: 'should fail if ngOnDestroy() method is empty',
-    annotatedSource: `
-        import {OnDestroy} from '@angular/core';
-        @Injectable()
-        class Test implements OnDestroy {
-          ngOnDestroy() {}
-          ~~~~~~~~~~~~~~~~
-        }
-      `,
-    messageId,
-    suggestions: [
-      {
-        messageId: suggestRemoveLifecycleMethod,
-        output: `
+      @Component()
+      class Test {
         
-        @Injectable()
-        class Test {
-          
-          
-        }
-      `,
+        
+      }
+    `,
       },
     ],
   }),
   convertAnnotatedSourceToFailureCase({
-    description: 'should fail if ngOnInit() method is empty',
+    description: 'should fail if `ngAfterContentInit()` method is empty',
     annotatedSource: `
-        import {DoBootstrap, OnInit} from '@angular/core';
-        @NgModule()
-        class Test implements OnInit, DoBootstrap {
-          ngOnInit() {}
-          ~~~~~~~~~~~~~
-        }
-      `,
+      @Directive()
+      class Test extends BaseDirective {
+        ngAfterContentInit() {}
+        ~~~~~~~~~~~~~~~~~~~~~~~
+      }
+    `,
     messageId,
     suggestions: [
       {
         messageId: suggestRemoveLifecycleMethod,
         output: `
-        import {DoBootstrap} from '@angular/core';
-        @NgModule()
-        class Test implements  DoBootstrap {
-          
-          
-        }
-      `,
+      @Directive()
+      class Test extends BaseDirective {
+        
+        
+      }
+    `,
+      },
+    ],
+  }),
+  convertAnnotatedSourceToFailureCase({
+    description: "should fail if `'ngAfterViewChecked'()` method is empty",
+    annotatedSource: `
+      @Injectable()
+      class Test extends BaseTest implements AfterViewChecked, OnDestroy {
+        'ngAfterViewChecked'() {}
+        ~~~~~~~~~~~~~~~~~~~~~~~~~
+      }
+    `,
+    messageId,
+    suggestions: [
+      {
+        messageId: suggestRemoveLifecycleMethod,
+        output: `
+      @Injectable()
+      class Test extends BaseTest implements  OnDestroy {
+        
+        
+      }
+    `,
+      },
+    ],
+  }),
+  convertAnnotatedSourceToFailureCase({
+    description: "should fail if `['ngAfterViewInit']()` method is empty",
+    annotatedSource: `
+      @NgModule()
+      class Test {
+        ['ngAfterViewInit']() {}
+        ~~~~~~~~~~~~~~~~~~~~~~~~
+      }
+    `,
+    messageId,
+    suggestions: [
+      {
+        messageId: suggestRemoveLifecycleMethod,
+        output: `
+      @NgModule()
+      class Test {
+        
+        
+      }
+    `,
+      },
+    ],
+  }),
+  convertAnnotatedSourceToFailureCase({
+    description: 'should fail if `[`ngDoBootstrap`]()` method is empty',
+    annotatedSource: `
+      import { HttpInterceptor } from '@angular/common/http';
+      import {
+        DoCheck,
+        DoBootstrap
+      } from '@angular/core';
+      @Pipe()
+      class Test {
+        [\`ngDoBootstrap\`]() {}
+        ~~~~~~~~~~~~~~~~~~~~~~
+      }
+    `,
+    messageId,
+    suggestions: [
+      {
+        messageId: suggestRemoveLifecycleMethod,
+        output: `
+      import { HttpInterceptor } from '@angular/common/http';
+      import {
+        DoCheck
+      } from '@angular/core';
+      @Pipe()
+      class Test {
+        
+        
+      }
+    `,
+      },
+    ],
+  }),
+  convertAnnotatedSourceToFailureCase({
+    description: 'should fail if `ngDoCheck()` method is empty',
+    annotatedSource: `
+      import {
+        AfterViewChecked,
+        DoCheck,
+        AfterViewInit,
+      } from '@angular/core';
+      @Component()
+      class Test 
+          implements AfterViewChecked,
+                      AfterViewInit,
+                      DoCheck {
+        ngDoCheck() {}
+        ~~~~~~~~~~~~~~
+      }
+    `,
+    messageId,
+    suggestions: [
+      {
+        messageId: suggestRemoveLifecycleMethod,
+        output: `
+      import {
+        AfterViewChecked,
+        AfterViewInit,
+      } from '@angular/core';
+      @Component()
+      class Test 
+          implements AfterViewChecked,
+                      AfterViewInit {
+        
+        
+      }
+    `,
+      },
+    ],
+  }),
+  convertAnnotatedSourceToFailureCase({
+    description: 'should fail if `ngOnChanges()` method is empty',
+    annotatedSource: `
+      import {OnChanges, AfterContentInit} from '@angular/core';
+      @Directive()
+      class Test implements OnChanges, AfterContentInit {
+        ngOnChanges() {}
+        ~~~~~~~~~~~~~~~~
+      }
+    `,
+    messageId,
+    suggestions: [
+      {
+        messageId: suggestRemoveLifecycleMethod,
+        output: `
+      import { AfterContentInit} from '@angular/core';
+      @Directive()
+      class Test implements  AfterContentInit {
+        
+        
+      }
+    `,
+      },
+    ],
+  }),
+  convertAnnotatedSourceToFailureCase({
+    description: 'should fail if `ngOnDestroy()` method is empty',
+    annotatedSource: `
+      import * as ng from '@angular/core';
+      @Injectable()
+      class Test implements ng.OnDestroy {
+        ngOnDestroy() {}
+        ~~~~~~~~~~~~~~~~
+      }
+    `,
+    messageId,
+    suggestions: [
+      {
+        messageId: suggestRemoveLifecycleMethod,
+        output: `
+      import * as ng from '@angular/core';
+      @Injectable()
+      class Test  {
+        
+        
+      }
+    `,
+      },
+    ],
+  }),
+  convertAnnotatedSourceToFailureCase({
+    description: 'should fail if `ngOnInit()` method is empty',
+    annotatedSource: `
+      import {DoBootstrap, OnInit} from '@angular/core';
+      @NgModule()
+      class Test implements OnInit, DoBootstrap {
+        ngOnInit() {}
+        ~~~~~~~~~~~~~
+      }
+    `,
+    messageId,
+    suggestions: [
+      {
+        messageId: suggestRemoveLifecycleMethod,
+        output: `
+      import {DoBootstrap} from '@angular/core';
+      @NgModule()
+      class Test implements  DoBootstrap {
+        
+        
+      }
+    `,
+      },
+    ],
+  }),
+  convertAnnotatedSourceToFailureCase({
+    // https://github.com/angular-eslint/angular-eslint/issues/604
+    description: 'should fail if `ngOnInit()` method is empty',
+    annotatedSource: `
+      @Component()
+      class Test extends BaseComponent<unknown> implements OnInit {
+        ngOnInit() {}
+        ~~~~~~~~~~~~~
+      }
+    `,
+    messageId,
+    suggestions: [
+      {
+        messageId: suggestRemoveLifecycleMethod,
+        output: `
+      @Component()
+      class Test extends BaseComponent<unknown>  {
+        
+        
+      }
+    `,
       },
     ],
   }),

--- a/packages/eslint-plugin/tests/rules/no-empty-lifecycle-method/cases.ts
+++ b/packages/eslint-plugin/tests/rules/no-empty-lifecycle-method/cases.ts
@@ -289,6 +289,13 @@ export const invalid = [
       import {DoBootstrap, OnInit} from '@angular/core';
       @NgModule()
       class Test implements OnInit, DoBootstrap {
+        ngOnInit() {
+          this.init();
+        }
+      }
+
+      @NgModule()
+      class Test2 implements OnInit, DoBootstrap {
         ngOnInit() {}
         ~~~~~~~~~~~~~
       }
@@ -298,9 +305,16 @@ export const invalid = [
       {
         messageId: suggestRemoveLifecycleMethod,
         output: `
-      import {DoBootstrap} from '@angular/core';
+      import {DoBootstrap, OnInit} from '@angular/core';
       @NgModule()
-      class Test implements  DoBootstrap {
+      class Test implements OnInit, DoBootstrap {
+        ngOnInit() {
+          this.init();
+        }
+      }
+
+      @NgModule()
+      class Test2 implements  DoBootstrap {
         
         
       }


### PR DESCRIPTION
In addittion to the fix on suggestion, it now reports literal `MethodDefinition`s and removes interfaces within `MemberExpression`s.

Fixes #604.