### PR TITLE
chore: normalize pkg versions we do not control in snapshots

### DIFF
--- a/.github/workflows/update-integration-tests-for-renovate.yml
+++ b/.github/workflows/update-integration-tests-for-renovate.yml
@@ -33,8 +33,6 @@ jobs:
           declare -a packages=(
             "eslint"
             "@typescript-eslint/parser"
-            "@angular/cli"
-            "@schematics/angular"
           )
 
           for package in "${packages[@]}"

--- a/packages/integration-tests/tests/__snapshots__/v13-new-workspace-create-application-false-ng-add-then-project.test.ts.snap
+++ b/packages/integration-tests/tests/__snapshots__/v13-new-workspace-create-application-false-ng-add-then-project.test.ts.snap
@@ -1,15 +1,15 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`v13-new-workspace-create-application-false-ng-add-then-project it should pass linting when adding a project before running ng-add 2`] = `
-Object {
-  "@angular-devkit/build-angular": "^15.0.2",
+{
+  "@angular-devkit/build-angular": "^15.X.X",
   "@angular-eslint/builder": "9999.0.1-local-integration-tests",
   "@angular-eslint/eslint-plugin": "9999.0.1-local-integration-tests",
   "@angular-eslint/eslint-plugin-template": "9999.0.1-local-integration-tests",
   "@angular-eslint/schematics": "9999.0.1-local-integration-tests",
   "@angular-eslint/template-parser": "9999.0.1-local-integration-tests",
-  "@angular/cli": "~15.0.2",
-  "@angular/compiler-cli": "^15.0.0",
+  "@angular/cli": "~15.X.X",
+  "@angular/compiler-cli": "^15.X.X",
   "@types/jasmine": "~4.3.0",
   "@typescript-eslint/eslint-plugin": "5.45.1",
   "@typescript-eslint/parser": "5.45.1",
@@ -20,7 +20,7 @@ Object {
   "karma-coverage": "~2.2.0",
   "karma-jasmine": "~5.1.0",
   "karma-jasmine-html-reporter": "~2.0.0",
-  "typescript": "~4.8.2",
+  "typescript": "~4.X.X"
 }
 `;
 

--- a/packages/integration-tests/tests/__snapshots__/v13-new-workspace-create-application-false-project-then-ng-add.test.ts.snap
+++ b/packages/integration-tests/tests/__snapshots__/v13-new-workspace-create-application-false-project-then-ng-add.test.ts.snap
@@ -1,15 +1,15 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`v13-new-workspace-create-application-false-project-then-ng-add it should pass linting when ng-add is run before adding a project 2`] = `
-Object {
-  "@angular-devkit/build-angular": "^15.0.2",
+{
+  "@angular-devkit/build-angular": "^15.X.X",
   "@angular-eslint/builder": "9999.0.1-local-integration-tests",
   "@angular-eslint/eslint-plugin": "9999.0.1-local-integration-tests",
   "@angular-eslint/eslint-plugin-template": "9999.0.1-local-integration-tests",
   "@angular-eslint/schematics": "9999.0.1-local-integration-tests",
   "@angular-eslint/template-parser": "9999.0.1-local-integration-tests",
-  "@angular/cli": "~15.0.2",
-  "@angular/compiler-cli": "^15.0.0",
+  "@angular/cli": "~15.X.X",
+  "@angular/compiler-cli": "^15.X.X",
   "@types/jasmine": "~4.3.0",
   "@typescript-eslint/eslint-plugin": "5.45.1",
   "@typescript-eslint/parser": "5.45.1",
@@ -20,7 +20,7 @@ Object {
   "karma-coverage": "~2.2.0",
   "karma-jasmine": "~5.1.0",
   "karma-jasmine-html-reporter": "~2.0.0",
-  "typescript": "~4.8.2",
+  "typescript": "~4.X.X"
 }
 `;
 

--- a/packages/integration-tests/tests/__snapshots__/v13-new-workspace.test.ts.snap
+++ b/packages/integration-tests/tests/__snapshots__/v13-new-workspace.test.ts.snap
@@ -1,15 +1,15 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`v13-new-workspace it should pass linting after creating a new workspace from scratch using @angular-eslint 2`] = `
-Object {
-  "@angular-devkit/build-angular": "^15.0.2",
+{
+  "@angular-devkit/build-angular": "^15.X.X",
   "@angular-eslint/builder": "9999.0.1-local-integration-tests",
   "@angular-eslint/eslint-plugin": "9999.0.1-local-integration-tests",
   "@angular-eslint/eslint-plugin-template": "9999.0.1-local-integration-tests",
   "@angular-eslint/schematics": "9999.0.1-local-integration-tests",
   "@angular-eslint/template-parser": "9999.0.1-local-integration-tests",
-  "@angular/cli": "~15.0.2",
-  "@angular/compiler-cli": "^15.0.0",
+  "@angular/cli": "~15.X.X",
+  "@angular/compiler-cli": "^15.X.X",
   "@types/jasmine": "~4.3.0",
   "@typescript-eslint/eslint-plugin": "5.45.1",
   "@typescript-eslint/parser": "5.45.1",
@@ -20,8 +20,8 @@ Object {
   "karma-coverage": "~2.2.0",
   "karma-jasmine": "~5.1.0",
   "karma-jasmine-html-reporter": "~2.0.0",
-  "ng-packagr": "^15.0.0",
-  "typescript": "~4.8.2",
+  "ng-packagr": "^15.X.X",
+  "typescript": "~4.X.X"
 }
 `;
 

