### PR TITLE
feat(eslint-plugin-template): [no-call-expression] add allowList option

### DIFF
--- a/packages/eslint-plugin-template/docs/rules/no-call-expression.md
+++ b/packages/eslint-plugin-template/docs/rules/no-call-expression.md
@@ -23,7 +23,17 @@ Disallows calling expressions in templates, except for output handlers
 
 ## Rule Options
 
-The rule does not have any configuration options.
+The rule accepts an options object with the following properties:
+
+```ts
+interface Options {
+  /**
+   * Default: `[]`
+   */
+  allowList?: string[];
+}
+
+```
 
 <br>
 
@@ -389,6 +399,39 @@ The rule does not have any configuration options.
 
 ```html
 <form [formGroup]="form" (ngSubmit)="id ? save() : edit()"></form>
+```
+
+<br>
+
+---
+
+<br>
+
+#### Custom Config
+
+```json
+{
+  "rules": {
+    "@angular-eslint/template/no-call-expression": [
+      "error",
+      {
+        "allowList": [
+          "nested",
+          "getHref"
+        ]
+      }
+    ]
+  }
+}
+```
+
+<br>
+
+#### ✅ Valid Code
+
+```html
+{{ obj?.nested() }} {{ obj!.nested() }}
+<a [href]="getHref()">info</a>
 ```
 
 </details>

--- a/packages/eslint-plugin-template/src/rules/no-call-expression.ts
+++ b/packages/eslint-plugin-template/src/rules/no-call-expression.ts
@@ -1,10 +1,14 @@
-import type { Call } from '@angular-eslint/bundled-angular-compiler';
+import type { AST, Call } from '@angular-eslint/bundled-angular-compiler';
 import { TmplAstBoundEvent } from '@angular-eslint/bundled-angular-compiler';
 import { ensureTemplateParser } from '@angular-eslint/utils';
 import { createESLintRule } from '../utils/create-eslint-rule';
 import { getNearestNodeFrom } from '../utils/get-nearest-node-from';
 
-type Options = [];
+type Options = [
+  {
+    readonly allowList?: readonly string[];
+  },
+];
 export type MessageIds = 'noCallExpression';
 export const RULE_NAME = 'no-call-expression';
 
@@ -17,13 +21,25 @@ export default createESLintRule<Options, MessageIds>({
         'Disallows calling expressions in templates, except for output handlers',
       recommended: false,
     },
-    schema: [],
+    schema: [
+      {
+        additionalProperties: false,
+        properties: {
+          allowList: {
+            items: { type: 'string' },
+            type: 'array',
+            uniqueItems: true,
+          },
+        },
+        type: 'object',
+      },
+    ],
     messages: {
       noCallExpression: 'Avoid calling expressions in templates',
     },
   },
-  defaultOptions: [],
-  create(context) {
+  defaultOptions: [{ allowList: [] }],
+  create(context, [{ allowList }]) {
     ensureTemplateParser(context);
     const sourceCode = context.getSourceCode();
 
@@ -34,6 +50,15 @@ export default createESLintRule<Options, MessageIds>({
         );
 
         if (isChildOfBoundEvent) return;
+
+        if (
+          allowList &&
+          allowList.length &&
+          isASTWithName(node.receiver) &&
+          allowList.indexOf(node.receiver.name) > -1
+        ) {
+          return;
+        }
 
         const {
           sourceSpan: { start, end },
@@ -52,4 +77,10 @@ export default createESLintRule<Options, MessageIds>({
 
 function isBoundEvent(node: unknown): node is TmplAstBoundEvent {
   return node instanceof TmplAstBoundEvent;
+}
+
+function isASTWithName(
+  ast: AST & { name?: string },
+): ast is AST & { name: string } {
+  return !!ast.name;
 }

--- a/packages/eslint-plugin-template/src/rules/no-call-expression.ts
+++ b/packages/eslint-plugin-template/src/rules/no-call-expression.ts
@@ -51,14 +51,7 @@ export default createESLintRule<Options, MessageIds>({
 
         if (isChildOfBoundEvent) return;
 
-        if (
-          allowList &&
-          allowList.length &&
-          isASTWithName(node.receiver) &&
-          allowList.indexOf(node.receiver.name) > -1
-        ) {
-          return;
-        }
+        if (isCallNameInAllowList(node.receiver, allowList)) return;
 
         const {
           sourceSpan: { start, end },
@@ -83,4 +76,16 @@ function isASTWithName(
   ast: AST & { name?: string },
 ): ast is AST & { name: string } {
   return !!ast.name;
+}
+
+function isCallNameInAllowList(
+  ast: AST & { name?: string },
+  allowList?: readonly string[],
+): boolean | undefined {
+  return (
+    allowList &&
+    allowList.length > 0 &&
+    isASTWithName(ast) &&
+    allowList.indexOf(ast.name) > -1
+  );
 }

--- a/packages/eslint-plugin-template/tests/rules/no-call-expression/cases.ts
+++ b/packages/eslint-plugin-template/tests/rules/no-call-expression/cases.ts
@@ -11,6 +11,17 @@ export const valid = [
   '<form [formGroup]="form" (ngSubmit)="form.valid || save()"></form>',
   '<form [formGroup]="form" (ngSubmit)="form.valid && save()"></form>',
   '<form [formGroup]="form" (ngSubmit)="id ? save() : edit()"></form>',
+  {
+    code: `
+      {{ obj?.nested() }} {{ obj!.nested() }}
+      <a [href]="getHref()">info</a>
+    `,
+    options: [
+      {
+        allowList: ['nested', 'getHref'],
+      },
+    ],
+  },
 ];
 
 export const invalid = [


### PR DESCRIPTION
Resolves #1055

Adds `allowList` option to the no-call-expression template rule to configure a list of function names allowed to be called.