### PR TITLE
chore: fix rule generator template defaultOptions

### DIFF
--- a/packages/nx-plugin/src/generators/rule/files/src/rules/__ruleName__.ts.template
+++ b/packages/nx-plugin/src/generators/rule/files/src/rules/__ruleName__.ts.template
@@ -6,19 +6,18 @@ export const RULE_NAME = '<%= ruleName %>';
 
 export default createESLintRule<Options, MessageIds>({
   name: RULE_NAME,
-  // TODO: Complete metadata
+  // TODO: Complete metadata, fixing any type errors
   meta: {
     type: '',
     docs: {
       description: '',
       recommended: '',
     },
-    fixable: '',
+    // fixable: '', TODO: Is it fixable?
     schema: [],
     messages: {
       <%= ruleName.replace(/-./g, c => c[1].toUpperCase()) %>: '',
-    },
-    defaultOptions: []
+    }
   },
   defaultOptions: [],
   create(context) {


### PR DESCRIPTION
This pull request fixes the template for the new rule generator by removing `defaultOptions` from the `meta` object, as the property does not belong there.