### PR TITLE
chore(integration-tests): fix snapshot and ensure clean fixtures pre run

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "scripts": {
     "build": "nx run-many --target=build --all --parallel",
     "test": "nx run-many --target=test --all --parallel",
-    "integration-tests": "nx spawn-and-populate-local-registry integration-tests && nx run-many --target=integration-test --all",
+    "integration-tests": "nx clean integration-tests && nx spawn-and-populate-local-registry integration-tests && nx run-many --target=integration-test --all",
     "update-integration-tests": "yarn integration-tests -u",
     "check-clean-workspace-after-install": "git diff --quiet --exit-code",
     "clean": "lerna clean && nx run-many --target=clean --all --parallel",

--- a/packages/integration-tests/project.json
+++ b/packages/integration-tests/project.json
@@ -37,6 +37,10 @@
     "spawn-and-populate-local-registry": {
       "dependsOn": [
         {
+          "target": "build",
+          "projects": "dependencies"
+        },
+        {
           "target": "kill-existing-verdaccio",
           "projects": "self"
         },

--- a/packages/integration-tests/tests/__snapshots__/v1123-multi-project-manual-config.test.ts.snap
+++ b/packages/integration-tests/tests/__snapshots__/v1123-multi-project-manual-config.test.ts.snap
@@ -17,7 +17,7 @@ __ROOT__/v1123-multi-project-manual-config/src/app/app.component.ts
 
 __ROOT__/v1123-multi-project-manual-config/src/app/example.component.ts
    4:13  error  Strings must use singlequote                                                                                                          @typescript-eslint/quotes
-  12:3   error  Use `@Input` rather than the \`inputs\` metadata property (https://angular.io/styleguide#style-05-12)                                     @angular-eslint/no-inputs-metadata-property
+  12:3   error  Use \`@Input\` rather than the \`inputs\` metadata property (https://angular.io/styleguide#style-05-12)                                   @angular-eslint/no-inputs-metadata-property
   13:3   error  Use \`@Output\` rather than the \`outputs\` metadata property (https://angular.io/styleguide#style-05-12)                                 @angular-eslint/no-outputs-metadata-property
   14:3   error  Use @HostBinding or @HostListener rather than the \`host\` metadata property (https://angular.io/styleguide#style-06-03)                @angular-eslint/no-host-metadata-property
   18:13  error  Output bindings, including aliases, should not be named \\"on\\", nor prefixed with it (https://angular.io/guide/styleguide#style-05-16)  @angular-eslint/no-output-on-prefix


### PR DESCRIPTION
Found while working on something else.

Current state: If you run integration-tests locally multiple times locally yarn and npm will not be doing a full install on each fixture Angular CLI workspace so you can end up using a stale copy of a package when the linting/assertions run.

I believe the touched snapshot here stayed out of date as a result