### PR TITLE
fix(eslint-plugin): [sort-ngmodule-metadata-arrays] remove the property restriction

### DIFF
--- a/packages/eslint-plugin/docs/rules/sort-ngmodule-metadata-arrays.md
+++ b/packages/eslint-plugin/docs/rules/sort-ngmodule-metadata-arrays.md
@@ -38,7 +38,7 @@ The rule does not have any configuration options.
 ```ts
 @NgModule({
   imports: [aModule, bModule, DModule, cModule]
-                              ~~~~~~~
+                                       ~~~~~~~
 })
 class Test {}
 ```
@@ -48,8 +48,8 @@ class Test {}
   'declarations': [
     AComponent,
     cPipe,
-    ~~~~~
     bDirective,
+    ~~~~~~~~~~
     DComponent,
   ],
 })
@@ -61,8 +61,8 @@ class Test {}
   ['exports']: [
     AComponent,
     cPipe,
-    ~~~~~
     bDirective,
+    ~~~~~~~~~~
     DComponent,
   ],
 })
@@ -74,8 +74,8 @@ class Test {}
   [`bootstrap`]: [
     AppModule2,
     AppModule3,
-    ~~~~~~~~~~
     AppModule1,
+    ~~~~~~~~~~
   ]
 })
 class Test {}
@@ -86,8 +86,8 @@ class Test {}
   schemas: [
     A_SCHEMA,
     C_SCHEMA,
-    ~~~~~~~~
     B_SCHEMA,
+    ~~~~~~~~
   ]
 })
 class Test {}
@@ -95,15 +95,15 @@ class Test {}
 
 ```ts
 @NgModule({
-  imports: [
+  providers: [
     AProvider,
     {
       provide: 'myprovider',
       useClass: MyProvider,
     },
     cProvider,
-    ~~~~~~~~~
     bProvider,
+    ~~~~~~~~~
     DProvider,
   ]
 })

--- a/packages/eslint-plugin/docs/rules/sort-ngmodule-metadata-arrays.md
+++ b/packages/eslint-plugin/docs/rules/sort-ngmodule-metadata-arrays.md
@@ -110,6 +110,23 @@ class Test {}
 class Test {}
 ```
 
+```ts
+@NgModule({
+  bootstrap,
+  declarations: declarations,
+  providers: providers(),
+  schemas: [],
+  [imports]: [
+    aModule,
+    bModule,
+    DModule,
+    cModule,
+    ~~~~~~~
+  ],
+})
+class Test {}
+```
+
 <br>
 
 ---
@@ -135,22 +152,6 @@ class Test {}
 ```ts
 const options = {};
 @NgModule(options)
-class Test {}
-```
-
-```ts
-@NgModule({
-  bootstrap,
-  declarations: declarations,
-  providers: providers(),
-  schemas: [],
-  [imports]: [
-    aModule,
-    bModule,
-    DModule,
-    cModule,
-  ],
-})
 class Test {}
 ```
 

