### PR TITLE
feat(i18n): option to require description for i18n metadata

### DIFF
--- a/packages/eslint-plugin-template/docs/rules/i18n.md
+++ b/packages/eslint-plugin-template/docs/rules/i18n.md
@@ -49,6 +49,7 @@ interface Options {
    */
   ignoreAttributes?: string[];
   ignoreTags?: string[];
+  requireDescription?: boolean
 }
 
 ```
@@ -448,6 +449,36 @@ interface Options {
           ~
   </div>
 </div>
+```
+
+<br>
+
+---
+
+<br>
+
+#### Custom Config
+
+```json
+{
+  "rules": {
+    "@angular-eslint/template/i18n": [
+      "error",
+      {
+        "requireDescription": true
+      }
+    ]
+  }
+}
+```
+
+<br>
+
+#### ❌ Invalid Code
+
+```html
+<h1 i18n>Hello</h1>
+~~~~~~~~~~~~~~~~~~~
 ```
 
 </details>
@@ -1128,6 +1159,35 @@ interface Options {
   <li>ItemB</li>
   <li>ItemC</li>
 </ul>
+```
+
+<br>
+
+---
+
+<br>
+
+#### Custom Config
+
+```json
+{
+  "rules": {
+    "@angular-eslint/template/i18n": [
+      "error",
+      {
+        "requireDescription": true
+      }
+    ]
+  }
+}
+```
+
+<br>
+
+#### ✅ Valid Code
+
+```html
+<h1 i18n="An introduction header for this sample">Hello i18n!</h1>
 ```
 
 </details>

--- a/packages/eslint-plugin-template/docs/rules/i18n.md
+++ b/packages/eslint-plugin-template/docs/rules/i18n.md
@@ -49,7 +49,7 @@ interface Options {
    */
   ignoreAttributes?: string[];
   ignoreTags?: string[];
-  requireDescription?: boolean
+  requireDescription?: boolean;
 }
 
 ```

--- a/packages/eslint-plugin-template/src/rules/i18n.ts
+++ b/packages/eslint-plugin-template/src/rules/i18n.ts
@@ -58,6 +58,7 @@ type Options = [
     readonly checkText?: boolean;
     readonly ignoreAttributes?: readonly string[];
     readonly ignoreTags?: readonly string[];
+    readonly requireDescription?: boolean;
   },
 ];
 export type MessageIds =
@@ -66,7 +67,8 @@ export type MessageIds =
   | 'i18nCustomIdOnAttribute'
   | 'i18nCustomIdOnElement'
   | 'i18nDuplicateCustomId'
