### PR TITLE
fix: generate type declarations for published packages

### DIFF
--- a/packages/eslint-plugin-template/tsconfig.build.json
+++ b/packages/eslint-plugin-template/tsconfig.build.json
@@ -3,6 +3,7 @@
   "compilerOptions": {
     "outDir": "./dist",
     "resolveJsonModule": true,
+    "declaration": true,
     "baseUrl": "."
   },
   "include": ["src"]

--- a/packages/eslint-plugin/tsconfig.build.json
+++ b/packages/eslint-plugin/tsconfig.build.json
@@ -3,6 +3,7 @@
   "compilerOptions": {
     "outDir": "./dist",
     "resolveJsonModule": true,
+    "declaration": true,
     "baseUrl": "."
   },
   "include": ["src"]

--- a/packages/schematics/tsconfig.build.json
+++ b/packages/schematics/tsconfig.build.json
@@ -2,6 +2,7 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "outDir": "./dist",
+    "declaration": true,
     "baseUrl": ".",
     "paths": {
       "@angular-eslint/eslint-plugin": ["../../eslint-plugin/dist/index.js"],

--- a/packages/template-parser/tsconfig.build.json
+++ b/packages/template-parser/tsconfig.build.json
@@ -2,6 +2,7 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "outDir": "./dist",
+    "declaration": true,
     "baseUrl": "."
   },
   "include": ["src"]


### PR DESCRIPTION
Some of the `@angular-eslint/*` packages declare a `"types"` field in their published `package.json`, however their respective `tsconfig.build.json` configuration files lack the`"declaration": true` field.

This means that no `.d.ts` files will be created for these packages when building the package for publishing to npm, causing the `"types"` field to reference a missing file.

This PR fixes this, allowing the published npm packages to be imported directly within a TypeScript project.