### PR TITLE
fix(eslint-plugin-template): [accessibility-valid-aria] use Number() to parse numeric values

### DIFF
--- a/packages/eslint-plugin-template/docs/rules/accessibility-valid-aria.md
+++ b/packages/eslint-plugin-template/docs/rules/accessibility-valid-aria.md
@@ -342,6 +342,32 @@ The rule does not have any configuration options.
 #### ✅ Valid Code
 
 ```html
+<table aria-rowcount="-1"></table>
+```
+
+<br>
+
+---
+
+<br>
+
+#### Default Config
+
+```json
+{
+  "rules": {
+    "@angular-eslint/template/accessibility-valid-aria": [
+      "error"
+    ]
+  }
+}
+```
+
+<br>
+
+#### ✅ Valid Code
+
+```html
 <div aria-relevant="additions">additions</div>
 ```
 
@@ -394,7 +420,33 @@ The rule does not have any configuration options.
 #### ✅ Valid Code
 
 ```html
-<div role="slider" [aria-valuemin]="1"></div>
+<div role="slider" [attr.aria-valuemin]="1"></div>
+```
+
+<br>
+
+---
+
+<br>
+
+#### Default Config
+
+```json
+{
+  "rules": {
+    "@angular-eslint/template/accessibility-valid-aria": [
+      "error"
+    ]
+  }
+}
+```
+
+<br>
+
+#### ✅ Valid Code
+
+```html
+<div role="slider" aria-valuemin="1"></div>
 ```
 
 <br>

--- a/packages/eslint-plugin-template/src/rules/accessibility-valid-aria.ts
+++ b/packages/eslint-plugin-template/src/rules/accessibility-valid-aria.ts
@@ -134,7 +134,7 @@ function isInteger(value: unknown): boolean {
 function isNumeric(value: unknown): boolean {
   return (
     !Number.isNaN(Number.parseFloat(value as string)) &&
-    Number.isFinite(value as number)
+    Number.isFinite(Number(value))
   );
 }
 

--- a/packages/eslint-plugin-template/tests/rules/accessibility-valid-aria/cases.ts
+++ b/packages/eslint-plugin-template/tests/rules/accessibility-valid-aria/cases.ts
@@ -14,9 +14,11 @@ export const valid = [
   '<div aria-haspopup="menu">aria-haspopup</div>',
   '<div [attr.aria-pressed]="undefined">aria-pressed</div>',
   '<input [attr.aria-rowcount]="2">',
+  '<table aria-rowcount="-1"></table>',
   '<div aria-relevant="additions">additions</div>',
   '<div aria-checked="false">checked</div>',
-  '<div role="slider" [aria-valuemin]="1"></div>',
+  '<div role="slider" [attr.aria-valuemin]="1"></div>',
+  '<div role="slider" aria-valuemin="1"></div>',
   '<div aria-="text">Text</div>',
   `
       <input


### PR DESCRIPTION
Fixes parsing plain text numeric attribute values: accessibility-valid-aria is currently just allowing for bound numeric attribute values but not parsing from plain text values, e.g. `aria-valuemin="1"`