### PR TITLE
fix(eslint-plugin-template): [prefer-ngsrc] Do not prefer ngsrc for base64-encoded strings

### DIFF
--- a/packages/eslint-plugin-template/docs/rules/prefer-ngsrc.md
+++ b/packages/eslint-plugin-template/docs/rules/prefer-ngsrc.md
@@ -103,6 +103,8 @@ The rule does not have any configuration options.
                             ~~~~~~~~~~~~~
   <img [src]="otherValue" [ngSrc]="value">
        ~~~~~~~~~~~~~~~~~~
+  <img src="data:image/png;base64" [ngSrc]="otherValue">
+       ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 </ng-template>
 ```
 
@@ -189,6 +191,32 @@ The rule does not have any configuration options.
 
 ```html
 <img [ngSrc]="value">
+```
+
+<br>
+
+---
+
+<br>
+
+#### Default Config
+
+```json
+{
+  "rules": {
+    "@angular-eslint/template/prefer-ngsrc": [
+      "error"
+    ]
+  }
+}
+```
+
+<br>
+
+#### ✅ Valid Code
+
+```html
+<img src="data:image/jpeg;base64">
 ```
 
 </details>

--- a/packages/eslint-plugin-template/src/rules/prefer-ngsrc.ts
+++ b/packages/eslint-plugin-template/src/rules/prefer-ngsrc.ts
@@ -1,8 +1,8 @@
 import type {
   TmplAstBoundAttribute,
   TmplAstElement,
-  TmplAstTextAttribute,
 } from '@angular-eslint/bundled-angular-compiler';
+import { TmplAstTextAttribute } from '@angular-eslint/bundled-angular-compiler';
 import { getTemplateParserServices } from '@angular-eslint/utils';
 import { createESLintRule } from '../utils/create-eslint-rule';
 
@@ -34,7 +34,10 @@ export default createESLintRule<Options, MessageIds>({
         const ngSrcAttribute = hasNgSrcAttribute(element);
         const srcAttribute = hasNormalSrcAttribute(element);
 
-        if (!srcAttribute) {
+        if (
+          !srcAttribute ||
+          (!ngSrcAttribute && isSrcBase64Image(srcAttribute))
+        ) {
           return;
         }
 
@@ -65,4 +68,14 @@ function hasNormalSrcAttribute({
   attributes,
 }: TmplAstElement): TmplAstTextAttribute | TmplAstBoundAttribute | undefined {
   return [...inputs, ...attributes].find(({ name }) => name === 'src');
+}
+
+function isSrcBase64Image(
+  attribute: TmplAstTextAttribute | TmplAstBoundAttribute,
+) {
+  if (attribute instanceof TmplAstTextAttribute) {
+    return attribute.value.trim().startsWith('data:');
+  }
+
+  return false;
 }

--- a/packages/eslint-plugin-template/src/rules/prefer-ngsrc.ts
+++ b/packages/eslint-plugin-template/src/rules/prefer-ngsrc.ts
@@ -70,6 +70,8 @@ function hasNormalSrcAttribute({
   return [...inputs, ...attributes].find(({ name }) => name === 'src');
 }
 
+// Adheres to angular's assertion that ngSrc value is not a data URL.
+// https://github.com/angular/angular/blob/17.0.3/packages/common/src/directives/ng_optimized_image/ng_optimized_image.ts#L585
 function isSrcBase64Image(
   attribute: TmplAstTextAttribute | TmplAstBoundAttribute,
 ) {

--- a/packages/eslint-plugin-template/tests/rules/prefer-ngsrc/cases.ts
+++ b/packages/eslint-plugin-template/tests/rules/prefer-ngsrc/cases.ts
@@ -8,6 +8,7 @@ export const valid = [
   '<img ngSrc="http://localhost">',
   "<img [ngSrc]=\"'http://localhost'>",
   '<img [ngSrc]="value">',
+  '<img src="data:image/jpeg;base64">',
 ];
 
 export const invalid = [
@@ -56,6 +57,8 @@ export const invalid = [
                                   %%%%%%%%%%%%%
         <img [src]="otherValue" [ngSrc]="value">
              ¶¶¶¶¶¶¶¶¶¶¶¶¶¶¶¶¶¶
+        <img src="data:image/png;base64" [ngSrc]="otherValue">
+             ¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨
       </ng-template>
       `,
     messages: [
@@ -85,6 +88,10 @@ export const invalid = [
       },
       {
         char: '¶',
+        messageId: invalidDoubleSource,
+      },
+      {
+        char: '¨',
         messageId: invalidDoubleSource,
       },
     ],


### PR DESCRIPTION
Closes https://github.com/angular-eslint/angular-eslint/issues/1543

Rule prefer-ngsrc should not error if image src is a base64-encoded string because NgOptimizedImage does not support Base64-encoded strings.

Expected Behavior:
`<img src="data:image/png;base64" />` ✅ should not throw an error

`<img [src]="'data:image/png;base64'" /> ` ❌ should throw an error because `[src]` is a BoundAttribute

`<img src="data:image/png;base64" [ngSrc]="'data:image/png;base64'" />` ❌ should throw an error because there is two sources.

