### PR TITLE
feat(eslint-plugin): [require-localize-metadata] option to require me…

### DIFF
--- a/packages/eslint-plugin/docs/rules/require-localize-metadata.md
+++ b/packages/eslint-plugin/docs/rules/require-localize-metadata.md
@@ -28,6 +28,7 @@ The rule accepts an options object with the following properties:
 ```ts
 interface Options {
   requireDescription?: boolean;
+  requireMeaning?: boolean;
 }
 
 ```
@@ -250,6 +251,128 @@ const localizedText = $localize`:@@custom_id:Hello i18n!`;
 ```ts
 const localizedText = $localize`:site header|@@custom_id:Hello i18n!`;
                                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+```
+
+<br>
+
+---
+
+<br>
+
+#### Custom Config
+
+```json
+{
+  "rules": {
+    "@angular-eslint/require-localize-metadata": [
+      "error",
+      {
+        "requireMeaning": true
+      }
+    ]
+  }
+}
+```
+
+<br>
+
+#### ❌ Invalid Code
+
+```ts
+const localizedText = $localize`Hello i18n!`;
+                               ~~~~~~~~~~~~~
+```
+
+<br>
+
+---
+
+<br>
+
+#### Custom Config
+
+```json
+{
+  "rules": {
+    "@angular-eslint/require-localize-metadata": [
+      "error",
+      {
+        "requireDescription": true,
+        "requireMeaning": true
+      }
+    ]
+  }
+}
+```
+
+<br>
+
+#### ❌ Invalid Code
+
+```ts
+const localizedText = $localize`:An introduction header for this sample:Hello i18n!`;
+                               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+```
+
+<br>
+
+---
+
+<br>
+
+#### Custom Config
+
+```json
+{
+  "rules": {
+    "@angular-eslint/require-localize-metadata": [
+      "error",
+      {
+        "requireMeaning": true
+      }
+    ]
+  }
+}
+```
+
+<br>
+
+#### ❌ Invalid Code
+
+```ts
+const localizedText = $localize`:|An introduction header for this sample:Hello i18n!`;
+                               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+```
+
+<br>
+
+---
+
+<br>
+
+#### Custom Config
+
+```json
+{
+  "rules": {
+    "@angular-eslint/require-localize-metadata": [
+      "error",
+      {
+        "requireDescription": true,
+        "requireMeaning": true
+      }
+    ]
+  }
+}
+```
+
+<br>
+
+#### ❌ Invalid Code
+
+```ts
+const localizedText = $localize`:Hello i18n!`;
+                               ~~~~~~~~~~~~~~
 ```
 
 </details>
