### PR TITLE
feat: add package group for ng update

### DIFF
--- a/packages/schematics/package.json
+++ b/packages/schematics/package.json
@@ -18,6 +18,14 @@
   ],
   "schematics": "./dist/collection.json",
   "ng-update": {
+    "packageGroup": [
+      "@angular-eslint/builder",
+      "@angular-eslint/eslint-plugin",
+      "@angular-eslint/eslint-plugin-template",
+      "@angular-eslint/schematics",
+      "@angular-eslint/template-parser"
+    ],
+    "packageGroupName": "@angular-eslint/schematics",
     "migrations": "./dist/migrations.json"
   },
   "ng-add": {


### PR DESCRIPTION
`ng update` checks the "ng-update"."packageGroup" field in the package.json for related packages. If defined these will also be updated to the resolved version: https://github.com/angular/angular-cli/blob/master/docs/specifications/update.md#library-developers
This simplifies the update procedure; Consumers will only have to execute `ng update @angular-eslint/schematics`, which will update all installed `@angular-eslint/*` packages.