### PR TITLE
fix(eslint-plugin-template): structural directives not parsed correctly [attributes-order]

### DIFF
--- a/packages/eslint-plugin-template/docs/rules/attributes-order.md
+++ b/packages/eslint-plugin-template/docs/rules/attributes-order.md
@@ -567,6 +567,114 @@ interface Options {
              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 ```
 
+<br>
+
+---
+
+<br>
+
+#### Default Config
+
+```json
+{
+  "rules": {
+    "@angular-eslint/template/attributes-order": [
+      "error"
+    ]
+  }
+}
+```
+
+<br>
+
+#### ❌ Invalid Code
+
+```html
+<div test-attr *colDef="let element"></div>
+     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+```
+
+<br>
+
+---
+
+<br>
+
+#### Default Config
+
+```json
+{
+  "rules": {
+    "@angular-eslint/template/attributes-order": [
+      "error"
+    ]
+  }
+}
+```
+
+<br>
+
+#### ❌ Invalid Code
+
+```html
+<div test-attr *transloco="let t; scope: 'scopeName'; read: 'components.my-component'"></div>
+     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+```
+
+<br>
+
+---
+
+<br>
+
+#### Default Config
+
+```json
+{
+  "rules": {
+    "@angular-eslint/template/attributes-order": [
+      "error"
+    ]
+  }
+}
+```
+
+<br>
+
+#### ❌ Invalid Code
+
+```html
+<div test-attr *transloco="let t; read: component.prop || component.otherProp"></div>
+     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+```
+
+<br>
+
+---
+
+<br>
+
+#### Default Config
+
+```json
+{
+  "rules": {
+    "@angular-eslint/template/attributes-order": [
+      "error"
+    ]
+  }
+}
+```
+
+<br>
+
+#### ❌ Invalid Code
+
+```html
+<div test-attr *ngFor="let x of array.xs; let i = index"></div>
+     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+```
+
 </details>
 
 <br>

--- a/packages/eslint-plugin-template/docs/rules/attributes-order.md
+++ b/packages/eslint-plugin-template/docs/rules/attributes-order.md
@@ -617,6 +617,33 @@ interface Options {
 #### ❌ Invalid Code
 
 ```html
+<div test-attr *ngIf="sth.property as property"></div>
+     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+```
+
+<br>
+
+---
+
+<br>
+
+#### Default Config
+
+```json
+{
+  "rules": {
+    "@angular-eslint/template/attributes-order": [
+      "error"
+    ]
+  }
+}
+```
+
+<br>
+
+#### ❌ Invalid Code
+
+```html
 <div test-attr *transloco="let t; scope: 'scopeName'; read: 'components.my-component'"></div>
      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 ```

--- a/packages/eslint-plugin-template/src/rules/attributes-order.ts
+++ b/packages/eslint-plugin-template/src/rules/attributes-order.ts
@@ -331,10 +331,7 @@ function extractTemplateAttrs(
   // Pick up on any subsequent `let` bindings, e.g. `index as i`
   let sourceEnd = attrs[attrs.length - 1].sourceSpan.end;
   node.parent.variables.forEach((v) => {
-    if (
-      v.sourceSpan.start.offset <= sourceEnd.offset &&
-      sourceEnd.offset < v.sourceSpan.end.offset
-    ) {
+    if (sourceEnd.offset < v.sourceSpan.end.offset) {
       sourceEnd = v.sourceSpan.end;
     }
   });

--- a/packages/eslint-plugin-template/tests/rules/attributes-order/cases.ts
+++ b/packages/eslint-plugin-template/tests/rules/attributes-order/cases.ts
@@ -354,4 +354,68 @@ export const invalid = [
             
     `,
   }),
