### PR TITLE
refactor(eslint-plugin): [sort-ngmodule-metadata-arrays]: properly handle multiple fixes at once

### DIFF
--- a/packages/eslint-plugin/docs/rules/sort-ngmodule-metadata-arrays.md
+++ b/packages/eslint-plugin/docs/rules/sort-ngmodule-metadata-arrays.md
@@ -19,6 +19,8 @@ Ensures ASC alphabetical order for `NgModule` metadata arrays for easy visual sc
 - Category: Best Practices
 - 🔧 Supports autofix (`--fix`)
 
+- 💡 Provides suggestions on how to fix issues (https://eslint.org/docs/developer-guide/working-with-rules#providing-suggestions)
+
 <br>
 
 ## Rule Options
@@ -38,7 +40,7 @@ The rule does not have any configuration options.
 ```ts
 @NgModule({
   imports: [aModule, bModule, DModule, cModule]
-                              ~~~~~~~
+                                       ~~~~~~~
 })
 class Test {}
 ```
@@ -48,8 +50,8 @@ class Test {}
   'declarations': [
     AComponent,
     cPipe,
-    ~~~~~
     bDirective,
+    ~~~~~~~~~~
     DComponent,
   ],
 })
@@ -61,8 +63,8 @@ class Test {}
   ['exports']: [
     AComponent,
     cPipe,
-    ~~~~~
     bDirective,
+    ~~~~~~~~~~
     DComponent,
   ],
 })
@@ -74,8 +76,8 @@ class Test {}
   [`bootstrap`]: [
     AppModule2,
     AppModule3,
-    ~~~~~~~~~~
     AppModule1,
+    ~~~~~~~~~~
   ]
 })
 class Test {}
@@ -86,8 +88,8 @@ class Test {}
   schemas: [
     A_SCHEMA,
     C_SCHEMA,
-    ~~~~~~~~
     B_SCHEMA,
+    ~~~~~~~~
   ]
 })
 class Test {}
@@ -95,19 +97,119 @@ class Test {}
 
 ```ts
 @NgModule({
-  imports: [
+  providers: [
+    // @ts-ignore
     AProvider,
+    // @ts-expect-error
     {
-      provide: 'myprovider',
       useClass: MyProvider,
+      // eslint-disable-next-line sort-keys
+      provide: 'myprovider',
     },
     cProvider,
+    bProvider, // TODO: This provider should be removed soon.
     ~~~~~~~~~
-    bProvider,
-    DProvider,
+    /* CommentAfter */ DProvider,
   ]
 })
 class Test {}
+```
+
+```ts
+@NgModule({
+  bootstrap,
+  declarations: declarations,
+  providers: providers(),
+  schemas: [],
+  [imports]: [
+    aModule,
+    bModule,
+    DModule,
+    cModule,
+    ~~~~~~~
+  ],
+})
+class Test {}
+```
+
+```ts
+@NgModule({
+  bootstrap,
+  declarations: declarations,
+  providers: providers(),
+  schemas: [],
+  imports: [
+    Module1,
+    [...commonModules, Module4, Module0],
+                                ~~~~~~~
+  ],
+})
+class Test {}
+```
+
+```ts
+@NgModule({
+  imports: [
+    AppRoutingModule,
+    BrowserModule,
+    DeprecatedModule as unknown as Type<unknown>,
+    FlexLayoutModule,
+    HttpClientModule,
+    new Array([TestModule]),
+    MatListModule,
+    ...(shouldLoadModuleB ? [ModuleA, ModuleB] : []),
+    MatMenuModule,
+    StoreModule.forRoot({}),
+    MatSidenavModule,
+    MatToolbarModule,
+    ...[sharedDeclarations],
+    BrowserAnimationsModule,
+    ~~~~~~~~~~~~~~~~~~~~~~~
+    Test!,
+  ],
+  declarations: [
+    AutoHeightDirective,
+    NgxColumnComponent,
+    NgxOptionsComponent,
+    TableBuilderComponent,
+    TableTbodyComponent,
+    TableTheadComponent,
+    TableCellComponent,
+    ~~~~~~~~~~~~~~~~~~
+    TemplateBodyTdDirective,
+    [B, A, C],
+        ~
+    TemplateHeadThDirective,
+    ObserverViewDirective,
+    NgxContextMenuComponent,
+    NgxContextMenuItemComponent,
+    NgxContextMenuDividerComponent,
+    NgxMenuContentComponent,
+    NgxEmptyComponent,
+    NgxHeaderComponent,
+    NgxFooterComponent,
+    NgxFilterViewerComponent,
+    NgxFilterComponent,
+    NgxFilterDirective,
+    DragIconComponent,
+    NgxSourceNullComponent,
+    DisableRowPipe,
+    TableSelectedItemsPipe,
+    MapToTableEntriesPipe,
+    VirtualForDirective,
+    GetFreeSizePipe,
+    GetClientHeightPipe
+  ],
+  providers: [
+    {provide: 'TOKEN', useFactory: useToken},
+    WebWorkerThreadService,
+  ],
+})
+class TableBuilderModule {
+  static forRoot(): ModuleWithProviders<TableBuilderModule> {
+    return { ngModule: TableBuilderModule, providers: [] };
+  }
+}
 ```
 
 <br>
