### PR TITLE
docs: fix .prettierrc in eslint-plugin-prettier section

### DIFF
--- a/README.md
+++ b/README.md
@@ -406,13 +406,14 @@ If you choose to use `eslint-plugin-prettier`, **please ensure that you are usin
 
 **.prettierrc**
 
-```jsonc
-// This ensures that prettier applies its own Angular parser to all HTML files in our project
+```json
 {
   "overrides": [
     {
       "files": "*.html",
-      "parser": "angular"
+      "options": {
+        "parser": "angular"
+      }
     }
   ]
 }


### PR DESCRIPTION
1. `.prettierc` can't contain comments
2. the `parser` option should be in the `options` option https://prettier.io/docs/en/configuration.html#setting-the-parserdocsenoptionshtmlparser-option

Fixes #1144.