### PR TITLE
fix(eslint-plugin-template): [prefer-self-closing-tags] consider ng-content and ng-template elements

### DIFF
--- a/packages/eslint-plugin-template/docs/rules/prefer-self-closing-tags.md
+++ b/packages/eslint-plugin-template/docs/rules/prefer-self-closing-tags.md
@@ -149,6 +149,144 @@ The rule does not have any configuration options.
  ~~~~~~~~~~~~~~~
 ```
 
+<br>
+
+---
+
+<br>
+
+#### Default Config
+
+```json
+{
+  "rules": {
+    "@angular-eslint/template/prefer-self-closing-tags": [
+      "error"
+    ]
+  }
+}
+```
+
+<br>
+
+#### ❌ Invalid Code
+
+```html
+<ng-template></ng-template>
+             ~~~~~~~~~~~~~~
+```
+
+<br>
+
+---
+
+<br>
+
+#### Default Config
+
+```json
+{
+  "rules": {
+    "@angular-eslint/template/prefer-self-closing-tags": [
+      "error"
+    ]
+  }
+}
+```
+
+<br>
+
+#### ❌ Invalid Code
+
+```html
+<ng-template> </ng-template>
+              ~~~~~~~~~~~~~~
+```
+
+<br>
+
+---
+
+<br>
+
+#### Default Config
+
+```json
+{
+  "rules": {
+    "@angular-eslint/template/prefer-self-closing-tags": [
+      "error"
+    ]
+  }
+}
+```
+
+<br>
+
+#### ❌ Invalid Code
+
+```html
+<ng-content></ng-content>
+            ~~~~~~~~~~~~~
+```
+
+<br>
+
+---
+
+<br>
+
+#### Default Config
+
+```json
+{
+  "rules": {
+    "@angular-eslint/template/prefer-self-closing-tags": [
+      "error"
+    ]
+  }
+}
+```
+
+<br>
+
+#### ❌ Invalid Code
+
+```html
+<ng-content
+  selector="my-selector"
+></ng-content>
+ ~~~~~~~~~~~~~
+```
+
+<br>
+
+---
+
+<br>
+
+#### Default Config
+
+```json
+{
+  "rules": {
+    "@angular-eslint/template/prefer-self-closing-tags": [
+      "error"
+    ]
+  }
+}
+```
+
+<br>
+
+#### ❌ Invalid Code
+
+```html
+<ng-content>
+</ng-content>
+~~~~~~~~~~~~~
+```
+
 </details>
 
 <br>
@@ -287,6 +425,110 @@ The rule does not have any configuration options.
 
 ```html
 <div></div>
