### PR TITLE
fix(eslint-plugin): more appropriate language for no-attribute-decorator

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,6 +73,9 @@ jobs:
       - name: Check code formatting (not distributable)
         run: NX_CLOUD_DISTRIBUTED_EXECUTION=false yarn format-check
 
+      - name: Build utils upfront to avoid cache race condition (will be addressed in Nx itself soon)
+        run: npx nx build utils
+
       - name: Run parallel distributed tasks for build, typecheck, check-configs, check-rule-docs, lint and test targets
         uses: jameshenry/parallel-bash-commands@v1
         with:

--- a/packages/eslint-plugin/docs/rules/no-attribute-decorator.md
+++ b/packages/eslint-plugin/docs/rules/no-attribute-decorator.md
@@ -13,7 +13,7 @@
 
 # `@angular-eslint/no-attribute-decorator`
 
-Disallows usage of @Attribute decorator.
+The @Attribute decorator is used to obtain a single value for an attribute. This is a much less common use-case than getting a stream of values (using @Input), so often the @Attribute decorator is mistakenly used when @Input was what was intended. This rule disallows usage of @Attribute decorator altogether in order to prevent these mistakes.
 
 - Type: problem
 - Category: Possible Errors

--- a/packages/eslint-plugin/src/rules/no-attribute-decorator.ts
+++ b/packages/eslint-plugin/src/rules/no-attribute-decorator.ts
@@ -10,14 +10,14 @@ export default createESLintRule<Options, MessageIds>({
   meta: {
     type: 'problem',
     docs: {
-      description: 'Disallows usage of @Attribute decorator.',
+      description: `The @Attribute decorator is used to obtain a single value for an attribute. This is a much less common use-case than getting a stream of values (using @Input), so often the @Attribute decorator is mistakenly used when @Input was what was intended. This rule disallows usage of @Attribute decorator altogether in order to prevent these mistakes.`,
       category: 'Possible Errors',
       recommended: false,
     },
     schema: [],
     messages: {
       noAttributeDecorator:
-        'The usage of @Attribute is considered a bad practice. Use @Input instead',
+        '@Attribute can only obtain a single value and is rarely what is required. Use @Input instead to retrieve a stream of values.',
     },
   },
   defaultOptions: [],


### PR DESCRIPTION
Closes #237

I spoke with Minko from the Angular Team and agreed on this change in language to make it clearer why the rule exists