### PR TITLE
fix(eslint-plugin): [sort-ngmodule-metadata-arrays]: ignore `arrays` inside `objects`

### DIFF
--- a/packages/eslint-plugin/docs/rules/sort-ngmodule-metadata-arrays.md
+++ b/packages/eslint-plugin/docs/rules/sort-ngmodule-metadata-arrays.md
@@ -280,6 +280,41 @@ class Test {}
 class Test {}
 ```
 
+<br>
+
+---
+
+<br>
+
+#### Default Config
+
+```json
+{
+  "rules": {
+    "@angular-eslint/sort-ngmodule-metadata-arrays": [
+      "error"
+    ]
+  }
+}
+```
+
+<br>
+
+#### ❌ Invalid Code
+
+```ts
+@NgModule({
+  imports: [
+    Module1,
+    [...commonModules, Module4, Module0],
+                                ~~~~~~~
+    ...(shouldLoadModules ? [ModuleB, ModuleA] : []),
+                                      ~~~~~~~
+  ],
+})
+class Test {}
+```
+
 </details>
 
 <br>
@@ -447,6 +482,76 @@ class Test {}
     bProvider,
     cProvider,
     DProvider,
+  ],
+})
+class Test {}
+```
+
+<br>
+
+---
+
+<br>
+
+#### Default Config
+
+```json
+{
+  "rules": {
+    "@angular-eslint/sort-ngmodule-metadata-arrays": [
+      "error"
+    ]
+  }
+}
+```
+
+<br>
+
+#### ✅ Valid Code
+
+```ts
+@NgModule({
+  providers: [
+    {
+      provide: API_LINK,
+      useFactory: createHttpLink,
+      deps: [HttpLink, EnvService, Injector, LocaleService],
+    },
+  ],
+})
+class Test {}
+```
+
+<br>
+
+---
+
+<br>
+
+#### Default Config
+
+```json
+{
+  "rules": {
+    "@angular-eslint/sort-ngmodule-metadata-arrays": [
+      "error"
+    ]
+  }
+}
+```
+
+<br>
+
+#### ✅ Valid Code
+
+```ts
+@NgModule({
+  providers: [
+    {
+      provide: API_LINK,
+      useFactory: createHttpLink,
+      [deps]: [HttpLink, EnvService, Injector, LocaleService],
+    },
   ],
 })
 class Test {}

--- a/packages/eslint-plugin/src/rules/sort-ngmodule-metadata-arrays.ts
+++ b/packages/eslint-plugin/src/rules/sort-ngmodule-metadata-arrays.ts
@@ -1,4 +1,4 @@
-import { Selectors } from '@angular-eslint/utils';
+import { ASTUtils, Selectors } from '@angular-eslint/utils';
 import type { TSESTree } from '@typescript-eslint/experimental-utils';
 import { ASTUtils as TSESLintASTUtils } from '@typescript-eslint/experimental-utils';
 import { createESLintRule } from '../utils/create-eslint-rule';
@@ -29,7 +29,20 @@ export default createESLintRule<Options, MessageIds>({
     return {
       [`${Selectors.MODULE_CLASS_DECORATOR} Property ArrayExpression`]({
         elements,
+        parent,
       }: TSESTree.ArrayExpression) {
+        const isObjectWithinArrayExpression = Boolean(
+          parent?.parent &&
+            ASTUtils.isObjectExpression(parent.parent) &&
+            parent.parent.parent &&
+            ASTUtils.isArrayExpression(parent.parent.parent),
+        );
+
+        // // ignore `ObjectExpression` within `ArrayExpression`.
+        if (isObjectWithinArrayExpression) {
+          return;
+        }
+
         const unorderedNodes = elements
           .filter(TSESLintASTUtils.isIdentifier)
           .map((current, index, list) => [current, list[index + 1]])

--- a/packages/eslint-plugin/tests/rules/sort-ngmodule-metadata-arrays/cases.ts
+++ b/packages/eslint-plugin/tests/rules/sort-ngmodule-metadata-arrays/cases.ts
@@ -52,6 +52,31 @@ export const valid = [
   })
   class Test {}
   `,
+  // https://github.com/angular-eslint/angular-eslint/issues/703
+  `
+  @NgModule({
+    providers: [
+      {
+        provide: API_LINK,
+        useFactory: createHttpLink,
+        deps: [HttpLink, EnvService, Injector, LocaleService],
+      },
+    ],
+  })
+  class Test {}
+  `,
+  `
+  @NgModule({
+    providers: [
+      {
+        provide: API_LINK,
+        useFactory: createHttpLink,
+        [deps]: [HttpLink, EnvService, Injector, LocaleService],
+      },
+    ],
+  })
+  class Test {}
+  `,
   `
   @Component({
     providers: [        
@@ -260,6 +285,38 @@ export const invalid = [
         cModule,
         DModule,
         ~~~~~~~~~
+      ],
+    })
+    class Test {}
+    `,
+  }),
+  convertAnnotatedSourceToFailureCase({
+    description:
+      'should fail if nested arrays within metadata is not sorted ASC',
+    annotatedSource: `
+    @NgModule({
+      imports: [
+        Module1,
+        [...commonModules, Module4, Module0],
+                                    ~~~~~~~
+        ...(shouldLoadModules ? [ModuleB, ModuleA] : []),
+                                          ^^^^^^^
+      ],
+    })
+    class Test {}
+    `,
+    messages: [
+      { char: '~', messageId },
+      { char: '^', messageId },
+    ],
+    annotatedOutput: `
+    @NgModule({
+      imports: [
+        Module1,
+        [...commonModules, Module0, Module4],
+                                           
+        ...(shouldLoadModules ? [ModuleA, ModuleB] : []),
+                                          
       ],
     })
     class Test {}


### PR DESCRIPTION
Fixes #703.