### PR TITLE
fix(angular-eslint): no output rename and metadata property

### DIFF
--- a/packages/eslint-plugin/docs/rules/no-output-rename.md
+++ b/packages/eslint-plugin/docs/rules/no-output-rename.md
@@ -726,6 +726,105 @@ class Test {
 #### ✅ Valid Code
 
 ```ts
+@Component({
+  selector: 'foo',
+  hostDirectives: [{
+    directive: CdkMenuItem,
+    outputs: ['cdkMenuItemTriggered: triggered'],
+  }]
+})
+class Test {}
+```
+
+<br>
+
+---
+
+<br>
+
+#### Default Config
+
+```json
+{
+  "rules": {
+    "@angular-eslint/no-output-rename": [
+      "error"
+    ]
+  }
+}
+```
+
+<br>
+
+#### ✅ Valid Code
+
+```ts
+@Component({
+  selector: 'foo',
+  'hostDirectives': [{
+    directive: CdkMenuItem,
+    outputs: ['cdkMenuItemTriggered: triggered'],
+  }]
+})
+class Test {}
+```
+
+<br>
+
+---
+
+<br>
+
+#### Default Config
+
+```json
+{
+  "rules": {
+    "@angular-eslint/no-output-rename": [
+      "error"
+    ]
+  }
+}
+```
+
+<br>
+
+#### ✅ Valid Code
+
+```ts
+@Component({
+  selector: 'foo',
+  ['hostDirectives']: [{
+    directive: CdkMenuItem,
+    outputs: ['cdkMenuItemTriggered: triggered'],
+  }]
+})
+class Test {}
+```
+
+<br>
+
+---
+
+<br>
+
+#### Default Config
+
+```json
+{
+  "rules": {
+    "@angular-eslint/no-output-rename": [
+      "error"
+    ]
+  }
+}
+```
+
+<br>
+
+#### ✅ Valid Code
+
+```ts
 @Directive({
   selector: 'foo'
 })

--- a/packages/eslint-plugin/docs/rules/no-outputs-metadata-property.md
+++ b/packages/eslint-plugin/docs/rules/no-outputs-metadata-property.md
@@ -489,6 +489,105 @@ class Test {}
 class Test {}
 ```
 
+<br>
+
+---
+
+<br>
+
+#### Default Config
+
+```json
+{
+  "rules": {
+    "@angular-eslint/no-outputs-metadata-property": [
+      "error"
+    ]
+  }
+}
+```
+
+<br>
+
+#### ✅ Valid Code
+
+```ts
+@Component({
+  selector: 'foo',
+  hostDirectives: [{
+    directive: CdkMenuItem,
+    outputs: ['cdkMenuItemTriggered: triggered'],
+  }]
+})
+class Test {}
+```
+
+<br>
+
+---
+
+<br>
+
+#### Default Config
+
+```json
+{
+  "rules": {
+    "@angular-eslint/no-outputs-metadata-property": [
+      "error"
+    ]
+  }
+}
+```
+
+<br>
+
+#### ✅ Valid Code
+
+```ts
+@Component({
+  selector: 'foo',
+  'hostDirectives': [{
+    directive: CdkMenuItem,
+    outputs: ['cdkMenuItemTriggered: triggered'],
+  }]
+})
+class Test {}
+```
+
+<br>
+
+---
+
+<br>
+
+#### Default Config
+
+```json
+{
+  "rules": {
+    "@angular-eslint/no-outputs-metadata-property": [
+      "error"
+    ]
+  }
+}
+```
+
+<br>
+
+#### ✅ Valid Code
+
+```ts
+@Component({
+  selector: 'foo',
+  ['hostDirectives']: [{
+    directive: CdkMenuItem,
+    outputs: ['cdkMenuItemTriggered: triggered'],
+  }]
+})
+class Test {}
+```
+
 </details>
 
 <br>

--- a/packages/eslint-plugin/src/rules/no-output-rename.ts
+++ b/packages/eslint-plugin/src/rules/no-output-rename.ts
@@ -98,6 +98,28 @@ export default createESLintRule<Options, MessageIds>({
       [Selectors.OUTPUTS_METADATA_PROPERTY_LITERAL](
         node: TSESTree.Literal | TSESTree.TemplateElement,
       ) {
+        const ancestorMaybeHostDirectiveAPI = node.parent?.parent?.parent;
+        if (
+          ancestorMaybeHostDirectiveAPI &&
+          ASTUtils.isProperty(ancestorMaybeHostDirectiveAPI)
+        ) {
+          /**
+           * Angular v15 introduced the directive composition API: https://angular.io/guide/directive-composition-api
+           * Renaming host directive outputs using this API is not a bad practice and should not be reported
+           */
+          const hostDirectiveAPIPropertyName = 'hostDirectives';
+          if (
+            (ASTUtils.isLiteral(ancestorMaybeHostDirectiveAPI.key) &&
+              ancestorMaybeHostDirectiveAPI.key.value ===
+                hostDirectiveAPIPropertyName) ||
+            (TSESLintASTUtils.isIdentifier(ancestorMaybeHostDirectiveAPI.key) &&
+              ancestorMaybeHostDirectiveAPI.key.name ===
+                hostDirectiveAPIPropertyName)
+          ) {
+            return;
+          }
+        }
+
         const [propertyName, aliasName] = withoutBracketsAndWhitespaces(
           ASTUtils.getRawText(node),
         ).split(':');

--- a/packages/eslint-plugin/src/rules/no-outputs-metadata-property.ts
+++ b/packages/eslint-plugin/src/rules/no-outputs-metadata-property.ts
@@ -1,5 +1,6 @@
-import { Selectors } from '@angular-eslint/utils';
+import { ASTUtils, Selectors } from '@angular-eslint/utils';
 import type { TSESTree } from '@typescript-eslint/utils';
+import { ASTUtils as TSESLintASTUtils } from '@typescript-eslint/utils';
 import { createESLintRule } from '../utils/create-eslint-rule';
 
 type Options = [];
@@ -29,6 +30,30 @@ export default createESLintRule<Options, MessageIds>({
       } ${Selectors.metadataProperty(METADATA_PROPERTY_NAME)}`](
         node: TSESTree.Property,
       ) {
+        /**
+         * Angular v15 introduced the directive composition API: https://angular.io/guide/directive-composition-api
+         * Using host directive outputs using this API is not a bad practice and should not be reported
+         */
+        const ancestorMayBeHostDirectiveAPI = node.parent?.parent?.parent;
+
+        if (
+          ancestorMayBeHostDirectiveAPI &&
+          ASTUtils.isProperty(ancestorMayBeHostDirectiveAPI)
+        ) {
+          const hostDirectiveAPIPropertyName = 'hostDirectives';
+
+          if (
+            (ASTUtils.isLiteral(ancestorMayBeHostDirectiveAPI.key) &&
+              ancestorMayBeHostDirectiveAPI.key.value ===
+                hostDirectiveAPIPropertyName) ||
+            (TSESLintASTUtils.isIdentifier(ancestorMayBeHostDirectiveAPI.key) &&
+              ancestorMayBeHostDirectiveAPI.key.name ===
+                hostDirectiveAPIPropertyName)
+          ) {
+            return;
+          }
+        }
+
         context.report({
           node,
           messageId: 'noOutputsMetadataProperty',

--- a/packages/eslint-plugin/tests/rules/no-output-rename/cases.ts
+++ b/packages/eslint-plugin/tests/rules/no-output-rename/cases.ts
@@ -108,6 +108,40 @@ export const valid = [
       @Output('foo') label: string;
     }
     `,
+  /**
+   * Renaming outputs when using the directive composition API is not a bad practice
+   * https://angular.io/guide/directive-composition-api
+   */
+  `
+    @Component({
+      selector: 'foo',
+      hostDirectives: [{
+        directive: CdkMenuItem,
+        outputs: ['cdkMenuItemTriggered: triggered'],
+      }]
+    })
+    class Test {}
+  `,
+  `
+    @Component({
+      selector: 'foo',
+      'hostDirectives': [{
+        directive: CdkMenuItem,
+        outputs: ['cdkMenuItemTriggered: triggered'],
+      }]
+    })
+    class Test {}
+  `,
+  `
+    @Component({
+      selector: 'foo',
+      ['hostDirectives']: [{
+        directive: CdkMenuItem,
+        outputs: ['cdkMenuItemTriggered: triggered'],
+      }]
+    })
+    class Test {}
+  `,
   `
     @Directive({
       selector: 'foo'

--- a/packages/eslint-plugin/tests/rules/no-outputs-metadata-property/cases.ts
+++ b/packages/eslint-plugin/tests/rules/no-outputs-metadata-property/cases.ts
@@ -45,6 +45,40 @@ export const valid = [
     })
     class Test {}
     `,
+  /**
+   * Renaming outputs when using the directive composition API is not a bad practice
+   * https://angular.io/guide/directive-composition-api
+   */
+  `
+    @Component({
+      selector: 'foo',
+      hostDirectives: [{
+        directive: CdkMenuItem,
+        outputs: ['cdkMenuItemTriggered: triggered'],
+      }]
+    })
+    class Test {}
+  `,
+  `
+    @Component({
+      selector: 'foo',
+      'hostDirectives': [{
+        directive: CdkMenuItem,
+        outputs: ['cdkMenuItemTriggered: triggered'],
+      }]
+    })
+    class Test {}
+  `,
+  `
+    @Component({
+      selector: 'foo',
+      ['hostDirectives']: [{
+        directive: CdkMenuItem,
+        outputs: ['cdkMenuItemTriggered: triggered'],
+      }]
+    })
+    class Test {}
+  `,
 ];
 
 export const invalid = [


### PR DESCRIPTION
I noticed that there are cases for the `no-input-rename` https://github.com/angular-eslint/angular-eslint/pull/1231 and `no-inputs-metadata-property` https://github.com/angular-eslint/angular-eslint/pull/1248, but there are no cases for the `no-output-rename` and `no-outputs-metadata-property`.

This PR has code almost identical ("borrowed" 🤭) from the above-mentioned PRs