### PR TITLE
feat(es-plugin-template): create `accessibility` config

### DIFF
--- a/packages/eslint-plugin-template/src/configs/README.md
+++ b/packages/eslint-plugin-template/src/configs/README.md
@@ -36,3 +36,13 @@ If you disagree with a rule (or it disagrees with your codebase), consider using
 ### Suggesting changes to the recommended set
 
 If you feel _very_, **very**, **_very_** strongly that a specific rule should (or should not) be in the recommended ruleset, please feel free to file an issue along with a **detailed** argument explaining your reasoning. We expect to see you citing concrete evidence supporting why (or why not) a rule is considered best practice. **Please note that if your reasoning is along the lines of "it's what my project/company does", or "I don't like the rule", then we will likely close the request without discussion.**
+
+## `accessibility`
+
+This config is a set of rules designed to improve the accessibility of your application.
+
+These rules are based on a number of best practice recommendations and resources including:
+
+- [W3C - Web Accessibility Initiative (WAI)](https://www.w3.org/WAI/)
+- [Mozilla Developer Network - Accessibility](https://developer.mozilla.org/en-US/docs/Web/Accessibility)
+- [Google Chrome - Audit Rules](https://github.com/GoogleChrome/accessibility-developer-tools/wiki/Audit-Rules)

--- a/packages/eslint-plugin-template/src/configs/accessibility.json
+++ b/packages/eslint-plugin-template/src/configs/accessibility.json
@@ -1,0 +1,18 @@
+{
+  "extends": "./configs/base.json",
+  "rules": {
+    "@angular-eslint/template/accessibility-alt-text": "error",
+    "@angular-eslint/template/accessibility-elements-content": "error",
+    "@angular-eslint/template/accessibility-interactive-supports-focus": "error",
+    "@angular-eslint/template/accessibility-label-for": "error",
+    "@angular-eslint/template/accessibility-label-has-associated-control": "error",
+    "@angular-eslint/template/accessibility-role-has-required-aria": "error",
+    "@angular-eslint/template/accessibility-table-scope": "error",
+    "@angular-eslint/template/accessibility-valid-aria": "error",
+    "@angular-eslint/template/click-events-have-key-events": "error",
+    "@angular-eslint/template/mouse-events-have-key-events": "error",
+    "@angular-eslint/template/no-autofocus": "error",
+    "@angular-eslint/template/no-distracting-elements": "error",
+    "@angular-eslint/template/no-positive-tabindex": "error"
+  }
+}

--- a/packages/eslint-plugin-template/src/index.ts
+++ b/packages/eslint-plugin-template/src/index.ts
@@ -2,6 +2,7 @@ import all from './configs/all.json';
 import base from './configs/base.json';
 import processInlineTemplates from './configs/process-inline-templates.json';
 import recommended from './configs/recommended.json';
+import accessibility from './configs/accessibility.json';
 import processors from './processors';
 import accessibilityAltText, {
   RULE_NAME as accessibilityAltTextRuleName,
@@ -85,6 +86,7 @@ export default {
     base,
     recommended,
     'process-inline-templates': processInlineTemplates,
+    accessibility,
   },
   processors,
   rules: {

--- a/packages/eslint-plugin-template/tests/configs.test.ts
+++ b/packages/eslint-plugin-template/tests/configs.test.ts
@@ -80,4 +80,24 @@ describe('configs', () => {
       ).toBe(true);
     });
   });
+
+  describe('accessibility', () => {
+    it('should only contain valid rules', () => {
+      expect(
+        Object.keys(eslintPluginTemplate.configs.accessibility.rules)
+          .filter((ruleName) =>
+            ruleName.startsWith(ESLINT_PLUGIN_TEMPLATE_PREFIX),
+          )
+          .every((ruleName) =>
+            Boolean(
+              eslintPluginTemplate.rules[
+                ruleName.slice(
+                  ESLINT_PLUGIN_TEMPLATE_PREFIX.length,
+                ) as keyof typeof eslintPluginTemplate.rules
+              ],
+            ),
+          ),
+      ).toBe(true);
+    });
+  });
 });


### PR DESCRIPTION
As suggested in https://github.com/angular-eslint/angular-eslint/issues/238#issuecomment-911594948, create a new `accessibility` preset so that each accessibility rule doesn't have to be enabled individually.