### PR TITLE
refactor(eslint-plugin-template): [click-events-have-key-events] switch to selectors

### DIFF
--- a/packages/eslint-plugin-template/docs/rules/click-events-have-key-events.md
+++ b/packages/eslint-plugin-template/docs/rules/click-events-have-key-events.md
@@ -13,7 +13,7 @@
 
 # `@angular-eslint/template/click-events-have-key-events`
 
-Ensures that the click event is accompanied with at least one key event keyup, keydown or keypress.
+Ensures that the `click` event is accompanied by at least one of the following: `keydown`, `keypress` or `keyup` events. Coding for the keyboard is important for users with physical disabilities who cannot use a mouse, AT compatibility, and screenreader users. This does not apply for interactive or hidden elements. See more at https://www.w3.org/WAI/WCAG21/Understanding/keyboard
 
 - Type: suggestion
 - Category: Best Practices
@@ -40,11 +40,6 @@ The rule does not have any configuration options.
 ```
 
 ```html
-<header (click)="onClick()"></header>
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-```
-
-```html
 <a (click)="onClick()"></a>
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 ```
@@ -55,8 +50,8 @@ The rule does not have any configuration options.
 ```
 
 ```html
-<div (click)="onClick()" [attr.aria-hidden]="'false'"></div>
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+<div (click)="onClick()" [attr.aria-hidden]="ariaHidden"></div>
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 ```
 
 ```html
@@ -65,13 +60,13 @@ The rule does not have any configuration options.
 ```
 
 ```html
-<div (click)="onClick()" role="aside"></div>
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+<a (click)="onClick()" [attr.role]="'header'"></a>
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 ```
 
 ```html
-<div (click)="onClick()" [attr.role]="'header'"></div>
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+<div (click)="onClick()" [role]="role"></div>
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 ```
 
 <br>
@@ -81,3 +76,50 @@ The rule does not have any configuration options.
 <br>
 
 ✅ - Examples of **correct** code for this rule:
+
+```html
+<div (click)="onClick()" (keyup)="onKeyup()"></div>
+```
+
+```html
+<div (click)="onClick()" (keypress.enter)="onKeypress()"></div>
+```
+
+```html
+<div (click)="onClick()" (keydown.shift.f)="onKeydown()"></div>
+```
+
+```html
+<cui-button (click)="onClick()"></cui-button>
+```
+
+```html
+<div (click)="onClick()" hidden></div>
+<div style="display: none">
+  <header (click)="onClick()"></header>
+</div>
+<div (click)="onClick()" [style.display.none]="true"></div>
+<div (click)="onClick()" [ngStyle]="{visibility: 'hidden'}"></div>
+<div (click)="onClick()" aria-hidden></div>
+<div (click)="onClick()" aria-hidden="true"></div>
+<div (click)="onClick()" [attr.aria-hidden]="true"></div>
+<div (click)="onClick()" [attr.aria-hidden]="'true'"></div>
+```
+
+```html
+<div (click)="onClick()" role="presentation"></div>
+<div (click)="onClick()" [attr.role]="'none'"></div>
+```
+
+```html
+<input (click)="onClick()">
+<button (click)="onClick()"></button>
+<textarea (click)="onClick()"></textarea>
+<select (click)="onClick()">
+  <option (click)="onClick()"></option>
+</select>
+<textarea (click)="onClick()"></textarea>
+<a href="#" (click)="onClick()"></a>
+<a [attr.href]="href" class="anchor" (click)="onClick()"></a>
+<a [routerLink]="'route'" (click)="onClick()"></a>
+```

--- a/packages/eslint-plugin-template/src/rules/click-events-have-key-events.ts
+++ b/packages/eslint-plugin-template/src/rules/click-events-have-key-events.ts
@@ -7,35 +7,36 @@ import { getDomElements } from '../utils/get-dom-elements';
 import { isHiddenFromScreenReader } from '../utils/is-hidden-from-screen-reader';
 import { isInteractiveElement } from '../utils/is-interactive-element';
 import { isPresentationRole } from '../utils/is-presentation-role';
+import { toPattern } from '../utils/to-pattern';
 
 type Options = [];
 export type MessageIds = 'clickEventsHaveKeyEvents';
 export const RULE_NAME = 'click-events-have-key-events';
