### PR TITLE
feat!: add original component filename to inline-template filename

### DIFF
--- a/packages/eslint-plugin-template/src/processors.ts
+++ b/packages/eslint-plugin-template/src/processors.ts
@@ -1,4 +1,5 @@
 import ts from 'typescript';
+import { basename } from 'path';
 
 const rangeMap = new Map();
 
@@ -155,7 +156,8 @@ export function preprocessComponentFile(
         continue;
       }
 
-      const inlineTemplateTmpFilename = `inline-template-${++id}.component.html`;
+      const baseFilename = basename(filename);
+      const inlineTemplateTmpFilename = `inline-template-${baseFilename}-${++id}.component.html`;
 
       const start = templateProperty.initializer.getStart();
       const end = templateProperty.initializer.getEnd();

--- a/packages/eslint-plugin-template/tests/processors.test.ts
+++ b/packages/eslint-plugin-template/tests/processors.test.ts
@@ -135,7 +135,7 @@ describe('extract-inline-html', () => {
         ).toEqual([
           input,
           {
-            filename: 'inline-template-1.component.html',
+            filename: 'inline-template-test.component.ts-1.component.html',
             text: '<h1>Hello, A!</h1>',
           },
         ]);
@@ -234,7 +234,7 @@ describe('extract-inline-html', () => {
           ).toEqual([
             tc.input,
             {
-              filename: 'inline-template-1.component.html',
+              filename: `inline-template-${tc.filename}-1.component.html`,
               text: inlineTemplate,
             },
           ]);
@@ -277,7 +277,7 @@ describe('extract-inline-html', () => {
           ).toEqual([
             tc.input,
             {
-              filename: 'inline-template-1.component.html',
+              filename: 'inline-template-test.component.ts-1.component.html',
               text: inlineTemplate,
             },
           ]);
@@ -320,7 +320,7 @@ describe('extract-inline-html', () => {
           ).toEqual([
             tc.input,
             {
-              filename: 'inline-template-1.component.html',
+              filename: 'inline-template-test.component.ts-1.component.html',
               text: inlineTemplate,
             },
           ]);
@@ -384,7 +384,7 @@ describe('extract-inline-html', () => {
           ).toEqual([
             tc.input,
             {
-              filename: 'inline-template-1.component.html',
+              filename: 'inline-template-test.component.ts-1.component.html',
               text: tc.expectedExtraction,
             },
           ]);
@@ -419,11 +419,13 @@ describe('extract-inline-html', () => {
         ).toEqual([
           input,
           {
-            filename: 'inline-template-1.component.html',
+            filename:
+              'inline-template-multiple-in-one.component.ts-1.component.html',
             text: '<h1>Hello, A!</h1>',
           },
           {
-            filename: 'inline-template-2.component.html',
+            filename:
+              'inline-template-multiple-in-one.component.ts-2.component.html',
             text: '<h1>Hello, B!</h1>',
           },
         ]);


### PR DESCRIPTION
This PR updates the code to use the name of the component file in the name of any created inline-template filenames.  This allows overrides to be created to adjust the lint rules used for inline-templates based upon the containing filename.

The goal of this change is to allow configurations to do things like apply different eslint rules for spec/test file inline templates than they do for standard templates.

I _think_ it would work something like this, but have not been able to fully test it and I am looking for feedback from the maintainers on this idea.

```
{
  "root": true,
  "ignorePatterns": ["projects/**/*"],
  "overrides": [
    {
      "files": ["*.ts"],
      "parserOptions": {
        "project": ["tsconfig.json", "e2e/tsconfig.json"],
        "createDefaultProgram": true
      },
      "extends": [
        "plugin:@angular-eslint/recommended",
        "plugin:@angular-eslint/template/process-inline-templates",
        "plugin:prettier/recommended"
      ],
      "rules": {}
    },
    // Apply to all html except spec html
    {
      "files": ["*.html"],
      "excludedFiles": ["*spec*.html"],
      "extends": ["plugin:@angular-eslint/template/recommended"],
      "rules": {
         "@angular-eslint/template/i18n": "error",
      }
    },
    // Apply these rules to spec html files
    {
      "files": ["*spec*.html"],
      "extends": ["plugin:prettier/recommended"],
      "rules": {
         "@angular-eslint/template/i18n": "off",
      }
    }
  ]
}
```
