### PR TITLE
feat(eslint-plugin-template): allow `alias` option in [use-track-by-function]

### DIFF
--- a/packages/eslint-plugin-template/docs/rules/use-track-by-function.md
+++ b/packages/eslint-plugin-template/docs/rules/use-track-by-function.md
@@ -79,6 +79,42 @@ interface Options {
 
 <br>
 
+#### Custom Config
+
+```json
+{
+  "rules": {
+    "@angular-eslint/template/use-track-by-function": [
+      "error",
+      {
+        "alias": [
+          "ngForTrackByProperty"
+        ]
+      }
+    ]
+  }
+}
+```
+
+<br>
+
+#### ❌ Invalid Code
+
+```html
+<ul>
+  <li *ngFor="let item of [1, 2, 3];">
+      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    {{ item }}
+  </li>
+</ul>
+```
+
+<br>
+
+---
+
+<br>
+
 #### Default Config
 
 ```json
@@ -86,6 +122,40 @@ interface Options {
   "rules": {
     "@angular-eslint/template/use-track-by-function": [
       "error"
+    ]
+  }
+}
+```
+
+<br>
+
+#### ❌ Invalid Code
+
+```html
+<ng-template ngFor let-item [ngForOf]="[1, 2, 3]" let-i="index">
+                            ~~~~~~~~~~~~~~~~~~~~~
+  {{ item }}
+</ng-template>
+```
+
+<br>
+
+---
+
+<br>
+
+#### Custom Config
+
+```json
+{
+  "rules": {
+    "@angular-eslint/template/use-track-by-function": [
+      "error",
+      {
+        "alias": [
+          "ngForTrackByProperty"
+        ]
+      }
     ]
   }
 }
@@ -167,6 +237,48 @@ interface Options {
                             ~~~~~~~~~~~~~~~~~~~~~
   {{ item }}
 </ng-template>
+```
+
+<br>
+
+---
+
+<br>
+
+#### Custom Config
+
+```json
+{
+  "rules": {
+    "@angular-eslint/template/use-track-by-function": [
+      "error",
+      {
+        "alias": [
+          "ngForTrackByProperty"
+        ]
+      }
+    ]
+  }
+}
+```
+
+<br>
+
+#### ❌ Invalid Code
+
+```html
+<div *ngFor="let item of [1, 2, 3]; trackBy: trackByFn">
+  {{ item }}
+</div>
+<div *ngFor="let item of [1, 2, 3]; trackByProperty: trackByFn">
+  {{ item }}
+</div>
+<ul>
+  <li *ngFor="let item of [1, 2, 3];">
+      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    {{ item }}
+  </li>
+</ul>
 ```
 
 </details>
@@ -472,6 +584,39 @@ interface Options {
 
 ```html
 <div *ngFor="let photo of photos; trackById"></div>
+```
+
+<br>
+
+---
+
+<br>
+
+#### Custom Config
+
+```json
+{
+  "rules": {
+    "@angular-eslint/template/use-track-by-function": [
+      "error",
+      {
+        "alias": [
+          "ngForTrackByProperty"
+        ]
+      }
+    ]
+  }
+}
+```
+
+<br>
+
+#### ✅ Valid Code
+
+```html
+<ng-template ngFor let-item [ngForOf]="[1, 2, 3]" let-i="index" [ngForTrackByProperty]="trackByFn">
+  {{ item }}
+</ng-template>
 ```
 
 </details>

--- a/packages/eslint-plugin-template/docs/rules/use-track-by-function.md
+++ b/packages/eslint-plugin-template/docs/rules/use-track-by-function.md
@@ -23,7 +23,17 @@ Ensures trackBy function is used
 
 ## Rule Options
 
-The rule does not have any configuration options.
+The rule accepts an options object with the following properties:
+
+```ts
+interface Options {
+  /**
+   * Default: `[]`
+   */
+  alias?: string[];
+}
+
+```
 
 <br>
 
@@ -396,6 +406,72 @@ The rule does not have any configuration options.
   let i = index;
   trackBy : trackByFn
 ">
+```
+
+<br>
+
+---
+
+<br>
+
+#### Custom Config
+
+```json
+{
+  "rules": {
+    "@angular-eslint/template/use-track-by-function": [
+      "error",
+      {
+        "alias": [
+          "ngForTrackByProperty"
+        ]
+      }
+    ]
+  }
+}
+```
+
+<br>
+
+#### ✅ Valid Code
+
+```html
+<div *ngFor="
+  let item of [1, 2, 3];
+  let i = index;
+  trackByProperty: 'id'
+">
+```
+
+<br>
+
+---
+
+<br>
+
+#### Custom Config
+
+```json
+{
+  "rules": {
+    "@angular-eslint/template/use-track-by-function": [
+      "error",
+      {
+        "alias": [
+          "ngForTrackById"
+        ]
+      }
+    ]
+  }
+}
+```
+
+<br>
+
+#### ✅ Valid Code
+
+```html
+<div *ngFor="let photo of photos; trackById"></div>
 ```
 
 </details>

--- a/packages/eslint-plugin-template/jest.config.ts
+++ b/packages/eslint-plugin-template/jest.config.ts
@@ -4,13 +4,13 @@
 export default {
   displayName: 'eslint-plugin-template',
   preset: '../../jest.preset.js',
-  globals: {
-    'ts-jest': {
-      tsconfig: '<rootDir>/tsconfig.spec.json',
-    },
-  },
   transform: {
-    '^.+\\.tsx?$': 'ts-jest',
+    '^.+\\.tsx?$': [
+      'ts-jest',
+      {
+        tsconfig: '<rootDir>/tsconfig.spec.json',
+      },
+    ],
   },
   moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx'],
   coverageDirectory: '../../coverage/packages/eslint-plugin-template',

--- a/packages/eslint-plugin-template/tests/rules/use-track-by-function/cases.ts
+++ b/packages/eslint-plugin-template/tests/rules/use-track-by-function/cases.ts
@@ -68,6 +68,14 @@ export const valid = [
       <div *ngFor="let photo of photos; trackById"></div>
     `,
   },
+  {
+    options: [{ alias: ['ngForTrackByProperty'] }],
+    code: `
+      <ng-template ngFor let-item [ngForOf]="[1, 2, 3]" let-i="index" [ngForTrackByProperty]="trackByFn">
+        {{ item }}
+      </ng-template>
+    `,
+  },
 ];
 
 export const invalid = [
@@ -84,7 +92,33 @@ export const invalid = [
     messageId,
   }),
   convertAnnotatedSourceToFailureCase({
+    description:
+      'should fail when trackBy function (`ngForTrackByProperty` alias) is not present',
+    options: [{ alias: ['ngForTrackByProperty'] }],
+    annotatedSource: `
+        <ul>
+          <li *ngFor="let item of [1, 2, 3];">
+              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+            {{ item }}
+          </li>
+        </ul>
+      `,
+    messageId,
+  }),
+  convertAnnotatedSourceToFailureCase({
     description: 'should fail when [ngForTrackBy] is missing in ng-template',
+    annotatedSource: `
+        <ng-template ngFor let-item [ngForOf]="[1, 2, 3]" let-i="index">
+                                    ~~~~~~~~~~~~~~~~~~~~~
+          {{ item }}
+        </ng-template>
+      `,
+    messageId,
+  }),
+  convertAnnotatedSourceToFailureCase({
+    description:
+      'should fail when [ngForTrackByProperty] is missing in ng-template',
+    options: [{ alias: ['ngForTrackByProperty'] }],
     annotatedSource: `
         <ng-template ngFor let-item [ngForOf]="[1, 2, 3]" let-i="index">
                                     ~~~~~~~~~~~~~~~~~~~~~
@@ -132,5 +166,25 @@ export const invalid = [
         messageId,
       },
     ],
+  }),
+  convertAnnotatedSourceToFailureCase({
+    description:
+      'should fail when there are three ngFor and for the third, trackBy function (`ngForTrackByProperty` alias) is not present',
+    options: [{ alias: ['ngForTrackByProperty'] }],
+    annotatedSource: `
+        <div *ngFor="let item of [1, 2, 3]; trackBy: trackByFn">
+          {{ item }}
+        </div>
+        <div *ngFor="let item of [1, 2, 3]; trackByProperty: trackByFn">
+          {{ item }}
+        </div>
+        <ul>
+          <li *ngFor="let item of [1, 2, 3];">
+              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+            {{ item }}
+          </li>
+        </ul>
+      `,
+    messageId,
   }),
 ];

--- a/packages/eslint-plugin-template/tests/rules/use-track-by-function/cases.ts
+++ b/packages/eslint-plugin-template/tests/rules/use-track-by-function/cases.ts
@@ -52,6 +52,22 @@ export const valid = [
         trackBy : trackByFn
       ">
     `,
+  {
+    options: [{ alias: ['ngForTrackByProperty'] }],
+    code: `
+        <div *ngFor="
+          let item of [1, 2, 3];
+          let i = index;
+          trackByProperty: 'id'
+        ">
+      `,
+  },
+  {
+    options: [{ alias: ['ngForTrackById'] }],
+    code: `
+      <div *ngFor="let photo of photos; trackById"></div>
+    `,
+  },
 ];
 
 export const invalid = [


### PR DESCRIPTION
This commit adds an `alias` option to the `use-track-by-function` rule, allowing the specification of a list of properties that should be treated similarly to `ngForTrackBy`.

Closes #1323 