+```
+
+<br>
+
+---
+
+<br>
+
+#### Default Config
+
+```json
+{
+  "rules": {
+    "@angular-eslint/template/prefer-self-closing-tags": [
+      "error"
+    ]
+  }
+}
+```
+
+<br>
+
+#### ✅ Valid Code
+
+```html
+<ng-template/>
+```
+
+<br>
+
+---
+
+<br>
+
+#### Default Config
+
+```json
+{
+  "rules": {
+    "@angular-eslint/template/prefer-self-closing-tags": [
+      "error"
+    ]
+  }
+}
+```
+
+<br>
+
+#### ✅ Valid Code
+
+```html
+<ng-template>Content</ng-template>
+```
+
+<br>
+
+---
+
+<br>
+
+#### Default Config
+
+```json
+{
+  "rules": {
+    "@angular-eslint/template/prefer-self-closing-tags": [
+      "error"
+    ]
+  }
+}
+```
+
+<br>
+
+#### ✅ Valid Code
+
+```html
+<ng-content/>
+```
+
+<br>
+
+---
+
+<br>
+
+#### Default Config
+
+```json
+{
+  "rules": {
+    "@angular-eslint/template/prefer-self-closing-tags": [
+      "error"
+    ]
+  }
+}
+```
+
+<br>
+
+#### ✅ Valid Code
+
+```html
+<ng-content select="my-selector" />
 ```
 
 </details>

--- a/packages/eslint-plugin-template/src/rules/prefer-self-closing-tags.ts
+++ b/packages/eslint-plugin-template/src/rules/prefer-self-closing-tags.ts
@@ -5,6 +5,7 @@ import type {
 import { getTemplateParserServices } from '@angular-eslint/utils';
 import { createESLintRule } from '../utils/create-eslint-rule';
 import { getDomElements } from '../utils/get-dom-elements';
+import type { TmplAstContent, TmplAstTemplate } from '@angular/compiler';
 
 export const MESSAGE_ID = 'preferSelfClosingTags';
 export const RULE_NAME = 'prefer-self-closing-tags';
@@ -30,53 +31,118 @@ export default createESLintRule<[], typeof MESSAGE_ID>({
     const parserServices = getTemplateParserServices(context);
 
     return {
-      Element$1({
-        children,
-        name,
-        startSourceSpan,
-        endSourceSpan,
-      }: TmplAstElement) {
-        // Ignore native elements.
-        if (getDomElements().has(name)) {
-          return;
+      'Element$1, Template, Content'(
+        node: TmplAstElement | TmplAstTemplate | TmplAstContent,
+      ) {
+        if (isContentNode(node)) {
+          processContentNode(node);
+        } else {
+          // Ignore native elements.
+          if ('name' in node && getDomElements().has(node.name)) {
+            return;
+          }
+          processElementOrTemplateNode(node);
         }
+      },
+    };
 
-        const noContent =
-          !children.length ||
-          children.every((node) => {
-            const text = (node as TmplAstText).value;
+    function processElementOrTemplateNode(
+      node: TmplAstElement | TmplAstTemplate,
+    ) {
+      const { children, startSourceSpan, endSourceSpan } = node;
 
-            // If the node has no value, or only whitespace,
-            // we can consider it empty.
-            return (
-              typeof text === 'string' && text.replace(/\n/g, '').trim() === ''
-            );
-          });
-        const noCloseTag =
-          !endSourceSpan ||
-          (startSourceSpan.start.offset === endSourceSpan.start.offset &&
-            startSourceSpan.end.offset === endSourceSpan.end.offset);
+      const noContent =
+        !children.length ||
+        children.every((node) => {
+          const text = (node as TmplAstText).value;
 
-        if (!noContent || noCloseTag) {
-          return;
-        }
+          // If the node has no value, or only whitespace,
+          // we can consider it empty.
+          return (
+            typeof text === 'string' && text.replace(/\n/g, '').trim() === ''
+          );
+        });
+      const noCloseTag =
+        !endSourceSpan ||
+        (startSourceSpan.start.offset === endSourceSpan.start.offset &&
+          startSourceSpan.end.offset === endSourceSpan.end.offset);
 
-        // HTML tags always have more than two characters
-        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-        const openingTagLastChar = startSourceSpan.toString().at(-2)!;
-        const hasOwnWhitespace = openingTagLastChar.trim() === '';
-        const closingTagPrefix = hasOwnWhitespace ? '' : ' ';
+      if (!noContent || noCloseTag) {
+        return;
+      }
+
+      // HTML tags always have more than two characters
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      const openingTagLastChar = startSourceSpan.toString().at(-2)!;
+      const closingTagPrefix = getClosingTagPrefix(openingTagLastChar);
+
+      context.report({
+        loc: parserServices.convertNodeSourceSpanToLoc(endSourceSpan),
+        messageId: MESSAGE_ID,
+        fix: (fixer) =>
+          fixer.replaceTextRange(
+            [startSourceSpan.end.offset - 1, endSourceSpan.end.offset],
+            closingTagPrefix + '/>',
+          ),
+      });
+    }
+
+    function processContentNode(node: TmplAstContent) {
+      const { sourceSpan } = node;
+      const ngContentCloseTag = '</ng-content>';
+      if (sourceSpan.toString().includes(ngContentCloseTag)) {
+        // content nodes can only contain whitespaces
+        const content =
+          sourceSpan
+            .toString()
+            .match(/>(\s*)</m)
+            ?.at(1) ?? '';
+        const openingTagLastChar =
+          // This is more than the minimum length of a ng-content element
+          // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+          sourceSpan
+            .toString()
+            .at(-2 - ngContentCloseTag.length - content.length)!;
+        const closingTagPrefix = getClosingTagPrefix(openingTagLastChar);
 
         context.report({
-          loc: parserServices.convertNodeSourceSpanToLoc(endSourceSpan),
+          // content nodes don't have information about startSourceSpan and endSourceSpan,
+          // so we need to calculate it by our own
+          loc: {
+            start: {
+              line: sourceSpan.end.line + 1,
+              column: sourceSpan.end.col - ngContentCloseTag.length,
+            },
+            end: {
+              line: sourceSpan.end.line + 1,
+              column: sourceSpan.end.col,
+            },
+          },
           messageId: MESSAGE_ID,
           fix: (fixer) =>
             fixer.replaceTextRange(
-              [startSourceSpan.end.offset - 1, endSourceSpan.end.offset],
+              [
+                sourceSpan.end.offset -
+                  ngContentCloseTag.length -
+                  content.length -
+                  1,
+                sourceSpan.end.offset,
+              ],
               closingTagPrefix + '/>',
             ),
         });
-      },
-    };
+      }
+    }
   },
 });
+
+function isContentNode(
+  node: TmplAstElement | TmplAstTemplate | TmplAstContent,
+): node is TmplAstContent {
+  return 'name' in node && node.name === 'ng-content';
+}
+
+function getClosingTagPrefix(openingTagLastChar: string): string {
+  const hasOwnWhitespace = openingTagLastChar.trim() === '';
+  return hasOwnWhitespace ? '' : ' ';
+}

--- a/packages/eslint-plugin-template/tests/rules/prefer-self-closing-tags/cases.ts
+++ b/packages/eslint-plugin-template/tests/rules/prefer-self-closing-tags/cases.ts
@@ -12,6 +12,10 @@ export const valid = [
   `,
   '<img />',
   '<div></div>',
