### PR TITLE
fix(eslint-plugin): export require-localize-metadata rule

### DIFF
--- a/packages/eslint-plugin/src/configs/all.json
+++ b/packages/eslint-plugin/src/configs/all.json
@@ -29,6 +29,7 @@
     "@angular-eslint/prefer-output-readonly": "error",
     "@angular-eslint/prefer-standalone-component": "error",
     "@angular-eslint/relative-url-prefix": "error",
+    "@angular-eslint/require-localize-metadata": "error",
     "@angular-eslint/sort-ngmodule-metadata-arrays": "error",
     "@angular-eslint/use-component-selector": "error",
     "@angular-eslint/use-component-view-encapsulation": "error",

--- a/packages/eslint-plugin/src/index.ts
+++ b/packages/eslint-plugin/src/index.ts
@@ -73,15 +73,18 @@ import pipePrefix, {
 import preferOnPushComponentChangeDetection, {
   RULE_NAME as preferOnPushComponentChangeDetectionRuleName,
 } from './rules/prefer-on-push-component-change-detection';
-import preferStandaloneComponent, {
-  RULE_NAME as preferStandaloneComponentRuleName,
-} from './rules/prefer-standalone-component';
 import preferOutputReadonly, {
   RULE_NAME as preferOutputReadonlyRuleName,
 } from './rules/prefer-output-readonly';
+import preferStandaloneComponent, {
+  RULE_NAME as preferStandaloneComponentRuleName,
+} from './rules/prefer-standalone-component';
 import relativeUrlPrefix, {
   RULE_NAME as relativeUrlPrefixRuleName,
 } from './rules/relative-url-prefix';
+import requireLocalizeMetadata, {
+  RULE_NAME as requireLocalizeMetadataRuleName,
+} from './rules/require-localize-metadata';
 import sortNgmoduleMetadataArrays, {
   RULE_NAME as sortNgmoduleMetadataArraysName,
 } from './rules/sort-ngmodule-metadata-arrays';
@@ -132,9 +135,10 @@ export = {
     [pipePrefixRuleName]: pipePrefix,
     [preferOnPushComponentChangeDetectionRuleName]:
       preferOnPushComponentChangeDetection,
-    [preferStandaloneComponentRuleName]: preferStandaloneComponent,
     [preferOutputReadonlyRuleName]: preferOutputReadonly,
+    [preferStandaloneComponentRuleName]: preferStandaloneComponent,
     [relativeUrlPrefixRuleName]: relativeUrlPrefix,
+    [requireLocalizeMetadataRuleName]: requireLocalizeMetadata,
     [sortNgmoduleMetadataArraysName]: sortNgmoduleMetadataArrays,
     [useComponentSelectorRuleName]: useComponentSelector,
     [useComponentViewEncapsulationRuleName]: useComponentViewEncapsulation,


### PR DESCRIPTION
Prevents the `Definition for rule '@angular-eslint/require-localize-metadata' was not found` ESLint error.

Also, fix sorted order for the `prefer-standalone-component` rule.