--- a/packages/integration-tests/tests/v13-new-workspace-create-application-false-ng-add-then-project.test.ts
+++ b/packages/integration-tests/tests/v13-new-workspace-create-application-false-ng-add-then-project.test.ts
@@ -9,6 +9,9 @@ import {
 } from '../utils/local-registry-process';
 import { requireUncached } from '../utils/require-uncached';
 import { runLint } from '../utils/run-lint';
+import { normalizeVersionsOfPackagesWeDoNotControl } from '../utils/snapshot-serializers';
+
+expect.addSnapshotSerializer(normalizeVersionsOfPackagesWeDoNotControl);
 
 const fixtureDirectory =
   'v13-new-workspace-create-application-false-ng-add-then-project';
@@ -33,9 +36,13 @@ describe(fixtureDirectory, () => {
       `"Cannot find module '../fixtures/v13-new-workspace-create-application-false-ng-add-then-project/tslint.json' from 'tests/v13-new-workspace-create-application-false-ng-add-then-project.test.ts'"`,
     );
     expect(
-      requireUncached(
-        '../fixtures/v13-new-workspace-create-application-false-ng-add-then-project/package.json',
-      ).devDependencies,
+      JSON.stringify(
+        requireUncached(
+          '../fixtures/v13-new-workspace-create-application-false-ng-add-then-project/package.json',
+        ).devDependencies,
+        null,
+        2,
+      ),
     ).toMatchSnapshot();
 
     // Root eslint config

--- a/packages/integration-tests/tests/v13-new-workspace-create-application-false-project-then-ng-add.test.ts
+++ b/packages/integration-tests/tests/v13-new-workspace-create-application-false-project-then-ng-add.test.ts
@@ -9,6 +9,9 @@ import {
 } from '../utils/local-registry-process';
 import { requireUncached } from '../utils/require-uncached';
 import { runLint } from '../utils/run-lint';
+import { normalizeVersionsOfPackagesWeDoNotControl } from '../utils/snapshot-serializers';
+
+expect.addSnapshotSerializer(normalizeVersionsOfPackagesWeDoNotControl);
 
 const fixtureDirectory =
   'v13-new-workspace-create-application-false-project-then-ng-add';
@@ -33,9 +36,13 @@ describe(fixtureDirectory, () => {
       `"Cannot find module '../fixtures/v13-new-workspace-create-application-false-project-then-ng-add/tslint.json' from 'tests/v13-new-workspace-create-application-false-project-then-ng-add.test.ts'"`,
     );
     expect(
-      requireUncached(
-        '../fixtures/v13-new-workspace-create-application-false-project-then-ng-add/package.json',
-      ).devDependencies,
+      JSON.stringify(
+        requireUncached(
+          '../fixtures/v13-new-workspace-create-application-false-project-then-ng-add/package.json',
+        ).devDependencies,
+        null,
+        2,
+      ),
     ).toMatchSnapshot();
 
     // Root eslint config

--- a/packages/integration-tests/tests/v13-new-workspace.test.ts
+++ b/packages/integration-tests/tests/v13-new-workspace.test.ts
@@ -9,6 +9,9 @@ import {
 } from '../utils/local-registry-process';
 import { requireUncached } from '../utils/require-uncached';
 import { runLint } from '../utils/run-lint';
+import { normalizeVersionsOfPackagesWeDoNotControl } from '../utils/snapshot-serializers';
+
+expect.addSnapshotSerializer(normalizeVersionsOfPackagesWeDoNotControl);
 
 const fixtureDirectory = 'v13-new-workspace';
 
@@ -33,8 +36,12 @@ describe(fixtureDirectory, () => {
       `"Cannot find module '../fixtures/v13-new-workspace/tslint.json' from 'tests/v13-new-workspace.test.ts'"`,
     );
     expect(
-      requireUncached('../fixtures/v13-new-workspace/package.json')
-        .devDependencies,
+      JSON.stringify(
+        requireUncached('../fixtures/v13-new-workspace/package.json')
+          .devDependencies,
+        null,
+        2,
+      ),
     ).toMatchSnapshot();
 
     // Root project

--- a/packages/integration-tests/utils/snapshot-serializers.ts
+++ b/packages/integration-tests/utils/snapshot-serializers.ts
@@ -1,0 +1,39 @@
+function escapeRegExp(str: string) {
+  return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function normalizeVersionOfPackage(str: string, pkg: string) {
+  const regex = new RegExp(
+    `("${escapeRegExp(pkg)}": "[~|^]\\d\\d?\\.)(\\d.\\d)"`,
+  );
+  return str.replace(regex, '$1X.X"');
+}
+
+const dependenciesToNormalize = [
+  '@angular-devkit/build-angular',
+  '@angular/cli',
+  '@angular/compiler-cli',
+  'ng-packagr',
+  'typescript',
+];
+
+/**
+ * Normalize dependencies controlled by the Angular CLI so that only the major version is explicitly
+ * checked so that we can massively cut down on snapshot update noise across PRs.
+ */
+export const normalizeVersionsOfPackagesWeDoNotControl = {
+  serialize(str: string) {
+    for (const pkg of dependenciesToNormalize) {
+      str = normalizeVersionOfPackage(str, pkg);
+    }
+    return str;
+  },
+  test(val: string) {
+    // Only run if we think it's package.json contents
+    return (
+      val != null &&
+      typeof val === 'string' &&
+      dependenciesToNormalize.some((pkg) => val.includes(`"${pkg}"`))
+    );
+  },
+};


### PR DESCRIPTION
There is a frustrating amount of friction in some integration test snapshots currently because of minor or patch version bumps happening via the Angular CLI tooling. We do not control these so there is no great value in tracking them granularly within snapshots.

This PR adds custom serialization logic to normalize the relevant minor and patch versions (we still want to catch and deal with any major version changes)