### PR TITLE
ci: disable dependabot version updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,4 +1,5 @@
 version: 2
+
 updates:
   - package-ecosystem: "npm"
     directory: "/"
@@ -7,11 +8,5 @@ updates:
     ignore:
       # @nrwl deps should always be updated by running `npx nx migrate @nrwl/workspace`
       - dependency-name: "@nrwl/*"
-  
-  # Attempt to get dependabot to ignore integration test fixtures
-  - package-ecosystem: "npm"
-    directory: "/packages/integration-tests/fixtures"
-    schedule:
-      interval: "weekly"
-    ignore:
-      - dependency-name: "*"
+    # Disable version updates, this does not affect security updates
+    open-pull-requests-limit: 0

--- a/README.md
+++ b/README.md
@@ -815,6 +815,4 @@ If you see a rule below that has **no status** against it, then please feel free
 
 <!-- PR Links -->
 
-[`pr559`]: https://api.github.com/repos/angular-eslint/angular-eslint/pulls/559
-
 <!-- end rule list -->


### PR DESCRIPTION
With this change version updates are disabled. This is due that Renovate Bot will be used instead.