+  '<ng-template/>',
+  '<ng-template>Content</ng-template>',
+  '<ng-content/>',
+  '<ng-content select="my-selector" />',
 ];
 
 export const invalid = [
@@ -79,6 +83,71 @@ export const invalid = [
         [items]="items"
       />
        
+    `,
+    messageId,
+  }),
+  convertAnnotatedSourceToFailureCase({
+    description: 'it should fail on ng-template elements',
+    annotatedSource: `
+      <ng-template></ng-template>
+                   ~~~~~~~~~~~~~~
+    `,
+    annotatedOutput: `
+      <ng-template />
+                   
+    `,
+    messageId,
+  }),
+  convertAnnotatedSourceToFailureCase({
+    description: 'it should fail on ng-template elements with white spaces',
+    annotatedSource: `
+      <ng-template> </ng-template>
+                    ~~~~~~~~~~~~~~
+    `,
+    annotatedOutput: `
+      <ng-template />
+                    
+    `,
+    messageId,
+  }),
+  convertAnnotatedSourceToFailureCase({
+    description: 'it should fail on ng-content elements',
+    annotatedSource: `
+      <ng-content></ng-content>
+                  ~~~~~~~~~~~~~
+    `,
+    annotatedOutput: `
+      <ng-content />
+                  
+    `,
+    messageId,
+  }),
+  convertAnnotatedSourceToFailureCase({
+    description: 'it should fail on ng-content elements with selector',
+    annotatedSource: `
+      <ng-content
+        selector="my-selector"
+      ></ng-content>
+       ~~~~~~~~~~~~~
+    `,
+    annotatedOutput: `
+      <ng-content
+        selector="my-selector"
+      />
+       
+    `,
+    messageId,
+  }),
+  convertAnnotatedSourceToFailureCase({
+    description: 'it should fail on ng-content elements with a line break',
+    annotatedSource: `
+      <ng-content>
+      </ng-content>
+      ~~~~~~~~~~~~~
+    `,
+    annotatedOutput: `
+      <ng-content />
+      
     `,
     messageId,
   }),

--- a/yarn.lock
+++ b/yarn.lock
@@ -3229,10 +3229,15 @@ acorn-walk@^8.1.1:
   resolved "https://registry.yarnpkg.com/acorn-walk/-/acorn-walk-8.2.0.tgz#741210f2e2426454508853a2f44d0ab83b7f69c1"
   integrity sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==
 
-acorn@^8.4.1, acorn@^8.5.0, acorn@^8.8.0:
+acorn@^8.4.1:
   version "8.8.2"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.8.2.tgz#1b2f25db02af965399b9776b0c2c391276d37c4a"
   integrity sha512-xjIYgE8HBrkpd/sJqOGNspf8uHG+NOHGOw6a/Urj8taM2EXfdNAH2oFcPeIFfsv3+kz/mJrS5VuMqbNLjCa2vw==
+
+acorn@^8.5.0:
+  version "8.11.2"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.11.2.tgz#ca0d78b51895be5390a5903c5b3bdcdaf78ae40b"
+  integrity sha512-nc0Axzp/0FILLEVsm4fNwLCwMttvhEI263QtVPQcbpfZZ3ts0hLsZGOpE6czNlid7CJ9MlyH8reXkpsf3YUY4w==
 
 acorn@^8.8.2, acorn@^8.9.0:
   version "8.9.0"
@@ -4894,15 +4899,15 @@ eslint-scope@^7.0.0, eslint-scope@^7.2.2:
     esrecurse "^4.3.0"
     estraverse "^5.2.0"
 
-eslint-visitor-keys@^3.0.0, eslint-visitor-keys@^3.3.0, eslint-visitor-keys@^3.4.1:
-  version "3.4.1"
-  resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-3.4.1.tgz#c22c48f48942d08ca824cc526211ae400478a994"
-  integrity sha512-pZnmmLwYzf+kWaM/Qgrvpen51upAktaaiI01nsJD/Yr3lMOdNtq0cxkrrg16w64VtisN6okbs7Q8AfGqj4c9fA==
-
-eslint-visitor-keys@^3.4.3:
+eslint-visitor-keys@^3.0.0, eslint-visitor-keys@^3.4.1, eslint-visitor-keys@^3.4.3:
   version "3.4.3"
   resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz#0cd72fe8550e3c2eae156a96a4dddcd1c8ac5800"
   integrity sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==
+
+eslint-visitor-keys@^3.3.0:
+  version "3.4.1"
+  resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-3.4.1.tgz#c22c48f48942d08ca824cc526211ae400478a994"
+  integrity sha512-pZnmmLwYzf+kWaM/Qgrvpen51upAktaaiI01nsJD/Yr3lMOdNtq0cxkrrg16w64VtisN6okbs7Q8AfGqj4c9fA==
 
 eslint@8.51.0:
   version "8.51.0"
@@ -4947,12 +4952,12 @@ eslint@8.51.0:
     strip-ansi "^6.0.1"
     text-table "^0.2.0"
 
-espree@^9.0.0:
-  version "9.5.2"
-  resolved "https://registry.yarnpkg.com/espree/-/espree-9.5.2.tgz#e994e7dc33a082a7a82dceaf12883a829353215b"
-  integrity sha512-7OASN1Wma5fum5SrNhFMAMJxOUAbhyfQ8dQ//PJaJbNw0URTPWqIghHWt1MmAANKhHZIYOHruW4Kw4ruUWOdGw==
+espree@^9.0.0, espree@^9.6.1:
+  version "9.6.1"
+  resolved "https://registry.yarnpkg.com/espree/-/espree-9.6.1.tgz#a2a17b8e434690a5432f2f8018ce71d331a48c6f"
+  integrity sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==
   dependencies:
-    acorn "^8.8.0"
+    acorn "^8.9.0"
     acorn-jsx "^5.3.2"
     eslint-visitor-keys "^3.4.1"
 
@@ -4960,15 +4965,6 @@ espree@^9.6.0:
   version "9.6.0"
   resolved "https://registry.yarnpkg.com/espree/-/espree-9.6.0.tgz#80869754b1c6560f32e3b6929194a3fe07c5b82f"
   integrity sha512-1FH/IiruXZ84tpUlm0aCUEwMl2Ho5ilqVh0VvQXw+byAz/4SAciyHLlfmL5WYqsvD38oymdUwBss0LtK8m4s/A==
-  dependencies:
-    acorn "^8.9.0"
-    acorn-jsx "^5.3.2"
-    eslint-visitor-keys "^3.4.1"
-
-espree@^9.6.1:
-  version "9.6.1"
-  resolved "https://registry.yarnpkg.com/espree/-/espree-9.6.1.tgz#a2a17b8e434690a5432f2f8018ce71d331a48c6f"
-  integrity sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==
   dependencies:
     acorn "^8.9.0"
     acorn-jsx "^5.3.2"
@@ -6961,9 +6957,9 @@ json5@^2.2.2, json5@^2.2.3:
   integrity sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==
 
 jsonc-eslint-parser@^2.1.0:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/jsonc-eslint-parser/-/jsonc-eslint-parser-2.3.0.tgz#7c2de97d01bff7227cbef2f25d1025d42a36198b"
-  integrity sha512-9xZPKVYp9DxnM3sd1yAsh/d59iIaswDkai8oTxbursfKYbg/ibjX0IzFt35+VZ8iEW453TVTXztnRvYUQlAfUQ==
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/jsonc-eslint-parser/-/jsonc-eslint-parser-2.4.0.tgz#74ded53f9d716e8d0671bd167bf5391f452d5461"
+  integrity sha512-WYDyuc/uFcGp6YtM2H0uKmUwieOuzeE/5YocFJLnLfclZ4inf3mRn8ZVy1s7Hxji7Jxm6Ss8gqpexD/GlKoGgg==
   dependencies:
     acorn "^8.5.0"
     eslint-visitor-keys "^3.0.0"
@@ -9292,14 +9288,14 @@ semver@7.5.3:
   dependencies:
     lru-cache "^6.0.0"
 
-semver@7.5.4, semver@^7.5.3:
+semver@7.5.4, semver@^7.3.5, semver@^7.5.3:
   version "7.5.4"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.5.4.tgz#483986ec4ed38e1c6c48c34894a9182dbff68a6e"
   integrity sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==
   dependencies:
     lru-cache "^6.0.0"
 
-semver@7.x, semver@^7.0.0, semver@^7.1.1, semver@^7.3.4, semver@^7.3.5, semver@^7.3.7, semver@^7.3.8:
+semver@7.x, semver@^7.0.0, semver@^7.1.1, semver@^7.3.4, semver@^7.3.7, semver@^7.3.8:
   version "7.5.1"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.5.1.tgz#c90c4d631cf74720e46b21c1d37ea07edfab91ec"
   integrity sha512-Wvss5ivl8TMRZXXESstBA4uR5iXgEN/VC5/sOcuXdVLzcdkz4HWetIoRfG5gb5X+ij/G9rw9YoGn3QoQ8OCSpw==


### PR DESCRIPTION
Currently the prefer-self-closing-tags rule doesn't report errors on  empty `<ng-content></ng-content>` and `<ng-template></ng-template>` elements, which is fixed by this pull request.

Closes #1567 