### PR TITLE
fix(eslint-plugin-template): [eqeqeq] update suggest message

### DIFF
--- a/packages/eslint-plugin-template/src/rules/eqeqeq.ts
+++ b/packages/eslint-plugin-template/src/rules/eqeqeq.ts
@@ -41,7 +41,7 @@ export default createESLintRule<Options, MessageIds>({
       eqeqeq:
         'Expected `{{expectedOperation}}` but received `{{actualOperation}}`',
       suggestStrictEquality:
-        'Replace `{{expectedOperation}}` with `{{actualOperation}}`',
+        'Replace `{{actualOperation}}` with `{{expectedOperation}}`',
     },
   },
   defaultOptions: [DEFAULT_OPTIONS],


### PR DESCRIPTION
Fix an issue where the suggest message for the `eqeqeq` rule suggests that you replace the "expected" value with the "actual" value instead of the other way around.

## Before
![screenshot of issue](https://user-images.githubusercontent.com/5626443/169328088-e05c8d4b-15ed-4d72-b021-39b86cb7b984.png)

## After
![screenshot of fix](https://user-images.githubusercontent.com/5626443/169329055-eded27f8-dfb8-4a89-840d-0f4de9041d19.png)

