### PR TITLE
fix(eslint-plugin): [sort-ngmodule-metadata-arrays] do not sort deps property

### DIFF
--- a/packages/eslint-plugin/docs/rules/sort-ngmodule-metadata-arrays.md
+++ b/packages/eslint-plugin/docs/rules/sort-ngmodule-metadata-arrays.md
@@ -483,6 +483,41 @@ class Test {}
 class Test {}
 ```
 
+<br>
+
+---
+
+<br>
+
+#### Default Config
+
+```json
+{
+  "rules": {
+    "@angular-eslint/sort-ngmodule-metadata-arrays": [
+      "error"
+    ]
+  }
+}
+```
+
+<br>
+
+#### ✅ Valid Code
+
+```ts
+@NgModule({
+  providers: [
+    {
+      provide: 'myprovider',
+      useFactory: myProviderFactory,
+      deps: [TOKEN_Z, ClassX, ClassA, TOKEN_A],
+    },
+  ],
+})
+class Test {}
+```
+
 </details>
 
 <br>

--- a/packages/eslint-plugin/src/rules/sort-ngmodule-metadata-arrays.ts
+++ b/packages/eslint-plugin/src/rules/sort-ngmodule-metadata-arrays.ts
@@ -26,7 +26,7 @@ export default createESLintRule<Options, MessageIds>({
   defaultOptions: [],
   create(context) {
     return {
-      [`${Selectors.MODULE_CLASS_DECORATOR} Property ArrayExpression`]({
+      [`${Selectors.MODULE_CLASS_DECORATOR} Property[key.name!="deps"] > ArrayExpression`]({
         elements,
       }: TSESTree.ArrayExpression) {
         const unorderedNodes = elements

--- a/packages/eslint-plugin/tests/rules/sort-ngmodule-metadata-arrays/cases.ts
+++ b/packages/eslint-plugin/tests/rules/sort-ngmodule-metadata-arrays/cases.ts
@@ -54,10 +54,22 @@ export const valid = [
   `,
   `
   @Component({
-    providers: [        
+    providers: [
       DeclarationD,
       DeclarationA,
     ]
+  })
+  class Test {}
+  `,
+  `
+  @NgModule({
+    providers: [
+      {
+        provide: 'myprovider',
+        useFactory: myProviderFactory,
+        deps: [TOKEN_Z, ClassX, ClassA, TOKEN_A],
+      },
+    ],
   })
   class Test {}
   `,


### PR DESCRIPTION
The rule currently sorts the `deps` property of factory providers which scrambles the order the arguments are given to the function.

New behavior: `deps` property is excluded from selector.

Closes #703