### PR TITLE
fix(eslint-plugin): [component-selector] enhance check for prefix and…

### DIFF
--- a/packages/eslint-plugin/docs/rules/component-selector.md
+++ b/packages/eslint-plugin/docs/rules/component-selector.md
@@ -484,6 +484,44 @@ class Test {}
 class Test {}
 ```
 
+<br>
+
+---
+
+<br>
+
+#### Custom Config
+
+```json
+{
+  "rules": {
+    "@angular-eslint/component-selector": [
+      "error",
+      {
+        "type": "element",
+        "prefix": [
+          "app",
+          "toh"
+        ],
+        "style": "kebab-case"
+      }
+    ]
+  }
+}
+```
+
+<br>
+
+#### ❌ Invalid Code
+
+```ts
+@Component({
+  selector: 'root'
+            ~~~~~~
+})
+class Test {}
+```
+
 </details>
 
 <br>
@@ -1124,6 +1162,39 @@ class Test {}
 ```ts
 @Directive({
   selector: 'app-foo-bar'
+})
+class Test {}
+```
+
+<br>
+
+---
+
+<br>
+
+#### Custom Config
+
+```json
+{
+  "rules": {
+    "@angular-eslint/component-selector": [
+      "error",
+      {
+        "type": "element",
+        "style": "kebab-case"
+      }
+    ]
+  }
+}
+```
+
+<br>
+
+#### ✅ Valid Code
+
+```ts
+@Component({
+  selector: 'singleword'
 })
 class Test {}
 ```

--- a/packages/eslint-plugin/docs/rules/component-selector.md
+++ b/packages/eslint-plugin/docs/rules/component-selector.md
@@ -522,6 +522,41 @@ class Test {}
 class Test {}
 ```
 
+<br>
+
+---
+
+<br>
+
+#### Custom Config
+
+```json
+{
+  "rules": {
+    "@angular-eslint/component-selector": [
+      "error",
+      {
+        "type": "element",
+        "prefix": "sg",
+        "style": "kebab-case"
+      }
+    ]
+  }
+}
+```
+
+<br>
+
+#### ❌ Invalid Code
+
+```ts
+@Component({
+  selector: 'sgggg-bar'
+            ~~~~~~~~~~~
+})
+class Test {}
+```
+
 </details>
 
 <br>

