### PR TITLE
fix(eslint-plugin): [sort-ngmodule-metadata-arrays] handle literal metadata and computed properties

### DIFF
--- a/packages/eslint-plugin/docs/rules/sort-ngmodule-metadata-arrays.md
+++ b/packages/eslint-plugin/docs/rules/sort-ngmodule-metadata-arrays.md
@@ -13,7 +13,7 @@
 
 # `@angular-eslint/sort-ngmodule-metadata-arrays`
 
-Enforces ASC alphabetical order for NgModule metadata arrays for easy visual scanning
+Ensures ASC alphabetical order for `NgModule` metadata arrays for easy visual scanning
 
 - Type: suggestion
 - Category: Best Practices
@@ -37,20 +37,15 @@ The rule does not have any configuration options.
 
 ```ts
 @NgModule({
-  imports: [
-    aModule,
-    bModule,
-    DModule,
-    ~~~~~~~
-    cModule,
-  ]
+  imports: [aModule, bModule, DModule, cModule]
+                              ~~~~~~~
 })
 class Test {}
 ```
 
 ```ts
 @NgModule({
-  declarations: [
+  'declarations': [
     AComponent,
     cPipe,
     ~~~~~
@@ -63,7 +58,7 @@ class Test {}
 
 ```ts
 @NgModule({
-  exports: [
+  ['exports']: [
     AComponent,
     cPipe,
     ~~~~~
@@ -76,7 +71,7 @@ class Test {}
 
 ```ts
 @NgModule({
-  bootstrap: [
+  [`bootstrap`]: [
     AppModule2,
     AppModule3,
     ~~~~~~~~~~
@@ -124,27 +119,63 @@ class Test {}
 ✅ - Examples of **correct** code for this rule:
 
 ```ts
+class Test {}
+```
+
+```ts
+@NgModule()
+class Test {}
+```
+
+```ts
+@NgModule({})
+class Test {}
+```
+
+```ts
+const options = {};
+@NgModule(options)
+class Test {}
+```
+
+```ts
+@NgModule({
+  bootstrap,
+  declarations: declarations,
+  providers: providers(),
+  schemas: [],
+  [imports]: [
+    aModule,
+    bModule,
+    DModule,
+    cModule,
+  ],
+})
+class Test {}
+```
+
+```ts
 @NgModule({
   bootstrap: [
     AppModule1,
     AppModule2,
     AppModule3,
   ],
-  declarations: [
+  'declarations': [
     AComponent,
     bDirective,
     cPipe,
     DComponent,
     VariableComponent,
   ],
-  imports: [
+  ['imports']: [
     _foo,
     AModule,
     bModule,
     cModule,
     DModule,
   ],
-  providers: [
+  [`providers`]: [
     AProvider,
     {
       provide: 'myprovider',
@@ -154,6 +185,16 @@ class Test {}
     cProvider,
     DProvider,
   ],
+})
+class Test {}
+```
+
+```ts
+@Component({
+  providers: [
+    DeclarationD,
+    DeclarationA,
+  ]
 })
 class Test {}
 ```

--- a/packages/eslint-plugin/src/rules/sort-ngmodule-metadata-arrays.ts
+++ b/packages/eslint-plugin/src/rules/sort-ngmodule-metadata-arrays.ts
@@ -1,22 +1,11 @@
-import type { NgModule } from '@angular/compiler/src/core';
 import type { TSESTree } from '@typescript-eslint/experimental-utils';
 import { ASTUtils } from '@typescript-eslint/experimental-utils';
 import { createESLintRule } from '../utils/create-eslint-rule';
-import { MODULE_CLASS_DECORATOR } from '../utils/selectors';
-import { getDecoratorPropertyValue, isArrayExpression } from '../utils/utils';
+import { metadataProperty, MODULE_CLASS_DECORATOR } from '../utils/selectors';
 
 type Options = [];
-export const RULE_NAME = 'sort-ngmodule-metadata-arrays';
 export type MessageIds = 'sortNgmoduleMetadataArrays';
-const validProperties: (keyof NgModule)[] = [
-  'bootstrap',
-  'declarations',
-  'entryComponents',
-  'exports',
-  'imports',
-  'providers',
-  'schemas',
-];
+export const RULE_NAME = 'sort-ngmodule-metadata-arrays';
 
 export default createESLintRule<Options, MessageIds>({
   name: RULE_NAME,
@@ -24,7 +13,7 @@ export default createESLintRule<Options, MessageIds>({
     type: 'suggestion',
     docs: {
       description:
-        'Enforces ASC alphabetical order for NgModule metadata arrays for easy visual scanning',
+        'Ensures ASC alphabetical order for `NgModule` metadata arrays for easy visual scanning',
       category: 'Best Practices',
       recommended: false,
     },
@@ -32,43 +21,35 @@ export default createESLintRule<Options, MessageIds>({
     schema: [],
     messages: {
       sortNgmoduleMetadataArrays:
-        'NgModule metadata arrays should be sorted in ASC alphabetical order',
+        '`NgModule` metadata arrays should be sorted in ASC alphabetical order',
     },
   },
   defaultOptions: [],
   create(context) {
-    return {
-      [MODULE_CLASS_DECORATOR](node: TSESTree.Decorator) {
-        validProperties.forEach((prop: keyof NgModule) => {
-          const initializer = getDecoratorPropertyValue(node, prop);
-          if (
-            !initializer ||
-            !isArrayExpression(initializer) ||
-            initializer.elements.length < 2
-          ) {
-            return;
-          }
-          const unorderedNodes = initializer.elements
-            .filter(ASTUtils.isIdentifier)
-            .map((current, index, list) => {
-              return [current, list[index + 1]];
-            })
-            .find(([current, next]) => {
-              return next && current.name.localeCompare(next.name) === 1;
-            });
-          if (!unorderedNodes) return;
+    const metadataPropertyPattern =
+      /^(bootstrap|declarations|entryComponents|exports|imports|providers|schemas)$/;
 
-          const [unorderedNode, nextNode] = unorderedNodes;
-          context.report({
-            messageId: 'sortNgmoduleMetadataArrays',
-            node: unorderedNode,
-            fix: (fixer) => {
-              return [
-                fixer.replaceText(unorderedNode, nextNode.name),
-                fixer.replaceText(nextNode, unorderedNode.name),
-              ];
-            },
+    return {
+      [`${MODULE_CLASS_DECORATOR} ${metadataProperty(
+        metadataPropertyPattern,
+      )} ArrayExpression`]({ elements }: TSESTree.ArrayExpression) {
+        const unorderedNodes = elements
+          .filter(ASTUtils.isIdentifier)
+          .map((current, index, list) => [current, list[index + 1]])
+          .find(([current, next]) => {
+            return next && current.name.localeCompare(next.name) === 1;
           });
+
+        if (!unorderedNodes) return;
+
+        const [unorderedNode, nextNode] = unorderedNodes;
+        context.report({
+          node: unorderedNode,
+          messageId: 'sortNgmoduleMetadataArrays',
+          fix: (fixer) => [
+            fixer.replaceText(unorderedNode, nextNode.name),
+            fixer.replaceText(nextNode, unorderedNode.name),
+          ],
         });
       },
     };

--- a/packages/eslint-plugin/tests/rules/sort-ngmodule-metadata-arrays/cases.ts
+++ b/packages/eslint-plugin/tests/rules/sort-ngmodule-metadata-arrays/cases.ts
@@ -4,214 +4,243 @@ import type { MessageIds } from '../../../src/rules/sort-ngmodule-metadata-array
 const messageId: MessageIds = 'sortNgmoduleMetadataArrays';
 
 export const valid = [
+  `class Test {}`,
   `
+  @NgModule()
+  class Test {}
+  `,
+  `
+  @NgModule({})
+  class Test {}
+  `,
+  `
+  const options = {};
+  @NgModule(options)
+  class Test {}
+  `,
+  `
+  @NgModule({
+    bootstrap,
+    declarations: declarations,
+    providers: providers(),
+    schemas: [],
+    [imports]: [
+      aModule,
+      bModule,
+      DModule,
+      cModule,
+    ],
+  })
+  class Test {}
+  `,
+  `
+  @NgModule({
+    bootstrap: [
+      AppModule1,
+      AppModule2,
+      AppModule3,
+    ],
+    'declarations': [
+      AComponent,
+      bDirective,
+      cPipe,
+      DComponent,
+      VariableComponent,
+    ],
+    ['imports']: [
+      _foo,
+      AModule,
+      bModule,
+      cModule,
+      DModule,
+    ],
+    [\`providers\`]: [
+      AProvider,
+      {
+        provide: 'myprovider',
+        useClass: MyProvider,
+      },
+      bProvider,
+      cProvider,
+      DProvider,
+    ],
+  })
+  class Test {}
+  `,
+  `
+  @Component({
+    providers: [        
+      DeclarationD,
+      DeclarationA,
+    ]
+  })
+  class Test {}
+  `,
+];
+
+export const invalid = [
+  convertAnnotatedSourceToFailureCase({
+    description: 'should fail if `imports` metadata arrays is not sorted ASC',
+    annotatedSource: `
     @NgModule({
-      bootstrap: [
-        AppModule1,
-        AppModule2,
-        AppModule3,
+      imports: [aModule, bModule, DModule, cModule]
+                                  ~~~~~~~
+    })
+    class Test {}
+    `,
+    messageId,
+    annotatedOutput: `
+    @NgModule({
+      imports: [aModule, bModule, cModule, DModule]
+                                  ~~~~~~~
+    })
+    class Test {}
+    `,
+  }),
+  convertAnnotatedSourceToFailureCase({
+    description:
+      'should fail if `declarations` metadata arrays is not sorted ASC',
+    annotatedSource: `
+    @NgModule({
+      'declarations': [
+        AComponent,
+        cPipe,
+        ~~~~~
+        bDirective,
+        DComponent,
       ],
-      declarations: [
+    })
+    class Test {}
+    `,
+    messageId,
+    annotatedOutput: `
+    @NgModule({
+      'declarations': [
         AComponent,
         bDirective,
+        ~~~~~
         cPipe,
         DComponent,
-        VariableComponent,
       ],
+    })
+    class Test {}
+    `,
+  }),
+  convertAnnotatedSourceToFailureCase({
+    description: 'should fail if `exports` metadata arrays is not sorted ASC',
+    annotatedSource: `
+    @NgModule({
+      ['exports']: [
+        AComponent,
+        cPipe,
+        ~~~~~
+        bDirective,
+        DComponent,
+      ],
+    })
+    class Test {}
+    `,
+    messageId,
+    annotatedOutput: `
+    @NgModule({
+      ['exports']: [
+        AComponent,
+        bDirective,
+        ~~~~~
+        cPipe,
+        DComponent,
+      ],
+    })
+    class Test {}
+    `,
+  }),
+  convertAnnotatedSourceToFailureCase({
+    description: 'should fail if `bootstrap` metadata arrays is not sorted ASC',
+    annotatedSource: `
+    @NgModule({
+      [\`bootstrap\`]: [
+        AppModule2,
+        AppModule3,
+        ~~~~~~~~~~
+        AppModule1,
+      ]
+    })
+    class Test {}
+    `,
+    messageId,
+    annotatedOutput: `
+    @NgModule({
+      [\`bootstrap\`]: [
+        AppModule2,
+        AppModule1,
+        ~~~~~~~~~~
+        AppModule3,
+      ]
+    })
+    class Test {}
+    `,
+  }),
+  convertAnnotatedSourceToFailureCase({
+    description: 'should fail if `schemas` metadata arrays is not sorted ASC',
+    annotatedSource: `
+    @NgModule({
+      schemas: [
+        A_SCHEMA,
+        C_SCHEMA,
+        ~~~~~~~~
+        B_SCHEMA,
+      ]
+    })
+    class Test {}
+    `,
+    messageId,
+    annotatedOutput: `
+    @NgModule({
+      schemas: [
+        A_SCHEMA,
+        B_SCHEMA,
+        ~~~~~~~~
+        C_SCHEMA,
+      ]
+    })
+    class Test {}
+    `,
+  }),
+  convertAnnotatedSourceToFailureCase({
+    description:
+      'should fail if `providers` metadata arrays is not sorted ASC, but ignore objects',
+    annotatedSource: `
+    @NgModule({
       imports: [
-        _foo,
-        AModule,
-        bModule,
-        cModule,
-        DModule,
-      ],
-      providers: [
+        AProvider,
+        {
+          provide: 'myprovider',
+          useClass: MyProvider,
+        },
+        cProvider,
+        ~~~~~~~~~
+        bProvider,
+        DProvider,
+      ]
+    })
+    class Test {}
+    `,
+    messageId,
+    annotatedOutput: `
+    @NgModule({
+      imports: [
         AProvider,
         {
           provide: 'myprovider',
           useClass: MyProvider,
         },
         bProvider,
+        ~~~~~~~~~
         cProvider,
         DProvider,
-      ],
+      ]
     })
     class Test {}
     `,
-];
-
-export const invalid = [
-  convertAnnotatedSourceToFailureCase({
-    description: 'it should fail if imports array is not sorted ASC',
-    annotatedSource: `
-      @NgModule({
-        imports: [
-          aModule,
-          bModule,
-          DModule,
-          ~~~~~~~
-          cModule,
-        ]
-      })
-      class Test {}
-      `,
-    messageId,
-    annotatedOutput: `
-      @NgModule({
-        imports: [
-          aModule,
-          bModule,
-          cModule,
-          ~~~~~~~
-          DModule,
-        ]
-      })
-      class Test {}
-      `,
-  }),
-  convertAnnotatedSourceToFailureCase({
-    description: 'it should fail if declarations array is not sorted ASC',
-    annotatedSource: `
-      @NgModule({
-        declarations: [
-          AComponent,
-          cPipe,
-          ~~~~~
-          bDirective,
-          DComponent,
-        ],
-      })
-      class Test {}
-      `,
-    messageId,
-    annotatedOutput: `
-      @NgModule({
-        declarations: [
-          AComponent,
-          bDirective,
-          ~~~~~
-          cPipe,
-          DComponent,
-        ],
-      })
-      class Test {}
-      `,
-  }),
-  convertAnnotatedSourceToFailureCase({
-    description: 'it should fail if exports array is not sorted ASC',
-    annotatedSource: `
-      @NgModule({
-        exports: [
-          AComponent,
-          cPipe,
-          ~~~~~
-          bDirective,
-          DComponent,
-        ],
-      })
-      class Test {}
-      `,
-    messageId,
-    annotatedOutput: `
-      @NgModule({
-        exports: [
-          AComponent,
-          bDirective,
-          ~~~~~
-          cPipe,
-          DComponent,
-        ],
-      })
-      class Test {}
-      `,
-  }),
-  convertAnnotatedSourceToFailureCase({
-    description: 'it should fail if bootstrap array is not sorted ASC',
-    annotatedSource: `
-      @NgModule({
-        bootstrap: [
-          AppModule2,
-          AppModule3,
-          ~~~~~~~~~~
-          AppModule1,
-        ]
-      })
-      class Test {}
-      `,
-    messageId,
-    annotatedOutput: `
-      @NgModule({
-        bootstrap: [
-          AppModule2,
-          AppModule1,
-          ~~~~~~~~~~
-          AppModule3,
-        ]
-      })
-      class Test {}
-      `,
-  }),
-  convertAnnotatedSourceToFailureCase({
-    description: 'it should fail if schemas array is not sorted ASC',
-    annotatedSource: `
-      @NgModule({
-        schemas: [
-          A_SCHEMA,
-          C_SCHEMA,
-          ~~~~~~~~
-          B_SCHEMA,
-        ]
-      })
-      class Test {}
-      `,
-    messageId,
-    annotatedOutput: `
-      @NgModule({
-        schemas: [
-          A_SCHEMA,
-          B_SCHEMA,
-          ~~~~~~~~
-          C_SCHEMA,
-        ]
-      })
-      class Test {}
-      `,
-  }),
-  convertAnnotatedSourceToFailureCase({
-    description:
-      'it should fail if providers array is not sorted ASC, but ignore objects',
-    annotatedSource: `
-      @NgModule({
-        imports: [
-          AProvider,
-          {
-            provide: 'myprovider',
-            useClass: MyProvider,
-          },
-          cProvider,
-          ~~~~~~~~~
-          bProvider,
-          DProvider,
-        ]
-      })
-      class Test {}
-      `,
-    messageId,
-    annotatedOutput: `
-      @NgModule({
-        imports: [
-          AProvider,
-          {
-            provide: 'myprovider',
-            useClass: MyProvider,
-          },
-          bProvider,
-          ~~~~~~~~~
-          cProvider,
-          DProvider,
-        ]
-      })
-      class Test {}
-      `,
   }),
 ];


### PR DESCRIPTION
This adds supports for computed properties and literals, like:

- `[providers]: [...]`
- `'imports': [...]`
- `['schema']: [...]`
- `[``declarations``]: [...]`