### PR TITLE
fix(utils): use tsconfigRootDir as root dir when specified

### DIFF
--- a/packages/utils/src/rules-tester.ts
+++ b/packages/utils/src/rules-tester.ts
@@ -33,7 +33,10 @@ export class RuleTester extends TSESLint.RuleTester {
     });
 
     if (options.parserOptions?.project) {
-      this.filename = path.join(getFixturesRootDir(), 'file.ts');
+      this.filename = path.join(
+        options.parserOptions?.tsconfigRootDir ?? getFixturesRootDir(),
+        'file.ts',
+      );
     }
 
     // make sure that the parser doesn't hold onto file handles between tests


### PR DESCRIPTION
Currently, when `options.parserOptions.project` is specified, we set the filename to be `path.join(process.cwd(), 'tests/fixtures/')`. This can be problematic when we run the test from a higher-up parent directory as it will use that as the base directory and look for `'tests/fixtures/file.ts` from there.

Instead, we should use `options.parserOptions.tsconfigRootDir` as the base directory when specified and resolve `file.ts` from there. This is similar to how `@typescript-eslint` does it: https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/utils/src/eslint-utils/rule-tester/RuleTester.ts#L122-L137