+const STYLE_GUIDE_LINK = 'https://www.w3.org/WAI/WCAG21/Understanding/keyboard';
 
 export default createESLintRule<Options, MessageIds>({
   name: RULE_NAME,
   meta: {
     type: 'suggestion',
     docs: {
-      description:
-        'Ensures that the click event is accompanied with at least one key event keyup, keydown or keypress.',
+      description: `Ensures that the \`click\` event is accompanied by at least one of the following: \`keydown\`, \`keypress\` or \`keyup\` events. Coding for the keyboard is important for users with physical disabilities who cannot use a mouse, AT compatibility, and screenreader users. This does not apply for interactive or hidden elements. See more at ${STYLE_GUIDE_LINK}`,
       category: 'Best Practices',
       recommended: false,
     },
     schema: [],
     messages: {
-      clickEventsHaveKeyEvents:
-        'click must be accompanied by either keyup, keydown or keypress event for accessibility.',
+      clickEventsHaveKeyEvents: `The \`click\` event should be accompanied by at least one of the following: \`keydown\`, \`keypress\` or \`keyup\` events (${STYLE_GUIDE_LINK})`,
     },
   },
   defaultOptions: [],
   create(context) {
-    return {
-      Element(node: TmplAstElement) {
-        if (!getDomElements().has(node.name)) {
-          return;
-        }
+    const parserServices = getTemplateParserServices(context);
+    const domElementsPattern = toPattern([...getDomElements()]);
 
+    return {
+      [`Element[name=${domElementsPattern}]:has(BoundEvent[name='click']):not(:has(BoundEvent[name=/^(keyup|keydown|keypress)(\\..+)?$/]))`](
+        node: TmplAstElement,
+      ) {
         if (
           isPresentationRole(node) ||
           isHiddenFromScreenReader(node) ||
@@ -44,22 +45,6 @@ export default createESLintRule<Options, MessageIds>({
           return;
         }
 
-        let hasClick = false,
-          hasKeyEvent = false;
-
-        for (const output of node.outputs) {
-          hasClick = output.name === 'click';
-          hasKeyEvent =
-            output.name.startsWith('keyup') ||
-            output.name.startsWith('keydown') ||
-            output.name.startsWith('keypress');
-        }
-
-        if (!hasClick || hasKeyEvent) {
-          return;
-        }
-
-        const parserServices = getTemplateParserServices(context);
         const loc = parserServices.convertNodeSourceSpanToLoc(node.sourceSpan);
 
         context.report({

--- a/packages/eslint-plugin-template/src/utils/get-attribute-value.ts
+++ b/packages/eslint-plugin-template/src/utils/get-attribute-value.ts
@@ -15,7 +15,7 @@ import { getOriginalAttributeName } from './get-original-attribute-name';
  * getAttributeValue(Element(`<div property="test"></div>`), 'nonExistent'); // null
  * getAttributeValue(Element(`<div aria-role="none"></div>`), 'role'); // 'none'
  * getAttributeValue(Element(`<div [attr.aria-checked]="true"></div>`), 'aria-checked'); // true
- * getAttributeValue(Element(`<button [variant]="variant"></button>`), 'variant'); // PROPERTY
+ * getAttributeValue(Element(`<button [variant]="variant"></button>`), 'variant'); // PROPERTY_READ
  * ```
  */
 export function getAttributeValue(

--- a/packages/eslint-plugin-template/src/utils/get-original-attribute-name.ts
+++ b/packages/eslint-plugin-template/src/utils/get-original-attribute-name.ts
@@ -10,7 +10,7 @@ import { TmplAstBoundEvent } from '@angular/compiler';
  * ```html
  * <div [style.display.none]="test"></div> <!-- Instead of "display", "style.display.none" -->
  * <div [attr.role]="'none'"></div> <!-- Instead of "attr.role", "role" -->
- * <div ([ngModel])="test"></div> <!-- Instead of "ngModel", "ngModelChange" -->
+ * <div [(ngModel)]="test"></div> <!-- Instead of "ngModel", "ngModelChange" -->
  * <div (@fade.start)="handle()"></div> <!-- Instead of "fade", "@fade.start" -->
  * ```
  */

--- a/packages/eslint-plugin-template/src/utils/is-hidden-from-screen-reader.ts
+++ b/packages/eslint-plugin-template/src/utils/is-hidden-from-screen-reader.ts
@@ -1,3 +1,4 @@
+import type { LiteralPrimitive } from '@angular/compiler';
 import { TmplAstElement } from '@angular/compiler';
 import { getAttributeValue } from './get-attribute-value';
 import { getNearestNodeFrom } from './get-nearest-node-from';
@@ -84,10 +85,17 @@ function hasHiddenDynamicStylesWithLiteralValues(
  */
 function hasHiddenStaticNgStyles(node: TmplAstElement): boolean {
   const ngStyleAttributeValue = getAttributeValue(node, 'ngStyle');
+
+  function isMap(
+    possibleMap: unknown,
+  ): possibleMap is Map<string, LiteralPrimitive> {
+    return possibleMap instanceof Map;
+  }
+
   return (
-    ngStyleAttributeValue instanceof Map &&
-    (ngStyleAttributeValue.get('display') === 'none' ||
-      ngStyleAttributeValue.get('visibility') === 'hidden')
+    isMap(ngStyleAttributeValue) &&
+    (ngStyleAttributeValue.get('display')?.value === 'none' ||
+      ngStyleAttributeValue.get('visibility')?.value === 'hidden')
   );
 }
 

--- a/packages/eslint-plugin-template/src/utils/is-interactive-element/get-interactive-element-ax-object-schemas.ts
+++ b/packages/eslint-plugin-template/src/utils/is-interactive-element/get-interactive-element-ax-object-schemas.ts
@@ -1,42 +1,45 @@
 // This is a basic typing for schemas that are coming from the
 // `axobject-query` package.
-interface AXObjectSchema {
+type Attribute = Readonly<{
   name: string;
-  attributes?: { name: string; value?: string }[];
-}
+  value?: string;
+}>;
+type AXObjectSchema = Readonly<{
+  name: string;
+  attributes?: Attribute[];
+}>;
 
-let interactiveElementAXObjectSchemas: AXObjectSchema[] | null = null;
+let interactiveElementAXObjectSchemas: readonly AXObjectSchema[] | null = null;
 
 // This function follows the lazy initialization pattern.
 // Since this is a top-level module (it will be included via `require`), we do not need to
 // initialize the `interactiveElementAXObjectSchemas` until the function is called
 // for the first time, so we will not take up the memory.
-export function getInteractiveElementAXObjectSchemas(): AXObjectSchema[] {
-  if (interactiveElementAXObjectSchemas === null) {
-    // This package doesn't have type definitions.
-    // eslint-disable-next-line @typescript-eslint/no-var-requires
-    const { AXObjects, elementAXObjects } = require('axobject-query');
-
-    // This set will contain all possible roles in ARIA, which are
-    // type of `structure` or `window` (since we filter out `widget` type).
-    const interactiveAXObjects = new Set<string>(
-      Array.from<string>(AXObjects.keys()).filter(
-        (name) => AXObjects.get(name).type === 'widget',
-      ),
-    );
-
-    // This will contain all schemas that are related to ARIA roles
-    // listed in the above set `interactiveAXObjects`.
-    interactiveElementAXObjectSchemas = [...elementAXObjects].reduce<
-      AXObjectSchema[]
-    >((accumulator, [elementSchema, AXObjectSet]) => {
-      return accumulator.concat(
-        [...AXObjectSet].every((role) => interactiveAXObjects.has(role))
-          ? elementSchema
-          : [],
-      );
-    }, []);
+export function getInteractiveElementAXObjectSchemas(): readonly AXObjectSchema[] {
+  if (interactiveElementAXObjectSchemas) {
+    return interactiveElementAXObjectSchemas;
   }
 
-  return interactiveElementAXObjectSchemas;
+  // This package doesn't have type definitions.
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const { AXObjects, elementAXObjects } = require('axobject-query');
+  // This set will contain all possible roles in ARIA, which are
+  // type of `structure` or `window` (since we filter out `widget` type).
+  const interactiveAXObjects = new Set(
+    Array.from<string>(AXObjects.keys()).filter(
+      (name) => AXObjects.get(name).type === 'widget',
+    ),
+  );
+
+  // This will contain all schemas that are related to ARIA roles
+  // listed in the above set `interactiveAXObjects`.
+  return (interactiveElementAXObjectSchemas = [...elementAXObjects].reduce<
+    readonly AXObjectSchema[]
+  >((accumulator, [elementSchema, AXObjectSet]) => {
+    return accumulator.concat(
+      [...AXObjectSet].every((role) => interactiveAXObjects.has(role))
+        ? elementSchema
+        : [],
+    );
+  }, []));
 }

--- a/packages/eslint-plugin-template/src/utils/is-interactive-element/get-interactive-element-role-schemas.ts
+++ b/packages/eslint-plugin-template/src/utils/is-interactive-element/get-interactive-element-role-schemas.ts
@@ -1,49 +1,46 @@
 import type { ARIARoleDefintionKey, ARIARoleRelationConcept } from 'aria-query';
 import { elementRoles, roles } from 'aria-query';
 
-let interactiveElementRoleSchemas: ARIARoleRelationConcept[] | null = null;
+let interactiveElementRoleSchemas: readonly ARIARoleRelationConcept[] | null =
+  null;
 
 // This function follows the lazy initialization pattern.
 // Since this is a top-level module (it will be included via `require`), we do not need to
 // initialize the `interactiveElementRoleSchemas` until the function is called
 // for the first time, so we will not take up the memory.
-export function getInteractiveElementRoleSchemas(): ARIARoleRelationConcept[] {
-  if (interactiveElementRoleSchemas === null) {
-    const roleKeys = [...roles.keys()];
-    const elementRoleEntries = [...elementRoles];
-
-    // This set will contain all possible values for the `role` attribute,
-    // e.g. `button`, `navigation` or `presentation`.
-    const interactiveRoles = new Set<ARIARoleDefintionKey>(
-      roleKeys
-        .filter((name: ARIARoleDefintionKey) => {
-          const role = roles.get(name);
-          return (
-            role &&
-            !role.abstract &&
-            // The `progressbar` is descended from `widget`, but in practice, its
-            // value is always `readonly`, so we treat it as a non-interactive role.
-            name !== 'progressbar' &&
-            role.superClass.some((classes) => classes.includes('widget'))
-          );
-        })
-        .concat(
-          // 'toolbar' does not descend from widget, but it does support
-          // aria-activedescendant, thus in practice we treat it as a widget.
-          'toolbar',
-        ),
-    );
-
-    interactiveElementRoleSchemas = elementRoleEntries.reduce<
-      ARIARoleRelationConcept[]
-    >((accumulator, [elementSchema, roleSet]) => {
-      return accumulator.concat(
-        [...roleSet].every((role) => interactiveRoles.has(role))
-          ? elementSchema
-          : [],
-      );
-    }, []);
+export function getInteractiveElementRoleSchemas(): readonly ARIARoleRelationConcept[] {
+  if (interactiveElementRoleSchemas) {
+    return interactiveElementRoleSchemas;
   }
 
-  return interactiveElementRoleSchemas;
+  const roleKeys = [...roles.keys()];
+  const elementRoleEntries = [...elementRoles];
+  // This set will contain all possible values for the `role` attribute,
+  // e.g. `button`, `navigation` or `presentation`.
+  const interactiveRoles = new Set<ARIARoleDefintionKey>([
+    ...roleKeys.filter((name) => {
+      const role = roles.get(name);
+      return (
+        role &&
+        !role.abstract &&
+        // The `progressbar` is descended from `widget`, but in practice, its
+        // value is always `readonly`, so we treat it as a non-interactive role.
+        name !== 'progressbar' &&
+        role.superClass.some((classes) => classes.includes('widget'))
+      );
+    }),
+    // 'toolbar' does not descend from widget, but it does support
+    // aria-activedescendant, thus in practice we treat it as a widget.
+    'toolbar',
+  ]);
+
+  return (interactiveElementRoleSchemas = elementRoleEntries.reduce<
+    readonly ARIARoleRelationConcept[]
+  >((accumulator, [elementSchema, roleSet]) => {
+    return accumulator.concat(
+      [...roleSet].every((role) => interactiveRoles.has(role))
+        ? elementSchema
+        : [],
+    );
+  }, []));
 }

--- a/packages/eslint-plugin-template/src/utils/is-interactive-element/get-non-interactive-element-role-schemas.ts
+++ b/packages/eslint-plugin-template/src/utils/is-interactive-element/get-non-interactive-element-role-schemas.ts
@@ -1,47 +1,45 @@
 import type { ARIARoleDefintionKey, ARIARoleRelationConcept } from 'aria-query';
 import { elementRoles, roles } from 'aria-query';
 
-let nonInteractiveElementRoleSchemas: ARIARoleRelationConcept[] | null = null;
+let nonInteractiveElementRoleSchemas:
+  | readonly ARIARoleRelationConcept[]
+  | null = null;
 
 // This function follows the lazy initialization pattern.
 // Since this is a top-level module (it will be included via `require`), we do not need to
 // initialize the `nonInteractiveElementRoleSchemas` until the function is called
 // for the first time, so we will not take up the memory.
-export function getNonInteractiveElementRoleSchemas(): ARIARoleRelationConcept[] {
-  if (nonInteractiveElementRoleSchemas === null) {
-    const roleKeys = [...roles.keys()];
-    const elementRoleEntries = [...elementRoles];
-
-    const nonInteractiveRoles = new Set<ARIARoleDefintionKey>(
-      roleKeys
-        .filter((name) => {
-          const role = roles.get(name);
-          return (
-            role &&
-            !role.abstract &&
-            // 'toolbar' does not descend from widget, but it does support
-            // aria-activedescendant, thus in practice we treat it as a widget.
-            name !== 'toolbar' &&
-            !role.superClass.some((classes) => classes.includes('widget'))
-          );
-        })
-        .concat(
-          // The `progressbar` is descended from `widget`, but in practice, its
-          // value is always `readonly`, so we treat it as a non-interactive role.
-          'progressbar',
-        ),
-    );
-
-    nonInteractiveElementRoleSchemas = elementRoleEntries.reduce<
-      ARIARoleRelationConcept[]
-    >((accumulator, [elementSchema, roleSet]) => {
-      return accumulator.concat(
-        [...roleSet].every((role) => nonInteractiveRoles.has(role))
-          ? elementSchema
-          : [],
-      );
-    }, []);
+export function getNonInteractiveElementRoleSchemas(): readonly ARIARoleRelationConcept[] {
+  if (nonInteractiveElementRoleSchemas) {
+    return nonInteractiveElementRoleSchemas;
   }
 
-  return nonInteractiveElementRoleSchemas;
+  const roleKeys = [...roles.keys()];
+  const elementRoleEntries = [...elementRoles];
+  const nonInteractiveRoles = new Set<ARIARoleDefintionKey>([
+    ...roleKeys.filter((name) => {
+      const role = roles.get(name);
+      return (
+        role &&
+        !role.abstract &&
+        // 'toolbar' does not descend from widget, but it does support
+        // aria-activedescendant, thus in practice we treat it as a widget.
+        name !== 'toolbar' &&
+        !role.superClass.some((classes) => classes.includes('widget'))
+      );
+    }),
+    // The `progressbar` is descended from `widget`, but in practice, its
+    // value is always `readonly`, so we treat it as a non-interactive role.
+    'progressbar',
+  ]);
+
+  return (nonInteractiveElementRoleSchemas = elementRoleEntries.reduce<
+    readonly ARIARoleRelationConcept[]
+  >((accumulator, [elementSchema, roleSet]) => {
+    return accumulator.concat(
+      [...roleSet].every((role) => nonInteractiveRoles.has(role))
+        ? elementSchema
+        : [],
+    );
+  }, []));
 }

--- a/packages/eslint-plugin-template/src/utils/is-interactive-element/index.ts
+++ b/packages/eslint-plugin-template/src/utils/is-interactive-element/index.ts
@@ -10,20 +10,25 @@ function checkIsInteractiveElement(node: TmplAstElement): boolean {
   function elementSchemaMatcher({ attributes, name }: ARIARoleRelationConcept) {
     return node.name === name && attributesComparator(attributes ?? [], node);
   }
+
   // Check in elementRoles for inherent interactive role associations for
   // this element.
   const isInherentInteractiveElement =
     getInteractiveElementRoleSchemas().some(elementSchemaMatcher);
+
   if (isInherentInteractiveElement) {
     return true;
   }
+
   // Check in elementRoles for inherent non-interactive role associations for
   // this element.
   const isInherentNonInteractiveElement =
     getNonInteractiveElementRoleSchemas().some(elementSchemaMatcher);
+
   if (isInherentNonInteractiveElement) {
     return false;
   }
+
   // Check in elementAXObjects for AX Tree associations for this element.
   return getInteractiveElementAXObjectSchemas().some(elementSchemaMatcher);
 }


### PR DESCRIPTION
**1st. commit**: replaces long if blocks in `eslint-plugin-template/utils` with early return to improve readability;
**2nd. commit**: corrects a small mistake where we check on a `NgStyle` if a node is hidden from screenreader;
**3rd. commit**:
- switch implementation to be selector-based;
- improve docs to better describe the intention;
- update tests descriptions and, even if unintentionally, corrects the docs gen of valid cases 😆