### PR TITLE
fix(builder): remove peer dependencies on `@angular/cli`

### DIFF
--- a/packages/builder/package.json
+++ b/packages/builder/package.json
@@ -22,7 +22,6 @@
     "@nrwl/devkit": "12.6.0"
   },
   "peerDependencies": {
-    "@angular/cli": ">= 12.0.0 < 13.0.0",
     "eslint": "*",
     "typescript": "*"
   },


### PR DESCRIPTION
Builders don't require a dependency on the `@angular/cli` to be executed.