### PR TITLE
fix(eslint-plugin-template): handle i18n tags on structural direcives

### DIFF
--- a/packages/eslint-plugin-template/docs/rules/i18n.md
+++ b/packages/eslint-plugin-template/docs/rules/i18n.md
@@ -893,6 +893,33 @@ interface Options {
 
 <br>
 
+#### Default Config
+
+```json
+{
+  "rules": {
+    "@angular-eslint/template/i18n": [
+      "error"
+    ]
+  }
+}
+```
+
+<br>
+
+#### ❌ Invalid Code
+
+```html
+<p *ngIf="condition" i18n>Text</p>
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+```
+
+<br>
+
+---
+
+<br>
+
 #### Custom Config
 
 ```json
@@ -1973,6 +2000,32 @@ interface Options {
 
 ```html
 <h1 i18n="site header|An introduction header for this sample">Hello i18n!</h1>
+```
+
+<br>
+
+---
+
+<br>
+
+#### Default Config
+
+```json
+{
+  "rules": {
+    "@angular-eslint/template/i18n": [
+      "error"
+    ]
+  }
+}
+```
+
+<br>
+
+#### ✅ Valid Code
+
+```html
+<ng-template i18n="@@foo"><p *ngIf="condition">Text</p></ng-template>
 ```
 
 <br>

--- a/packages/eslint-plugin-template/tests/rules/i18n/cases.ts
+++ b/packages/eslint-plugin-template/tests/rules/i18n/cases.ts
@@ -219,6 +219,9 @@ export const valid = [
       { checkId: false, requireDescription: true, requireMeaning: true },
     ],
   },
+  `
+    <ng-template i18n="@@foo"><p *ngIf="condition">Text</p></ng-template>
+  `,
   {
     code: `
       <h1 i18n="site header|">Hello i18n!</h1>
@@ -848,6 +851,14 @@ export const invalid = [
         The author is {gender, select, male {male} female {female} other {other}}
       </ng-template>
                    ~
+    `,
+    messageId: i18nCustomIdOnElement,
+  }),
+  convertAnnotatedSourceToFailureCase({
+    description: 'should fail if a structural directive is missing a custom ID',
+    annotatedSource: `
+      <p *ngIf="condition" i18n>Text</p>
+      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     `,
     messageId: i18nCustomIdOnElement,
   }),


### PR DESCRIPTION
Fixes a regression caused by https://github.com/angular-eslint/angular-eslint/pull/1257 where i18n attributes on structural directives are not propertly detected. The fix is to tighten the `isTemplate` helper to only check for `ng-template` nodes and not all template nodes which are created by using a structural directive.

First commit is from https://github.com/angular-eslint/angular-eslint/pull/1656 which this PR builds on as it requires the fix from that PR as well.