-  | 'suggestAddI18nAttribute';
+  | 'suggestAddI18nAttribute'
+  | 'i18nMissingDescription';
 type StronglyTypedElement = Omit<TmplAstElement, 'i18n'> & {
   i18n: Message;
   parent?: AST;
@@ -98,6 +100,8 @@ const STYLE_GUIDE_LINK_ICU = `${STYLE_GUIDE_LINK}#mark-plurals-and-alternates-fo
 const STYLE_GUIDE_LINK_TEXTS = `${STYLE_GUIDE_LINK}#mark-text-for-translations`;
 const STYLE_GUIDE_LINK_CUSTOM_IDS = `${STYLE_GUIDE_LINK}#manage-marked-text-with-custom-ids`;
 const STYLE_GUIDE_LINK_UNIQUE_CUSTOM_IDS = `${STYLE_GUIDE_LINK}#define-unique-custom-ids`;
+const STYLE_GUIDE_LINK_COMMON_PREPARE = `${STYLE_GUIDE_LINK}-common-prepare`;
+const STYLE_GUIDE_LINK_METADATA_FOR_TRANSLATION = `${STYLE_GUIDE_LINK_COMMON_PREPARE}#i18n-metadata-for-translation`;
 
 export default createESLintRule<Options, MessageIds>({
   name: RULE_NAME,
@@ -147,6 +151,10 @@ export default createESLintRule<Options, MessageIds>({
               type: 'string',
             },
           },
+          requireDescription: {
+            type: 'boolean',
+            default: DEFAULT_OPTIONS.requireDescription,
+          },
         },
         additionalProperties: false,
       },
@@ -158,6 +166,7 @@ export default createESLintRule<Options, MessageIds>({
       i18nCustomIdOnElement: `Missing custom ID on element. See more at ${STYLE_GUIDE_LINK_CUSTOM_IDS}`,
       i18nDuplicateCustomId: `Duplicate custom ID "@@{{customId}}". See more at ${STYLE_GUIDE_LINK_UNIQUE_CUSTOM_IDS}`,
       suggestAddI18nAttribute: 'Add the `i18n` attribute',
+      i18nMissingDescription: `Missing i18n description on element. See more at ${STYLE_GUIDE_LINK_METADATA_FOR_TRANSLATION}`,
     },
   },
   defaultOptions: [DEFAULT_OPTIONS],
@@ -171,6 +180,7 @@ export default createESLintRule<Options, MessageIds>({
         checkText,
         ignoreAttributes,
         ignoreTags,
+        requireDescription,
       },
     ],
   ) {
@@ -187,7 +197,7 @@ export default createESLintRule<Options, MessageIds>({
     const collectedCustomIds = new Map<string, readonly ParseSourceSpan[]>();
 
     function handleElement({
-      i18n: { customId },
+      i18n: { description, customId },
       name,
       parent,
       sourceSpan,
@@ -196,17 +206,27 @@ export default createESLintRule<Options, MessageIds>({
         return;
       }
 
-      if (!isEmpty(customId)) {
-        const sourceSpans = collectedCustomIds.get(customId) ?? [];
-        collectedCustomIds.set(customId, [...sourceSpans, sourceSpan]);
-        return;
-      }
-
       const loc = parserServices.convertNodeSourceSpanToLoc(sourceSpan);
-      context.report({
-        messageId: 'i18nCustomIdOnElement',
-        loc,
-      });
+
+      if (!requireDescription) {
+        if (!isEmpty(customId)) {
+          const sourceSpans = collectedCustomIds.get(customId) ?? [];
+          collectedCustomIds.set(customId, [...sourceSpans, sourceSpan]);
+          return;
+        }
+
+        context.report({
+          messageId: 'i18nCustomIdOnElement',
+          loc,
+        });
+      } else {
+        if (isEmpty(description)) {
+          context.report({
+            messageId: 'i18nMissingDescription',
+            loc,
+          });
+        }
+      }
     }
 
     function handleTextAttribute({
@@ -308,7 +328,7 @@ export default createESLintRule<Options, MessageIds>({
     }
 
     return {
-      ...(checkId && {
+      ...((checkId || requireDescription) && {
         'Element[i18n]'(node: StronglyTypedElement) {
           handleElement(node);
         },

--- a/packages/eslint-plugin-template/src/rules/i18n.ts
+++ b/packages/eslint-plugin-template/src/rules/i18n.ts
@@ -208,24 +208,23 @@ export default createESLintRule<Options, MessageIds>({
 
       const loc = parserServices.convertNodeSourceSpanToLoc(sourceSpan);
 
-      if (!requireDescription) {
-        if (!isEmpty(customId)) {
-          const sourceSpans = collectedCustomIds.get(customId) ?? [];
-          collectedCustomIds.set(customId, [...sourceSpans, sourceSpan]);
-          return;
-        }
-
-        context.report({
-          messageId: 'i18nCustomIdOnElement',
-          loc,
-        });
-      } else {
-        if (isEmpty(description)) {
+      if (checkId) {
+        if (isEmpty(customId)) {
           context.report({
-            messageId: 'i18nMissingDescription',
+            messageId: 'i18nCustomIdOnElement',
             loc,
           });
+        } else {
+          const sourceSpans = collectedCustomIds.get(customId) ?? [];
+          collectedCustomIds.set(customId, [...sourceSpans, sourceSpan]);
         }
+      }
+
+      if (requireDescription && isEmpty(description)) {
+        context.report({
+          messageId: 'i18nMissingDescription',
+          loc,
+        });
       }
     }
 

--- a/packages/eslint-plugin-template/tests/rules/i18n/cases.ts
+++ b/packages/eslint-plugin-template/tests/rules/i18n/cases.ts
@@ -162,6 +162,12 @@ export const valid = [
     code: `
       <h1 i18n="An introduction header for this sample">Hello i18n!</h1>
     `,
+    options: [{ checkId: false, requireDescription: true }],
+  },
+  {
+    code: `
+      <h1 i18n="An introduction header for this sample@@custom-id">Hello i18n!</h1>
+    `,
     options: [{ requireDescription: true }],
   },
 ];
@@ -463,6 +469,16 @@ export const invalid = [
     annotatedSource: `
       <h1 i18n>Hello</h1>
       ~~~~~~~~~~~~~~~~~~~
+    `,
+    messageId: i18nMissingDescription,
+    options: [{ checkId: false, requireDescription: true }],
+  }),
+  convertAnnotatedSourceToFailureCase({
+    description:
+      'should fail if i18n description is missing, despite an ID being provided',
+    annotatedSource: `
+      <h1 i18n="@@custom-id">Hello</h1>
+      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     `,
     messageId: i18nMissingDescription,
     options: [{ requireDescription: true }],

--- a/packages/eslint-plugin-template/tests/rules/i18n/cases.ts
+++ b/packages/eslint-plugin-template/tests/rules/i18n/cases.ts
@@ -7,6 +7,7 @@ const i18nCustomIdOnAttribute: MessageIds = 'i18nCustomIdOnAttribute';
 const i18nCustomIdOnElement: MessageIds = 'i18nCustomIdOnElement';
 const i18nDuplicateCustomId: MessageIds = 'i18nDuplicateCustomId';
 const suggestAddI18nAttribute: MessageIds = 'suggestAddI18nAttribute';
+const i18nMissingDescription: MessageIds = 'i18nMissingDescription';
 
 export const valid = [
   `
@@ -157,6 +158,12 @@ export const valid = [
       <li>ItemC</li>
     </ul>
   `,
+  {
+    code: `
+      <h1 i18n="An introduction header for this sample">Hello i18n!</h1>
+    `,
+    options: [{ requireDescription: true }],
+  },
 ];
 
 export const invalid = [
@@ -450,5 +457,14 @@ export const invalid = [
         </div>
       </div>
     `,
+  }),
+  convertAnnotatedSourceToFailureCase({
+    description: 'should fail if i18n description is missing',
+    annotatedSource: `
+      <h1 i18n>Hello</h1>
+      ~~~~~~~~~~~~~~~~~~~
+    `,
+    messageId: i18nMissingDescription,
+    options: [{ requireDescription: true }],
   }),
 ];


### PR DESCRIPTION
This pull request adds the option to enforce the requirement of a description for i18n metadata. Per the Angular guide, "To translate a text message accurately, provide additional information or context for the translator." This is especially helpful when working in projects that contain large amounts of translatable texts.

P.S.
- If this feature is sound, would it be worth adding the option to require the meaning for i18n metadata? If so, in this PR, or a follow-up? Maybe something like: `"requireMetadata": ["meaning", "description"]`
- The logic for this feature adds a conditional statement with the existing logic for checking the ID. Even though all of the tests are still passing, please provide any feedback on the changes to `handleElement(...)`.

Any/all feedback welcome. 😄 