### PR TITLE
ci: disable dependabot version updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,17 +1,10 @@
 version: 2
+
 updates:
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
       interval: "weekly"
-    ignore:
-      # @nrwl deps should always be updated by running `npx nx migrate @nrwl/workspace`
-      - dependency-name: "@nrwl/*"
-  
-  # Attempt to get dependabot to ignore integration test fixtures
-  - package-ecosystem: "npm"
-    directory: "/packages/integration-tests/fixtures"
-    schedule:
-      interval: "weekly"
-    ignore:
-      - dependency-name: "*"
+    commit-message:
+    # Disable version updates, this does not affect security updates
+    open-pull-requests-limit: 0


### PR DESCRIPTION
With this change version updates are disabled. This is due that Renovate Bot will be used instead.