### PR TITLE
fix(utils): use test case filename when specified

### DIFF
--- a/packages/utils/src/rules-tester.ts
+++ b/packages/utils/src/rules-tester.ts
@@ -69,10 +69,9 @@ export class RuleTester extends TSESLint.RuleTester {
         if (typeof test !== 'string' && isValidParser(test.parser)) {
           throw Error(errorMessage);
         }
-        return {
-          ...(typeof test === 'string' ? { code: test } : test),
-          filename: this.filename,
-        };
+        return typeof test === 'string'
+          ? { code: test, filename: this.filename }
+          : { ...test, filename: test.filename ?? this.filename };
       }),
       invalid: invalid.map((test) => {
         if (isValidParser(test.parser)) {
@@ -80,7 +79,7 @@ export class RuleTester extends TSESLint.RuleTester {
         }
         return {
           ...test,
-          filename: this.filename,
+          filename: test.filename ?? this.filename,
         };
       }),
     };


### PR DESCRIPTION
Addresses #898
- For valid and invalid test cases, use the test case's filename if specified, otherwise, use `this.filename`