### PR TITLE
fix: allow the combination of the "map binding" and "static value" use of the `style` and `class` attributes

### DIFF
--- a/packages/eslint-plugin-template/docs/rules/no-duplicate-attributes.md
+++ b/packages/eslint-plugin-template/docs/rules/no-duplicate-attributes.md
@@ -367,7 +367,7 @@ interface Options {
       "error",
       {
         "ignore": [
-          "class"
+          "placeholder"
         ]
       }
     ]
@@ -380,8 +380,62 @@ interface Options {
 #### ❌ Invalid Code
 
 ```html
-<input [name]="foo" class="css-static" name="bar" [class]="dynamic">
-       ~~~~~~~~~~~~                    ~~~~~~~~~~
+<input [name]="foo" placeholder="foo..." name="bar" [placeholder]="dynamic">
+       ~~~~~~~~~~~~                      ~~~~~~~~~~
+```
+
+<br>
+
+---
+
+<br>
+
+#### Default Config
+
+```json
+{
+  "rules": {
+    "@angular-eslint/template/no-duplicate-attributes": [
+      "error"
+    ]
+  }
+}
+```
+
+<br>
+
+#### ❌ Invalid Code
+
+```html
+<input class="foo" class="bar" [class]="dynamic">
+       ~~~~~~~~~~~ ~~~~~~~~~~~
+```
+
+<br>
+
+---
+
+<br>
+
+#### Default Config
+
+```json
+{
+  "rules": {
+    "@angular-eslint/template/no-duplicate-attributes": [
+      "error"
+    ]
+  }
+}
+```
+
+<br>
+
+#### ❌ Invalid Code
+
+```html
+<input style="color: blue" [style]="styleExpression" style="width:50px">
+       ~~~~~~~~~~~~~~~~~~~                           ~~~~~~~~~~~~~~~~~~
 ```
 
 </details>
@@ -675,6 +729,58 @@ interface Options {
 
 ```html
 <div [style.width]="col.width + 'px'" [width]="col.width"></div>
+```
+
+<br>
+
+---
+
+<br>
+
+#### Default Config
+
+```json
+{
+  "rules": {
+    "@angular-eslint/template/no-duplicate-attributes": [
+      "error"
+    ]
+  }
+}
+```
+
+<br>
+
+#### ✅ Valid Code
+
+```html
+<div class="foo" name="bar" [class]="dynamic"></div>
+```
+
+<br>
+
+---
+
+<br>
+
+#### Default Config
+
+```json
+{
+  "rules": {
+    "@angular-eslint/template/no-duplicate-attributes": [
+      "error"
+    ]
+  }
+}
+```
+
+<br>
+
+#### ✅ Valid Code
+
+```html
+<div style="color: blue" [style]="styleExpression"></div>
 ```
 
 </details>

--- a/packages/eslint-plugin-template/tests/rules/no-duplicate-attributes/cases.ts
+++ b/packages/eslint-plugin-template/tests/rules/no-duplicate-attributes/cases.ts
@@ -16,6 +16,10 @@ export const valid = [
   '<button [class.disabled]="!enabled" [disabled]="!enabled"></button>',
   '<button [@.disabled]="!enabled" [.disabled]="!enabled"></button>',
   '<div [style.width]="col.width + \'px\'" [width]="col.width"></div>',
+  // It should allow the combination of the "map binding" and "static value" for class attribute
+  '<div class="foo" name="bar" [class]="dynamic"></div>',
+  // It should allow the combination of the "map binding" and "static value" for style attribute
+  '<div style="color: blue" [style]="styleExpression"></div>',
 ];
 
 export const invalid = [
@@ -499,10 +503,10 @@ export const invalid = [
   convertAnnotatedSourceToFailureCase({
     description: 'should not report ignored properties',
     annotatedSource: `
-        <input [name]="foo" class="css-static" name="bar" [class]="dynamic">
-               ~~~~~~~~~~~~                    ^^^^^^^^^^
+        <input [name]="foo" placeholder="foo..." name="bar" [placeholder]="dynamic">
+               ~~~~~~~~~~~~                      ^^^^^^^^^^     
       `,
-    options: [{ ignore: ['class'] }],
+    options: [{ ignore: ['placeholder'] }],
     messages: [
       {
         char: '~',
@@ -512,8 +516,8 @@ export const invalid = [
           {
             messageId: suggestRemoveAttribute,
             output: `
-        <input class="css-static" name="bar" [class]="dynamic">
-                                               
+        <input placeholder="foo..." name="bar" [placeholder]="dynamic">
+                                                      
       `,
             data: { attributeName: 'name' },
           },
@@ -527,10 +531,88 @@ export const invalid = [
           {
             messageId: suggestRemoveAttribute,
             output: `
-        <input [name]="foo" class="css-static" [class]="dynamic">
-                                               
+        <input [name]="foo" placeholder="foo..." [placeholder]="dynamic">
+                                                      
       `,
             data: { attributeName: 'name' },
+          },
+        ],
+      },
+    ],
+  }),
+  convertAnnotatedSourceToFailureCase({
+    description: 'should report duplicate static binding for class attribute',
+    annotatedSource: `
+        <input class="foo" class="bar" [class]="dynamic">
+               ~~~~~~~~~~~ ^^^^^^^^^^^     
+      `,
+    messages: [
+      {
+        char: '~',
+        messageId,
+        data: { attributeName: 'class' },
+        suggestions: [
+          {
+            messageId: suggestRemoveAttribute,
+            output: `
+        <input class="bar" [class]="dynamic">
+                                
+      `,
+            data: { attributeName: 'class' },
+          },
+        ],
+      },
+      {
+        char: '^',
+        messageId,
+        data: { attributeName: 'class' },
+        suggestions: [
+          {
+            messageId: suggestRemoveAttribute,
+            output: `
+        <input class="foo" [class]="dynamic">
+                                
+      `,
+            data: { attributeName: 'class' },
+          },
+        ],
+      },
+    ],
+  }),
+  convertAnnotatedSourceToFailureCase({
+    description: 'should report duplicate static binding for style attribute',
+    annotatedSource: `
+        <input style="color: blue" [style]="styleExpression" style="width:50px">
+               ~~~~~~~~~~~~~~~~~~~                           ^^^^^^^^^^^^^^^^^^
+      `,
+    messages: [
+      {
+        char: '~',
+        messageId,
+        data: { attributeName: 'style' },
+        suggestions: [
+          {
+            messageId: suggestRemoveAttribute,
+            output: `
+        <input [style]="styleExpression" style="width:50px">
+                                                             
+      `,
+            data: { attributeName: 'style' },
+          },
+        ],
+      },
+      {
+        char: '^',
+        messageId,
+        data: { attributeName: 'style' },
+        suggestions: [
+          {
+            messageId: suggestRemoveAttribute,
+            output: `
+        <input style="color: blue" [style]="styleExpression">
+                                                             
+      `,
+            data: { attributeName: 'style' },
           },
         ],
       },


### PR DESCRIPTION
## Description

Allow the combination of the "map binding" and "static value" use of the `style` and `class` attributes : 

My proposition is not the best, I found another solution but in `angular/compiler` library, the `TmplAstTextAttribute` type doesn't contain the `type` attribute instead of other types (`TmplAstBoundEvent` and `TmplAstBoundAttribute`). 

If type was available, we could simple do : 

```ts
function findDuplicates<
  TAttributeType extends
    | TmplAstBoundEvent
    | TmplAstBoundAttribute
    | TmplAstTextAttribute,
>(elements: readonly TAttributeType[]): readonly TAttributeType[] {
  // According to the Angular documentation (https://angular.io/guide/style-precedence#style-precedence)
  // Angular merges both attributes which means their combined use is valid
  const mapAndStaticBindingAttributesAllowed = ['class', 'style'];
  return elements.filter((element) => {
    return elements.some((otherElement) => {
      if (
        mapAndStaticBindingAttributesAllowed.includes(
          getOriginalAttributeName(element),
        )
      ) {
        return (
          otherElement !== element &&
          getOriginalAttributeName(otherElement) ===
            getOriginalAttributeName(element) &&
          otherElement.type !== element.type
        );
      } else {
        return (
          otherElement !== element &&
          getOriginalAttributeName(otherElement) ===
            getOriginalAttributeName(element)
        );
      }
    });
  });
}
```

----

fixes #1406