### PR TITLE
fix(no-input-rename): allow input aliases that match the directive na…

### DIFF
--- a/packages/eslint-plugin/docs/rules/no-input-rename.md
+++ b/packages/eslint-plugin/docs/rules/no-input-rename.md
@@ -365,6 +365,38 @@ class Test {
 }
 ```
 
+<br>
+
+---
+
+<br>
+
+#### Default Config
+
+```json
+{
+  "rules": {
+    "@angular-eslint/no-input-rename": [
+      "error"
+    ]
+  }
+}
+```
+
+<br>
+
+#### ❌ Invalid Code
+
+```ts
+@Directive({
+  selector: 'img[fooDirective]',
+})
+class Test {
+  @Input('notFooDirective') foo: Foo;
+         ~~~~~~~~~~~~~~~~~
+}
+```
+
 </details>
 
 <br>
@@ -884,6 +916,68 @@ class Test {
 })
 class Test {
   @Input('fooMyColor') myColor: string;
+}
+```
+
+<br>
+
+---
+
+<br>
+
+#### Default Config
+
+```json
+{
+  "rules": {
+    "@angular-eslint/no-input-rename": [
+      "error"
+    ]
+  }
+}
+```
+
+<br>
+
+#### ✅ Valid Code
+
+```ts
+@Directive({
+  selector: 'img[fooDirective]'
+})
+class Test {
+  @Input foo: Foo;
+}
+```
+
+<br>
+
+---
+
+<br>
+
+#### Default Config
+
+```json
+{
+  "rules": {
+    "@angular-eslint/no-input-rename": [
+      "error"
+    ]
+  }
+}
+```
+
+<br>
+
+#### ✅ Valid Code
+
+```ts
+@Directive({
+  selector: 'img[fooDirective]'
+})
+class Test {
+  @Input('fooDirective') foo: Foo;
 }
 ```
 

--- a/packages/eslint-plugin/src/rules/no-input-rename.ts
+++ b/packages/eslint-plugin/src/rules/no-input-rename.ts
@@ -93,7 +93,6 @@ export default createESLintRule<Options, MessageIds>({
         );
 
         if (
-          aliasName === selectorDirectiveName ||
           allowedNames.includes(aliasName) ||
           (ariaAttributeKeys.has(aliasName) &&
             propertyName === kebabToCamelCase(aliasName))
@@ -107,7 +106,14 @@ export default createESLintRule<Options, MessageIds>({
             messageId: 'noInputRename',
             fix: (fixer) => fixer.remove(node),
           });
-        } else if (!isAliasNameAllowed(selectors, propertyName, aliasName)) {
+        } else if (
+          !isAliasNameAllowed(
+            selectors,
+            propertyName,
+            aliasName,
+            selectorDirectiveName,
+          )
+        ) {
           context.report({
             node,
             messageId: 'noInputRename',
@@ -156,7 +162,14 @@ export default createESLintRule<Options, MessageIds>({
                 ASTUtils.getReplacementText(node, propertyName),
               ),
           });
-        } else if (!isAliasNameAllowed(selectors, propertyName, aliasName)) {
+        } else if (
+          !isAliasNameAllowed(
+            selectors,
+            propertyName,
+            aliasName,
+            selectorDirectiveName,
+          )
+        ) {
           context.report({
             node,
             messageId: 'noInputRename',
@@ -191,10 +204,12 @@ function isAliasNameAllowed(
   selectors: ReadonlySet<string>,
   propertyName: string,
   aliasName: string,
+  selectorDirectiveName: string,
 ): boolean {
   return [...selectors].some((selector) => {
     return (
       selector === aliasName ||
+      selectorDirectiveName === aliasName ||
       composedName(selector, propertyName) === aliasName
     );
   });

--- a/packages/eslint-plugin/tests/rules/no-input-rename/cases.ts
+++ b/packages/eslint-plugin/tests/rules/no-input-rename/cases.ts
@@ -146,6 +146,22 @@ export const valid = [
       @Input('fooMyColor') myColor: string;
     }
   `,
+  `
+    @Directive({
+      selector: 'img[fooDirective]'
+    })
+    class Test {
+      @Input foo: Foo;
+    }
+  `,
+  `
+    @Directive({
+      selector: 'img[fooDirective]'
+    })
+    class Test {
+      @Input('fooDirective') foo: Foo;
+    }
+  `,
 ];
 
 export const invalid = [
@@ -442,6 +458,37 @@ export const invalid = [
       @Injectable()
       class Test {
         @Input() ${propertyName} = this.getInput();
+               
+      }
+    `,
+    })),
+  }),
+  convertAnnotatedSourceToFailureCase({
+    description:
+      'should fail if input property alias does not match the directive name when applied to an element in the selector',
+    annotatedSource: `
+      @Directive({
+        selector: 'img[fooDirective]',
+      })
+      class Test {
+        @Input('notFooDirective') foo: Foo;
+               ~~~~~~~~~~~~~~~~~
+      }
+    `,
+    messageId,
+    suggestions: (
+      [
+        [suggestRemoveAliasName, 'foo'],
+        [suggestReplaceOriginalNameWithAliasName, 'notFooDirective'],
+      ] as const
+    ).map(([messageId, propertyName]) => ({
+      messageId,
+      output: `
+      @Directive({
+        selector: 'img[fooDirective]',
+      })
+      class Test {
+        @Input() ${propertyName}: Foo;
                
       }
     `,


### PR DESCRIPTION
…me applied to an element

This pull request enhances the `no-input-rename` rule to allow input aliases that match the directive name applied to an element.

Example:
```ts
@Directive({
  selector: 'img[fooDirective]'
})
class Test {
  @Input('fooDirective') foo: Foo;
}
```

Resolves #978 

**Note:** No new suggestions have been added for this enhancement because the rule already allows input aliases that match the directive name (when not applied to an element).