+  // convertAnnotatedSourceToFailureCase({
+  //   messageId,
+  //   description: 'should work with aliased structural directive',
+  //   annotatedSource: `
+  //      <div test-attr *ngIf="sth.property as property "></div>
+  //           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  //   `,
+  //   data: {
+  //     actual: '`test-attr`, `*ngIf`',
+  //     expected: '`*ngIf`, `test-attr`',
+  //   },
+  //   annotatedOutput: `
+  //      <div *ngIf="sth.property as property " test-attr></div>
+  //
+  //   `,
+  // }),
+  convertAnnotatedSourceToFailureCase({
+    messageId,
+    description: 'should work with multiple property structural directive',
+    annotatedSource: `
+       <div test-attr *transloco="let t; scope: 'scopeName'; read: 'components.my-component'"></div>
+            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    `,
+    data: {
+      actual: '`test-attr`, `*transloco`',
+      expected: '`*transloco`, `test-attr`',
+    },
+    annotatedOutput: `
+       <div *transloco="let t; scope: 'scopeName'; read: 'components.my-component'" test-attr></div>
+            
+    `,
+  }),
+  convertAnnotatedSourceToFailureCase({
+    messageId,
+    description: 'should work with multiple property structural directive',
+    annotatedSource: `
+       <div test-attr *transloco="let t; read: component.prop || component.otherProp"></div>
+            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    `,
+    data: {
+      actual: '`test-attr`, `*transloco`',
+      expected: '`*transloco`, `test-attr`',
+    },
+    annotatedOutput: `
+       <div *transloco="let t; read: component.prop || component.otherProp" test-attr></div>
+            
+    `,
+  }),
+  convertAnnotatedSourceToFailureCase({
+    messageId,
+    description: 'should work with ngFor structural directive',
+    annotatedSource: `
+       <div test-attr *ngFor="let x of array.xs; let i = index"></div>
+            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    `,
+    data: {
+      actual: '`test-attr`, `*ngFor`',
+      expected: '`*ngFor`, `test-attr`',
+    },
+    annotatedOutput: `
+       <div *ngFor="let x of array.xs; let i = index" test-attr></div>
+            
+    `,
+  }),
 ];

--- a/packages/eslint-plugin-template/tests/rules/attributes-order/cases.ts
+++ b/packages/eslint-plugin-template/tests/rules/attributes-order/cases.ts
@@ -354,22 +354,22 @@ export const invalid = [
             
     `,
   }),
-  // convertAnnotatedSourceToFailureCase({
-  //   messageId,
-  //   description: 'should work with aliased structural directive',
-  //   annotatedSource: `
-  //      <div test-attr *ngIf="sth.property as property "></div>
-  //           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-  //   `,
-  //   data: {
-  //     actual: '`test-attr`, `*ngIf`',
-  //     expected: '`*ngIf`, `test-attr`',
-  //   },
-  //   annotatedOutput: `
-  //      <div *ngIf="sth.property as property " test-attr></div>
-  //
-  //   `,
-  // }),
+  convertAnnotatedSourceToFailureCase({
+    messageId,
+    description: 'should work with aliased structural directive',
+    annotatedSource: `
+       <div test-attr *ngIf="sth.property as property"></div>
+            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    `,
+    data: {
+      actual: '`test-attr`, `*ngIf`',
+      expected: '`*ngIf`, `test-attr`',
+    },
+    annotatedOutput: `
+       <div *ngIf="sth.property as property" test-attr></div>
+            
+    `,
+  }),
   convertAnnotatedSourceToFailureCase({
     messageId,
     description: 'should work with multiple property structural directive',

--- a/packages/eslint-plugin-template/tests/rules/attributes-order/cases.ts
+++ b/packages/eslint-plugin-template/tests/rules/attributes-order/cases.ts
@@ -1,7 +1,7 @@
 import { convertAnnotatedSourceToFailureCase } from '@angular-eslint/utils';
 import {
-  OrderType,
   type MessageIds,
+  OrderType,
 } from '../../../src/rules/attributes-order';
 
 const messageId: MessageIds = 'attributesOrder';
@@ -336,6 +336,22 @@ export const invalid = [
     annotatedOutput: `
       <ng-template #Template let-anotherValue="else" let-value="something"></ng-template>
                    
+    `,
+  }),
+  convertAnnotatedSourceToFailureCase({
+    messageId,
+    description: 'should work with implicit structural directive',
+    annotatedSource: `
+       <div test-attr *colDef="let element"></div>
+            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    `,
+    data: {
+      actual: '`test-attr`, `*colDef`',
+      expected: '`*colDef`, `test-attr`',
+    },
+    annotatedOutput: `
+       <div *colDef="let element" test-attr></div>
+            
     `,
   }),
 ];


### PR DESCRIPTION
Fixes #1500
