### PR TITLE
refactor(eslint-plugin-template): [i18n] remove non-actionable suggestion

### DIFF
--- a/packages/eslint-plugin-template/src/rules/i18n.ts
+++ b/packages/eslint-plugin-template/src/rules/i18n.ts
@@ -63,8 +63,7 @@ export type MessageIds =
   | 'i18nCustomIdOnAttribute'
   | 'i18nCustomIdOnElement'
   | 'i18nDuplicateCustomId'
-  | 'suggestAddI18nAttribute'
-  | 'suggestIgnoreAttribute';
+  | 'suggestAddI18nAttribute';
 type StronglyTypedElement = Omit<TmplAstElement, 'i18n'> & {
   i18n: Message;
   parent?: AST;
@@ -156,8 +155,6 @@ export default createESLintRule<Options, MessageIds>({
       i18nCustomIdOnElement: `Missing custom ID on element. See more at ${STYLE_GUIDE_LINK_CUSTOM_IDS}`,
       i18nDuplicateCustomId: `Duplicate custom ID "@@{{customId}}". See more at ${STYLE_GUIDE_LINK_UNIQUE_CUSTOM_IDS}`,
       suggestAddI18nAttribute: 'Add the `i18n` attribute',
-      suggestIgnoreAttribute:
-        'Add the attribute name "{{attributeName}}" to the `ignoreAttributes` option in the eslint config',
     },
   },
   defaultOptions: [DEFAULT_OPTIONS],
@@ -260,14 +257,6 @@ export default createESLintRule<Options, MessageIds>({
             ` i18n-${attributeName}`,
           );
         },
-        suggest: [
-          {
-            messageId: 'suggestIgnoreAttribute',
-            data: { attributeName },
-            // Little bit of a hack as VSCode ignores suggestions with no fix!?
-            fix: (fixer) => fixer.insertTextBeforeRange([0, 0], ''),
-          },
-        ],
       });
     }
 

--- a/packages/eslint-plugin-template/tests/rules/i18n/cases.ts
+++ b/packages/eslint-plugin-template/tests/rules/i18n/cases.ts
@@ -7,7 +7,6 @@ const i18nCustomIdOnAttribute: MessageIds = 'i18nCustomIdOnAttribute';
 const i18nCustomIdOnElement: MessageIds = 'i18nCustomIdOnElement';
 const i18nDuplicateCustomId: MessageIds = 'i18nDuplicateCustomId';
 const suggestAddI18nAttribute: MessageIds = 'suggestAddI18nAttribute';
-const suggestIgnoreAttribute: MessageIds = 'suggestIgnoreAttribute';
 
 export const valid = [
   `
@@ -165,16 +164,6 @@ export const invalid = [
       <div tooltip="This requires translation" i18n-tooltip></div>
            ~~~~~~~
     `,
-    suggestions: [
-      {
-        messageId: suggestIgnoreAttribute,
-        output: `
-      <div tooltip="This requires translation"></div>
-           
-    `,
-        data: { attributeName: 'tooltip' },
-      },
-    ],
   }),
   convertAnnotatedSourceToFailureCase({
     description:
@@ -417,34 +406,6 @@ export const invalid = [
         char: '~',
         messageId: i18nAttribute,
         data: { attributeName: 'tooltip' },
-        suggestions: [
-          {
-            messageId: suggestIgnoreAttribute,
-            output: `
-      <div
-        tooltip="This requires translation"
-               
-        i18n-placeholder
-        placeholder="More translation, please"
-                   
-        class="red"
-      >
-        <div
-          *ngIf="true"
-          width="100px"
-          label="Templates need translation too."
-               
-        >
-          <span i18n label="label is ignored in 'ignoreAttributes'">
-          
-            Missing custom ID
-          </span>
-                
-        </div>
-      </div>
-    `,
-          },
-        ],
       },
       {
         char: '^',
@@ -455,34 +416,6 @@ export const invalid = [
         char: '#',
         messageId: i18nAttribute,
         data: { attributeName: 'label' },
-        suggestions: [
-          {
-            messageId: suggestIgnoreAttribute,
-            output: `
-      <div
-        tooltip="This requires translation"
-               
-        i18n-placeholder
-        placeholder="More translation, please"
-                   
-        class="red"
-      >
-        <div
-          *ngIf="true"
-          width="100px"
-          label="Templates need translation too."
-               
-        >
-          <span i18n label="label is ignored in 'ignoreAttributes'">
-          
-            Missing custom ID
-          </span>
-                
-        </div>
-      </div>
-    `,
-          },
-        ],
       },
       { char: '%', messageId: i18nCustomIdOnElement },
     ],


### PR DESCRIPTION
Currently, the i18n rule has a suggestion that doesn't do anything. It was introduced in https://github.com/angular-eslint/angular-eslint/commit/25234c80b5bca3700d3ca71ab9181a8dc1ff1360 and it basically acts like a hint telling the user to add some config to the `.eslint` file, but IMHO it's unnecessary. We don't do this for any other option in this or other rule. Why should this be treated differently?