### PR TITLE
fix: rule docs links in create-eslint-rule utils

### DIFF
--- a/packages/eslint-plugin-template/src/utils/create-eslint-rule.ts
+++ b/packages/eslint-plugin-template/src/utils/create-eslint-rule.ts
@@ -2,12 +2,8 @@ import type {
   ParseSourceSpan,
   TmplAstElement,
 } from '@angular-eslint/bundled-angular-compiler';
-import type {
-  ESLintUtils,
-  TSESLint,
-  TSESTree,
-} from '@typescript-eslint/experimental-utils';
-import { applyDefault } from '@typescript-eslint/experimental-utils/dist/eslint-utils';
+import type { TSESLint, TSESTree } from '@typescript-eslint/experimental-utils';
+import { ESLintUtils } from '@typescript-eslint/experimental-utils';
 
 /**
  * We need to patch the RuleCreator in order to preserve the defaultOptions
@@ -23,7 +19,7 @@ const patchedRuleCreator: typeof ESLintUtils.RuleCreator = (urlCreator) => {
       }),
       defaultOptions,
       create(context) {
-        const optionsWithDefault = applyDefault(
+        const optionsWithDefault = ESLintUtils.applyDefault(
           defaultOptions,
           context.options,
         );
@@ -35,7 +31,7 @@ const patchedRuleCreator: typeof ESLintUtils.RuleCreator = (urlCreator) => {
 
 export const createESLintRule = patchedRuleCreator(
   (ruleName) =>
-    `https://github.com/angular-eslint/angular-eslint/blob/master/packages/eslint-plugin/docs/rules/${ruleName}.md`,
+    `https://github.com/angular-eslint/angular-eslint/blob/master/packages/eslint-plugin-template/docs/rules/${ruleName}.md`,
 );
 
 interface ParserServices {

--- a/packages/eslint-plugin/src/utils/create-eslint-rule.ts
+++ b/packages/eslint-plugin/src/utils/create-eslint-rule.ts
@@ -1,5 +1,4 @@
-import type { ESLintUtils } from '@typescript-eslint/experimental-utils';
-import { applyDefault } from '@typescript-eslint/experimental-utils/dist/eslint-utils';
+import { ESLintUtils } from '@typescript-eslint/experimental-utils';
 
 /**
  * We need to patch the RuleCreator in order to preserve the defaultOptions
@@ -15,7 +14,7 @@ const patchedRuleCreator: typeof ESLintUtils.RuleCreator = (urlCreator) => {
       }),
       defaultOptions,
       create(context) {
-        const optionsWithDefault = applyDefault(
+        const optionsWithDefault = ESLintUtils.applyDefault(
           defaultOptions,
           context.options,
         );
@@ -27,5 +26,5 @@ const patchedRuleCreator: typeof ESLintUtils.RuleCreator = (urlCreator) => {
 
 export const createESLintRule = patchedRuleCreator(
   (ruleName) =>
-    `https://github.com/angular-eslint/angular-eslint/blob/master/packages/eslint-plugin-template/docs/rules/${ruleName}.md`,
+    `https://github.com/angular-eslint/angular-eslint/blob/master/packages/eslint-plugin/docs/rules/${ruleName}.md`,
 );


### PR DESCRIPTION
Fixes #889

Also removes the deep imports into typescript-eslint