--- a/packages/eslint-plugin/src/rules/sort-ngmodule-metadata-arrays.ts
+++ b/packages/eslint-plugin/src/rules/sort-ngmodule-metadata-arrays.ts
@@ -26,13 +26,10 @@ export default createESLintRule<Options, MessageIds>({
   },
   defaultOptions: [],
   create(context) {
-    const metadataPropertyPattern =
-      /^(bootstrap|declarations|entryComponents|exports|imports|providers|schemas)$/;
-
     return {
-      [`${Selectors.MODULE_CLASS_DECORATOR} ${Selectors.metadataProperty(
-        metadataPropertyPattern,
-      )} ArrayExpression`]({ elements }: TSESTree.ArrayExpression) {
+      [`${Selectors.MODULE_CLASS_DECORATOR} Property ArrayExpression`]({
+        elements,
+      }: TSESTree.ArrayExpression) {
         const unorderedNodes = elements
           .filter(TSESLintASTUtils.isIdentifier)
           .map((current, index, list) => [current, list[index + 1]])

--- a/packages/eslint-plugin/src/rules/sort-ngmodule-metadata-arrays.ts
+++ b/packages/eslint-plugin/src/rules/sort-ngmodule-metadata-arrays.ts
@@ -44,7 +44,7 @@ export default createESLintRule<Options, MessageIds>({
 
         const [unorderedNode, nextNode] = unorderedNodes;
         context.report({
-          node: unorderedNode,
+          node: nextNode,
           messageId: 'sortNgmoduleMetadataArrays',
           fix: (fixer) => [
             fixer.replaceText(unorderedNode, nextNode.name),

--- a/packages/eslint-plugin/tests/rules/sort-ngmodule-metadata-arrays/cases.ts
+++ b/packages/eslint-plugin/tests/rules/sort-ngmodule-metadata-arrays/cases.ts
@@ -84,7 +84,7 @@ export const invalid = [
     annotatedSource: `
     @NgModule({
       imports: [aModule, bModule, DModule, cModule]
-                                  ~~~~~~~
+                                           ~~~~~~~
     })
     class Test {}
     `,
@@ -92,7 +92,7 @@ export const invalid = [
     annotatedOutput: `
     @NgModule({
       imports: [aModule, bModule, cModule, DModule]
-                                  ~~~~~~~
+                                           ~~~~~~~
     })
     class Test {}
     `,
@@ -105,8 +105,8 @@ export const invalid = [
       'declarations': [
         AComponent,
         cPipe,
-        ~~~~~
         bDirective,
+        ~~~~~~~~~~
         DComponent,
       ],
     })
@@ -118,8 +118,8 @@ export const invalid = [
       'declarations': [
         AComponent,
         bDirective,
-        ~~~~~
         cPipe,
+        ~~~~~~~~~~
         DComponent,
       ],
     })
@@ -133,8 +133,8 @@ export const invalid = [
       ['exports']: [
         AComponent,
         cPipe,
-        ~~~~~
         bDirective,
+        ~~~~~~~~~~
         DComponent,
       ],
     })
@@ -146,8 +146,8 @@ export const invalid = [
       ['exports']: [
         AComponent,
         bDirective,
-        ~~~~~
         cPipe,
+        ~~~~~~~~~~
         DComponent,
       ],
     })
@@ -161,8 +161,8 @@ export const invalid = [
       [\`bootstrap\`]: [
         AppModule2,
         AppModule3,
-        ~~~~~~~~~~
         AppModule1,
+        ~~~~~~~~~~
       ]
     })
     class Test {}
@@ -173,8 +173,8 @@ export const invalid = [
       [\`bootstrap\`]: [
         AppModule2,
         AppModule1,
-        ~~~~~~~~~~
         AppModule3,
+        ~~~~~~~~~~
       ]
     })
     class Test {}
@@ -187,8 +187,8 @@ export const invalid = [
       schemas: [
         A_SCHEMA,
         C_SCHEMA,
-        ~~~~~~~~
         B_SCHEMA,
+        ~~~~~~~~
       ]
     })
     class Test {}
@@ -199,8 +199,8 @@ export const invalid = [
       schemas: [
         A_SCHEMA,
         B_SCHEMA,
-        ~~~~~~~~
         C_SCHEMA,
+        ~~~~~~~~
       ]
     })
     class Test {}
@@ -208,18 +208,18 @@ export const invalid = [
   }),
   convertAnnotatedSourceToFailureCase({
     description:
-      'should fail if `providers` metadata arrays is not sorted ASC, but ignore objects',
+      'should fail if `providers` metadata arrays is not sorted ASC, ignoring objects',
     annotatedSource: `
     @NgModule({
-      imports: [
+      providers: [
         AProvider,
         {
           provide: 'myprovider',
           useClass: MyProvider,
         },
         cProvider,
-        ~~~~~~~~~
         bProvider,
+        ~~~~~~~~~
         DProvider,
       ]
     })
@@ -228,15 +228,15 @@ export const invalid = [
     messageId,
     annotatedOutput: `
     @NgModule({
-      imports: [
+      providers: [
         AProvider,
         {
           provide: 'myprovider',
           useClass: MyProvider,
         },
         bProvider,
-        ~~~~~~~~~
         cProvider,
+        ~~~~~~~~~
         DProvider,
       ]
     })

--- a/packages/eslint-plugin/tests/rules/sort-ngmodule-metadata-arrays/cases.ts
+++ b/packages/eslint-plugin/tests/rules/sort-ngmodule-metadata-arrays/cases.ts
@@ -20,21 +20,6 @@ export const valid = [
   `,
   `
   @NgModule({
-    bootstrap,
-    declarations: declarations,
-    providers: providers(),
-    schemas: [],
-    [imports]: [
-      aModule,
-      bModule,
-      DModule,
-      cModule,
-    ],
-  })
-  class Test {}
-  `,
-  `
-  @NgModule({
     bootstrap: [
       AppModule1,
       AppModule2,
@@ -239,6 +224,43 @@ export const invalid = [
         ~~~~~~~~~
         DProvider,
       ]
+    })
+    class Test {}
+    `,
+  }),
+  convertAnnotatedSourceToFailureCase({
+    description:
+      'should fail if a computed property has unordered metadata array',
+    annotatedSource: `
+    @NgModule({
+      bootstrap,
+      declarations: declarations,
+      providers: providers(),
+      schemas: [],
+      [imports]: [
+        aModule,
+        bModule,
+        DModule,
+        cModule,
+        ~~~~~~~
+      ],
+    })
+    class Test {}
+    `,
+    messageId,
+    annotatedOutput: `
+    @NgModule({
+      bootstrap,
+      declarations: declarations,
+      providers: providers(),
+      schemas: [],
+      [imports]: [
+        aModule,
+        bModule,
+        cModule,
+        DModule,
+        ~~~~~~~~~
+      ],
     })
     class Test {}
     `,


### PR DESCRIPTION
Commit 1 is from #693 and that PR should be merged first.

---

We currently have a restriction to search only some properties, but we don't need to. The rule should report all unordered arrays within `NgModule`, whatever the property name is.