--- a/packages/eslint-plugin/src/rules/component-selector.ts
+++ b/packages/eslint-plugin/src/rules/component-selector.ts
@@ -124,15 +124,17 @@ export default createESLintRule<SelectorUtils.Options, MessageIds>({
         if (!hasExpectedSelector.hasExpectedType) {
           SelectorUtils.reportTypeError(rawSelectors, type, context);
         } else if (!hasExpectedSelector.hasExpectedStyle) {
-          if (!hasExpectedSelector.hasExpectedPrefix) {
-            SelectorUtils.reportStyleAndPrefixError(
-              rawSelectors,
-              style,
-              prefix,
-              context,
-            );
-          } else if (style === overrideStyle) {
-            SelectorUtils.reportStyleError(rawSelectors, style, context);
+          if (style === overrideStyle) {
+            if (!hasExpectedSelector.hasExpectedPrefix) {
+              SelectorUtils.reportStyleAndPrefixError(
+                rawSelectors,
+                style,
+                prefix,
+                context,
+              );
+            } else {
+              SelectorUtils.reportStyleError(rawSelectors, style, context);
+            }
           } else {
             context.report({
               node: rawSelectors,

--- a/packages/eslint-plugin/src/rules/component-selector.ts
+++ b/packages/eslint-plugin/src/rules/component-selector.ts
@@ -14,6 +14,7 @@ export const RULE_NAME = 'component-selector';
 export type MessageIds =
   | 'prefixFailure'
   | 'styleFailure'
+  | 'styleAndPrefixFailure'
   | 'typeFailure'
   | 'shadowDomEncapsulatedStyleFailure';
 const STYLE_GUIDE_PREFIX_LINK =
@@ -68,6 +69,7 @@ export default createESLintRule<SelectorUtils.Options, MessageIds>({
     messages: {
       prefixFailure: `The selector should start with one of these prefixes: {{prefix}} (${STYLE_GUIDE_PREFIX_LINK})`,
       styleFailure: `The selector should be {{style}} (${STYLE_GUIDE_STYLE_LINK})`,
+      styleAndPrefixFailure: `The selector should be {{style}} and start with one of these prefixes: {{prefix}} (${STYLE_GUIDE_STYLE_LINK} and ${STYLE_GUIDE_PREFIX_LINK})`,
       typeFailure: `The selector should be used as an {{type}} (${STYLE_GUIDE_TYPE_LINK})`,
       shadowDomEncapsulatedStyleFailure: `The selector of a ShadowDom-encapsulated component should be \`${ASTUtils.OPTION_STYLE_KEBAB_CASE}\` (${SHADOW_DOM_ENCAPSULATED_STYLE_LINK})`,
     },
@@ -122,7 +124,14 @@ export default createESLintRule<SelectorUtils.Options, MessageIds>({
         if (!hasExpectedSelector.hasExpectedType) {
           SelectorUtils.reportTypeError(rawSelectors, type, context);
         } else if (!hasExpectedSelector.hasExpectedStyle) {
-          if (style === overrideStyle) {
+          if (!hasExpectedSelector.hasExpectedPrefix) {
+            SelectorUtils.reportStyleAndPrefixError(
+              rawSelectors,
+              style,
+              prefix,
+              context,
+            );
+          } else if (style === overrideStyle) {
             SelectorUtils.reportStyleError(rawSelectors, style, context);
           } else {
             context.report({

--- a/packages/eslint-plugin/src/rules/pipe-prefix.ts
+++ b/packages/eslint-plugin/src/rules/pipe-prefix.ts
@@ -70,8 +70,8 @@ export default createESLintRule<Options, MessageIds>({
         const allowPrefixesExpression = prefixes.join('|');
         const prefixValidator = SelectorUtils.SelectorValidator.prefix(
           allowPrefixesExpression,
-          'camelCase',
         );
+        const styleValidator = SelectorUtils.SelectorValidator.camelCase;
 
         let nameValue;
 
@@ -88,7 +88,7 @@ export default createESLintRule<Options, MessageIds>({
           return;
         }
 
-        if (!prefixValidator.apply(this, [nameValue])) {
+        if (!prefixValidator.apply(this, [nameValue]) || !styleValidator) {
           context.report({
             node: nameSelector,
             messageId: 'pipePrefix',

--- a/packages/eslint-plugin/src/rules/pipe-prefix.ts
+++ b/packages/eslint-plugin/src/rules/pipe-prefix.ts
@@ -70,8 +70,8 @@ export default createESLintRule<Options, MessageIds>({
         const allowPrefixesExpression = prefixes.join('|');
         const prefixValidator = SelectorUtils.SelectorValidator.prefix(
           allowPrefixesExpression,
+          'camelCase',
         );
-        const styleValidator = SelectorUtils.SelectorValidator.camelCase;
 
         let nameValue;
 
@@ -88,7 +88,7 @@ export default createESLintRule<Options, MessageIds>({
           return;
         }
 
-        if (!prefixValidator.apply(this, [nameValue]) || !styleValidator) {
+        if (!prefixValidator.apply(this, [nameValue])) {
           context.report({
             node: nameSelector,
             messageId: 'pipePrefix',

--- a/packages/eslint-plugin/tests/rules/component-selector/cases.ts
+++ b/packages/eslint-plugin/tests/rules/component-selector/cases.ts
@@ -3,6 +3,7 @@ import type { MessageIds } from '../../../src/rules/component-selector';
 
 const messageIdPrefixFailure: MessageIds = 'prefixFailure';
 const messageIdStyleFailure: MessageIds = 'styleFailure';
+const messageIdStyleAndPrefixFailure: MessageIds = 'styleAndPrefixFailure';
 const messageIdTypeFailure: MessageIds = 'typeFailure';
 const messageIdShadowDomEncapsulatedStyleFailure: MessageIds =
   'shadowDomEncapsulatedStyleFailure';
@@ -223,6 +224,15 @@ export const valid = [
       },
     ],
   },
+  {
+    code: `
+      @Component({
+        selector: 'singleword'
+      })
+      class Test {}
+      `,
+    options: [{ type: 'element', style: 'kebab-case' }],
+  },
 ];
 
 export const invalid = [
@@ -387,5 +397,18 @@ export const invalid = [
       `,
     messageId: messageIdShadowDomEncapsulatedStyleFailure,
     options: [{ type: 'element', prefix: ['app'], style: 'camelCase' }],
+  }),
+  convertAnnotatedSourceToFailureCase({
+    description: `it should fail if a selector is not kebab-cased and is not prefixed by a valid option`,
+    annotatedSource: `
+      @Component({
+        selector: 'root'
+                  ~~~~~~
+      })
+      class Test {}
+      `,
+    messageId: messageIdStyleAndPrefixFailure,
+    options: [{ type: 'element', prefix: ['app', 'toh'], style: 'kebab-case' }],
+    data: { style: 'kebab-case', prefix: '"app" or "toh"' },
   }),
 ];

--- a/packages/eslint-plugin/tests/rules/component-selector/cases.ts
+++ b/packages/eslint-plugin/tests/rules/component-selector/cases.ts
@@ -312,9 +312,9 @@ export const invalid = [
         })
         class Test {}
       `,
-    messageId: messageIdStyleFailure,
+    messageId: messageIdStyleAndPrefixFailure,
     options: [{ type: 'element', prefix: 'app', style: 'kebab-case' }],
-    data: { style: 'kebab-case' },
+    data: { style: 'kebab-case', prefix: '"app"' },
   }),
   convertAnnotatedSourceToFailureCase({
     description: `it should fail if a selector uses kebab-case style, but no dash`,
@@ -399,7 +399,7 @@ export const invalid = [
     options: [{ type: 'element', prefix: ['app'], style: 'camelCase' }],
   }),
   convertAnnotatedSourceToFailureCase({
-    description: `it should fail if a selector is not kebab-cased and is not prefixed by a valid option`,
+    description: `it should fail if a selector is not prefixed by a valid option with the correct case`,
     annotatedSource: `
       @Component({
         selector: 'root'
@@ -410,5 +410,18 @@ export const invalid = [
     messageId: messageIdStyleAndPrefixFailure,
     options: [{ type: 'element', prefix: ['app', 'toh'], style: 'kebab-case' }],
     data: { style: 'kebab-case', prefix: '"app" or "toh"' },
+  }),
+  convertAnnotatedSourceToFailureCase({
+    description: `it should fail if a selector uses kebab-case with an invalid prefix style`,
+    annotatedSource: `
+      @Component({
+        selector: 'sgggg-bar'
+                  ~~~~~~~~~~~
+      })
+      class Test {}
+      `,
+    messageId: messageIdPrefixFailure,
+    options: [{ type: 'element', prefix: 'sg', style: 'kebab-case' }],
+    data: { prefix: '"sg"' },
   }),
 ];

--- a/packages/utils/src/eslint-plugin/selector-utils.ts
+++ b/packages/utils/src/eslint-plugin/selector-utils.ts
@@ -52,13 +52,23 @@ export const SelectorValidator = {
     return /^[a-z0-9-]+-[a-z0-9-]+$/.test(selector);
   },
 
-  prefix(prefix: string): (selector: string) => boolean {
+  prefix(prefix: string, selectorStyle: string): (selector: string) => boolean {
     const regex = new RegExp(`^\\[?(${prefix})`);
 
     return (selector) => {
-      if (prefix && !regex.test(selector)) return false;
+      if (!prefix) return true;
 
-      return true;
+      if (!regex.test(selector)) return false;
+
+      const suffix = selector.replace(regex, '');
+
+      if (selectorStyle === OPTION_STYLE_CAMEL_CASE) {
+        return !suffix || suffix[0] === suffix[0].toUpperCase();
+      } else if (selectorStyle === OPTION_STYLE_KEBAB_CASE) {
+        return !suffix || suffix[0] === '-';
+      }
+
+      throw Error('Invalid selector style!');
     };
   },
 };
@@ -204,7 +214,9 @@ export const checkSelector = (
   const validSelectors = getValidSelectors(listSelectors, types);
 
   const hasExpectedPrefix = validSelectors.some((selector) =>
-    prefixOption.some((prefix) => SelectorValidator.prefix(prefix)(selector)),
+    prefixOption.some((prefix) =>
+      SelectorValidator.prefix(prefix, styleOption)(selector),
+    ),
   );
 
   const hasExpectedStyle = validSelectors.some((selector) =>


### PR DESCRIPTION
...kebab-case

Resolves #318 

This pull request contains the following changes to accommodate the discussion had in #318:
- Add new error message in rule `component-selector` for invalid prefix ***and*** case
- Add test cases to verify the examples posted in the issue