@@ -510,6 +633,65 @@ someFunction($localize\`:An introduction header for this sample:Hello i18n!\`);
 
 ```ts
 const localizedText = \`Hello i18n!\`;
+```
+
+<br>
+
+---
+
+<br>
+
+#### Custom Config
+
+```json
+{
+  "rules": {
+    "@angular-eslint/require-localize-metadata": [
+      "error",
+      {
+        "requireMeaning": true
+      }
+    ]
+  }
+}
+```
+
+<br>
+
+#### ✅ Valid Code
+
+```ts
+const localizedText = $localize\`:site header|:Hello i18n!\`;
+```
+
+<br>
+
+---
+
+<br>
+
+#### Custom Config
+
+```json
+{
+  "rules": {
+    "@angular-eslint/require-localize-metadata": [
+      "error",
+      {
+        "requireDescription": true,
+        "requireMeaning": true
+      }
+    ]
+  }
+}
+```
+
+<br>
+
+#### ✅ Valid Code
+
+```ts
+const localizedText = $localize\`:site header|An introduction header for this sample:Hello i18n!\`;
 ```
 
 </details>

--- a/packages/eslint-plugin/src/rules/require-localize-metadata.ts
+++ b/packages/eslint-plugin/src/rules/require-localize-metadata.ts
@@ -67,7 +67,10 @@ export default createESLintRule<Options, MessageIds>({
       TaggedTemplateExpression(
         taggedTemplateExpression: TSESTree.TaggedTemplateExpression,
       ) {
-        if (ASTUtils.isIdentifier(taggedTemplateExpression.tag)) {
+        if (
+          (requireDescription || requireMeaning) &&
+          ASTUtils.isIdentifier(taggedTemplateExpression.tag)
+        ) {
           const identifierName = taggedTemplateExpression.tag.name;
           const templateElement = taggedTemplateExpression.quasi.quasis[0];
 

--- a/packages/eslint-plugin/src/rules/require-localize-metadata.ts
+++ b/packages/eslint-plugin/src/rules/require-localize-metadata.ts
@@ -5,22 +5,30 @@ import { createESLintRule } from '../utils/create-eslint-rule';
 type Options = [
   {
     readonly requireDescription?: boolean;
+    readonly requireMeaning?: boolean;
   },
 ];
 
 const DEFAULT_OPTIONS: Options[number] = {
   requireDescription: false,
+  requireMeaning: false,
 };
 
 const VALID_LOCALIZED_STRING_WITH_DESCRIPTION = new RegExp(
   /:(.*\|)?([\w\s]+){1}(@@.*)?:.+/,
 );
 
+const VALID_LOCALIZED_STRING_WITH_MEANING = new RegExp(
+  /:([\w\s]+\|)(.*)?(@@.*)?:.+/,
+);
+
 const STYLE_GUIDE_LINK = 'https://angular.io/guide/i18n';
 const STYLE_GUIDE_LINK_COMMON_PREPARE = `${STYLE_GUIDE_LINK}-common-prepare`;
 const STYLE_GUIDE_LINK_METADATA_FOR_TRANSLATION = `${STYLE_GUIDE_LINK_COMMON_PREPARE}#i18n-metadata-for-translation`;
 
-export type MessageIds = 'requireLocalizeMetadata';
+export type MessageIds =
+  | 'requireLocalizeDescription'
+  | 'requireLocalizeMeaning';
 export const RULE_NAME = 'require-localize-metadata';
 
 export default createESLintRule<Options, MessageIds>({
@@ -40,49 +48,53 @@ export default createESLintRule<Options, MessageIds>({
             type: 'boolean',
             default: DEFAULT_OPTIONS.requireDescription,
           },
+          requireMeaning: {
+            type: 'boolean',
+            default: DEFAULT_OPTIONS.requireMeaning,
+          },
         },
         additionalProperties: false,
       },
     ],
     messages: {
-      requireLocalizeMetadata: `$localize tagged messages should contain a description. See more at ${STYLE_GUIDE_LINK_METADATA_FOR_TRANSLATION}`,
+      requireLocalizeDescription: `$localize tagged messages should contain a description. See more at ${STYLE_GUIDE_LINK_METADATA_FOR_TRANSLATION}`,
+      requireLocalizeMeaning: `$localize tagged messages should contain a meaning. See more at ${STYLE_GUIDE_LINK_METADATA_FOR_TRANSLATION}`,
     },
   },
   defaultOptions: [DEFAULT_OPTIONS],
-  create(context, [{ requireDescription }]) {
-    function reportRequireLocalizeMetadataError(
-      templateElement: TSESTree.TemplateElement,
-    ) {
-      context.report({
-        loc: templateElement.loc,
-        messageId: 'requireLocalizeMetadata',
-      });
-    }
-
-    function testLocalizeTemplateElementWithDescription(
-      templateElement: TSESTree.TemplateElement,
-    ) {
-      if (
-        !VALID_LOCALIZED_STRING_WITH_DESCRIPTION.test(templateElement.value.raw)
-      ) {
-        reportRequireLocalizeMetadataError(templateElement);
-      }
-    }
-
+  create(context, [{ requireDescription, requireMeaning }]) {
     return {
       TaggedTemplateExpression(
         taggedTemplateExpression: TSESTree.TaggedTemplateExpression,
       ) {
-        if (
-          requireDescription &&
-          ASTUtils.isIdentifier(taggedTemplateExpression.tag)
-        ) {
+        if (ASTUtils.isIdentifier(taggedTemplateExpression.tag)) {
           const identifierName = taggedTemplateExpression.tag.name;
           const templateElement = taggedTemplateExpression.quasi.quasis[0];
 
           if (identifierName === '$localize' && !!templateElement) {
-            // Test for i18n description only
-            testLocalizeTemplateElementWithDescription(templateElement);
+            const templateElementRawValue = templateElement.value.raw;
+
+            if (
+              requireDescription &&
+              !VALID_LOCALIZED_STRING_WITH_DESCRIPTION.test(
+                templateElementRawValue,
+              )
+            ) {
+              context.report({
+                loc: templateElement.loc,
+                messageId: 'requireLocalizeDescription',
+              });
+            }
+
+            if (
+              requireMeaning &&
+              !VALID_LOCALIZED_STRING_WITH_MEANING.test(templateElementRawValue)
+            ) {
+              context.report({
+                loc: templateElement.loc,
+                messageId: 'requireLocalizeMeaning',
+              });
+            }
           }
         }
       },

--- a/packages/eslint-plugin/tests/rules/require-localize-metadata/cases.ts
+++ b/packages/eslint-plugin/tests/rules/require-localize-metadata/cases.ts
@@ -1,7 +1,9 @@
 import { convertAnnotatedSourceToFailureCase } from '@angular-eslint/utils';
 import type { MessageIds } from '../../../src/rules/require-localize-metadata';
 
-const messageId: MessageIds = 'requireLocalizeMetadata';
+const messageIdRequireLocalizeDescription: MessageIds =
+  'requireLocalizeDescription';
+const messageIdRequireLocalizeMeaning: MessageIds = 'requireLocalizeMeaning';
 
 export const valid = [
   `const localizedText = $localize\`Hello i18n!\`;`,
@@ -40,6 +42,14 @@ export const valid = [
     code: `const localizedText = \`Hello i18n!\`;`,
     options: [{ requireDescription: true }],
   },
+  {
+    code: `const localizedText = $localize\`:site header|:Hello i18n!\`;`,
+    options: [{ requireMeaning: true }],
+  },
+  {
+    code: `const localizedText = $localize\`:site header|An introduction header for this sample:Hello i18n!\`;`,
+    options: [{ requireDescription: true, requireMeaning: true }],
+  },
 ];
 
 export const invalid = [
@@ -50,7 +60,7 @@ export const invalid = [
       const localizedText = $localize\`Hello i18n!\`;
                                      ~~~~~~~~~~~~~
     `,
-    messageId,
+    messageId: messageIdRequireLocalizeDescription,
     options: [{ requireDescription: true }],
   }),
   convertAnnotatedSourceToFailureCase({
@@ -63,7 +73,7 @@ export const invalid = [
       localizedTexts.helloI18n = $localize\`Hello i18n!\`;
                                           ~~~~~~~~~~~~~
     `,
-    messageId,
+    messageId: messageIdRequireLocalizeDescription,
     options: [{ requireDescription: true }],
   }),
   convertAnnotatedSourceToFailureCase({
@@ -73,7 +83,7 @@ export const invalid = [
       return $localize\`Hello i18n!\`;
                       ~~~~~~~~~~~~~
     `,
-    messageId,
+    messageId: messageIdRequireLocalizeDescription,
     options: [{ requireDescription: true }],
   }),
   convertAnnotatedSourceToFailureCase({
@@ -83,37 +93,83 @@ export const invalid = [
       someFunction($localize\`Hello i18n!\`);
                             ~~~~~~~~~~~~~
     `,
-    messageId,
+    messageId: messageIdRequireLocalizeDescription,
     options: [{ requireDescription: true }],
   }),
   convertAnnotatedSourceToFailureCase({
     description:
-      'it should fail if no $localize description is provided when required for variable declarations, despite a $localize meaning being provided',
+      'it should fail if no $localize description is provided when required for variable declarations, despite a meaning being provided',
     annotatedSource: `
       const localizedText = $localize\`:site header|:Hello i18n!\`;
                                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~
     `,
-    messageId,
+    messageId: messageIdRequireLocalizeDescription,
     options: [{ requireDescription: true }],
   }),
   convertAnnotatedSourceToFailureCase({
     description:
-      'it should fail if no $localize description is provided when required for variable declarations, despite a $localize ID being provided',
+      'it should fail if no $localize description is provided when required for variable declarations, despite a ID being provided',
     annotatedSource: `
       const localizedText = $localize\`:@@custom_id:Hello i18n!\`;
                                      ~~~~~~~~~~~~~~~~~~~~~~~~~~
     `,
-    messageId,
+    messageId: messageIdRequireLocalizeDescription,
     options: [{ requireDescription: true }],
   }),
   convertAnnotatedSourceToFailureCase({
     description:
-      'it should fail if no $localize description is provided when required for variable declarations, despite a $localize meaning and ID being provided',
+      'it should fail if no $localize description is provided when required for variable declarations, despite a meaning and ID being provided',
     annotatedSource: `
       const localizedText = $localize\`:site header|@@custom_id:Hello i18n!\`;
                                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     `,
-    messageId,
+    messageId: messageIdRequireLocalizeDescription,
     options: [{ requireDescription: true }],
+  }),
+  convertAnnotatedSourceToFailureCase({
+    description: 'it should fail if no $localize meaning is provided',
+    annotatedSource: `
+      const localizedText = $localize\`Hello i18n!\`;
+                                     ~~~~~~~~~~~~~
+    `,
+    messageId: messageIdRequireLocalizeMeaning,
+    options: [{ requireMeaning: true }],
+  }),
+  convertAnnotatedSourceToFailureCase({
+    description:
+      'it should fail if no $localize meaning is provided despite a description being provided',
+    annotatedSource: `
+      const localizedText = $localize\`:An introduction header for this sample:Hello i18n!\`;
+                                     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    `,
+    messageId: messageIdRequireLocalizeMeaning,
+    options: [{ requireDescription: true, requireMeaning: true }],
+  }),
+  convertAnnotatedSourceToFailureCase({
+    description: 'it should fail if the $localize meaning is empty',
+    annotatedSource: `
+      const localizedText = $localize\`:|An introduction header for this sample:Hello i18n!\`;
+                                     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    `,
+    messageId: messageIdRequireLocalizeMeaning,
+    options: [{ requireMeaning: true }],
+  }),
+  convertAnnotatedSourceToFailureCase({
+    description: 'it should fail if no $localize metadata is provided',
+    annotatedSource: `
+      const localizedText = $localize\`:Hello i18n!\`;
+                                     ~~~~~~~~~~~~~~
+    `,
+    messages: [
+      {
+        char: '~',
+        messageId: messageIdRequireLocalizeDescription,
+      },
+      {
+        char: '~',
+        messageId: messageIdRequireLocalizeMeaning,
+      },
+    ],
+    options: [{ requireDescription: true, requireMeaning: true }],
   }),
 ];


### PR DESCRIPTION
…aning

This pull request adds the option to `requireMeaning` when using `$localize` to translate text in TypeScript.