@@ -135,22 +237,6 @@ class Test {}
 ```ts
 const options = {};
 @NgModule(options)
-class Test {}
-```
-
-```ts
-@NgModule({
-  bootstrap,
-  declarations: declarations,
-  providers: providers(),
-  schemas: [],
-  [imports]: [
-    aModule,
-    bModule,
-    DModule,
-    cModule,
-  ],
-})
 class Test {}
 ```
 

--- a/packages/eslint-plugin/src/rules/sort-ngmodule-metadata-arrays.ts
+++ b/packages/eslint-plugin/src/rules/sort-ngmodule-metadata-arrays.ts
@@ -1,10 +1,10 @@
-import { Selectors } from '@angular-eslint/utils';
-import type { TSESTree } from '@typescript-eslint/experimental-utils';
+import { ASTUtils, partition, Selectors } from '@angular-eslint/utils';
+import type { TSESLint, TSESTree } from '@typescript-eslint/experimental-utils';
 import { ASTUtils as TSESLintASTUtils } from '@typescript-eslint/experimental-utils';
 import { createESLintRule } from '../utils/create-eslint-rule';
 
 type Options = [];
-export type MessageIds = 'sortNgmoduleMetadataArrays';
+export type MessageIds = 'sortNgmoduleMetadataArrays' | 'suggestFix';
 export const RULE_NAME = 'sort-ngmodule-metadata-arrays';
 
 export default createESLintRule<Options, MessageIds>({
@@ -16,42 +16,106 @@ export default createESLintRule<Options, MessageIds>({
         'Ensures ASC alphabetical order for `NgModule` metadata arrays for easy visual scanning',
       category: 'Best Practices',
       recommended: false,
+      suggestion: true,
     },
     fixable: 'code',
     schema: [],
     messages: {
       sortNgmoduleMetadataArrays:
         '`NgModule` metadata arrays should be sorted in ASC alphabetical order',
+      suggestFix: 'Sort members (WARNING! comments will probably be messed up)',
     },
   },
   defaultOptions: [],
   create(context) {
-    const metadataPropertyPattern =
-      /^(bootstrap|declarations|entryComponents|exports|imports|providers|schemas)$/;
+    const sourceCode = context.getSourceCode();
 
     return {
-      [`${Selectors.MODULE_CLASS_DECORATOR} ${Selectors.metadataProperty(
-        metadataPropertyPattern,
-      )} ArrayExpression`]({ elements }: TSESTree.ArrayExpression) {
-        const unorderedNodes = elements
-          .filter(TSESLintASTUtils.isIdentifier)
-          .map((current, index, list) => [current, list[index + 1]])
-          .find(([current, next]) => {
-            return next && current.name.localeCompare(next.name) === 1;
-          });
+      [`${Selectors.MODULE_CLASS_DECORATOR} Property ArrayExpression`]({
+        elements,
+      }: TSESTree.ArrayExpression) {
+        const [expressions, identifiers] = partition(
+          elements,
+          TSESLintASTUtils.isIdentifier,
+        );
+        const firstUnorderedNode = getFirstUnderedNode(identifiers);
 
-        if (!unorderedNodes) return;
+        if (!firstUnorderedNode) {
+          return;
+        }
 
-        const [unorderedNode, nextNode] = unorderedNodes;
+        const hasComments = elements.some((element) =>
+          ASTUtils.hasComments(sourceCode, element),
+        );
+        const fix: TSESLint.ReportFixFunction = (fixer) =>
+          getFixes(sourceCode, fixer, elements, expressions, identifiers);
         context.report({
-          node: unorderedNode,
+          node: firstUnorderedNode,
           messageId: 'sortNgmoduleMetadataArrays',
-          fix: (fixer) => [
-            fixer.replaceText(unorderedNode, nextNode.name),
-            fixer.replaceText(nextNode, unorderedNode.name),
-          ],
+          ...(hasComments
+            ? { suggest: [{ messageId: 'suggestFix', fix }] }
+            : { fix }),
         });
       },
     };
   },
 });
+
+function getFirstUnderedNode(identifiers: readonly TSESTree.Identifier[]) {
+  return identifiers.find((identifier, index, array) => {
+    const previousElement = array[index - 1];
+    return (
+      previousElement &&
+      previousElement.name.localeCompare(identifier.name) === 1
+    );
+  });
+}
+
+function getFixes(
+  sourceCode: Readonly<TSESLint.SourceCode>,
+  fixer: TSESLint.RuleFixer,
+  elements: readonly TSESTree.Expression[],
+  expressions: readonly TSESTree.Expression[],
+  identifiers: readonly TSESTree.Identifier[],
+) {
+  const sortedIdentifiers = [...identifiers].sort((one, other) =>
+    one.name.localeCompare(other.name),
+  );
+  const sortedExpressions = [...sortedIdentifiers, ...expressions];
+  const text = sortedExpressions.reduce(toText(sourceCode, elements), '');
+  return fixer.replaceTextRange(getRangeFromFirstToLast(elements), text);
+}
+
+function toText(
+  sourceCode: Readonly<TSESLint.SourceCode>,
+  elements: readonly TSESTree.Expression[],
+) {
+  return (
+    accumulator: string,
+    expression: TSESTree.Expression,
+    index: number,
+  ) => {
+    const isLastElement = index === elements.length - 1;
+    const textAfterExpression = isLastElement
+      ? ''
+      : sourceCode
+          .getText()
+          .slice(...getRangeBetweenCurrentAndNext(elements, index));
+    return `${accumulator}${sourceCode.getText(
+      expression,
+    )}${textAfterExpression}`;
+  };
+}
+
+function getRangeBetweenCurrentAndNext(
+  elements: readonly TSESTree.Expression[],
+  index: number,
+): TSESTree.Range {
+  return [elements[index].range[1], elements[index + 1].range[0]];
+}
+
+function getRangeFromFirstToLast(
+  elements: readonly TSESTree.Expression[],
+): TSESTree.Range {
+  return [elements[0].range[0], elements[elements.length - 1].range[1]];
+}

--- a/packages/utils/src/eslint-plugin/ast-utils.ts
+++ b/packages/utils/src/eslint-plugin/ast-utils.ts
@@ -1,4 +1,4 @@
-import type { TSESTree } from '@typescript-eslint/experimental-utils';
+import type { TSESLint, TSESTree } from '@typescript-eslint/experimental-utils';
 import {
   ASTUtils,
   AST_NODE_TYPES,
@@ -507,6 +507,22 @@ export function getReplacementText(
   text: string,
 ): string {
   return isLiteral(node) ? `'${text}'` : `\`${text}\``;
+}
+
+/**
+ * Checks whether any comments exist or not given a node.
+ * @param sourceCode The source code.
+ * @param node The node to check.
+ * @returns `true` if one or more comments exist.
+ */
+export function hasComments(
+  sourceCode: Readonly<TSESLint.SourceCode>,
+  node: TSESTree.Node,
+): boolean {
+  return (
+    sourceCode.getCommentsBefore(node).length > 0 ||
+    sourceCode.getCommentsAfter(node).length > 0
+  );
 }
 
 // SECTION START:

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -1,20 +1,18 @@
 export * from './convert-annotated-source-to-failure-case';
-export * from './rules-tester';
-
-export {
-  toHumanReadableText,
-  arrayify,
-  isNotNullOrUndefined,
-  toPattern,
-  kebabToCamelCase,
-  withoutBracketsAndWhitespaces,
-  capitalize,
-} from './utils';
-
+export * as ASTUtils from './eslint-plugin/ast-utils';
 export { getAriaAttributeKeys } from './eslint-plugin/get-aria-attribute-keys';
 export { getNativeEventNames } from './eslint-plugin/get-native-event-names';
-
-export * as ASTUtils from './eslint-plugin/ast-utils';
 export * as RuleFixes from './eslint-plugin/rule-fixes';
-export * as Selectors from './eslint-plugin/selectors';
 export * as SelectorUtils from './eslint-plugin/selector-utils';
+export * as Selectors from './eslint-plugin/selectors';
+export * from './rules-tester';
+export {
+  arrayify,
+  capitalize,
+  isNotNullOrUndefined,
+  kebabToCamelCase,
+  partition,
+  toHumanReadableText,
+  toPattern,
+  withoutBracketsAndWhitespaces,
+} from './utils';

--- a/packages/utils/src/utils.ts
+++ b/packages/utils/src/utils.ts
@@ -67,7 +67,7 @@ export function withoutBracketsAndWhitespaces(text: string): string {
 }
 
 /**
- * Split the `array` into two `arrays`, where the first array contains all
+ * Splits the `array` into two `arrays`, where the first array contains all
  * the items that don't satisfy the received predicate and the second the
  * ones that do.
  * @example

--- a/packages/utils/src/utils.ts
+++ b/packages/utils/src/utils.ts
@@ -65,3 +65,32 @@ export function capitalize<T extends string>(text: T): Capitalize<T> {
 export function withoutBracketsAndWhitespaces(text: string): string {
   return text.replace(/[[\]\s]/g, '');
 }
+
+/**
+ * Split the `array` into two `arrays`, where the first array contains all
+ * the items that don't satisfy the received predicate and the second the
+ * ones that do.
+ * @example
+ * ```ts
+ * const [others, numbers] = partition([1, 2, 'a', true], isNumber);
+ * // others => ['a', true];
+ * // numbers => [1, 2];
+ * ```
+ */
+export function partition<TItem, TPredicateResult extends TItem>(
+  items: readonly TItem[],
+  predicate: (
+    value: TItem,
+    index?: number,
+    array?: readonly TItem[],
+  ) => value is TPredicateResult,
+): readonly [TItem[], TPredicateResult[]] {
+  return items.reduce<readonly [TItem[], TPredicateResult[]]>(
+    (partition, item, index, array) => {
+      const partitionIndex = predicate(item, index, array) ? 1 : 0;
+      partition[partitionIndex].push(item as TPredicateResult);
+      return partition;
+    },
+    [[], []],
+  );
+}


### PR DESCRIPTION
Besides addressing the issue #675, the report node is more accurate now and reports nested arrays.

PS: TBH, I'm not sure which scope should be this PR, so I used `refactor` 🤷‍♂️

Closes #677.