### PR TITLE
fix(@angular-eslint/utils): [eslint-plugin-template] add support to eslint 9.0.0

### DIFF
--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -16,7 +16,7 @@
     "LICENSE"
   ],
   "peerDependencies": {
-    "eslint": "^7.20.0 || ^8.0.0",
+    "eslint": "^7.20.0 || ^8.0.0 || ^9.0.0",
     "typescript": "*"
   },
   "dependencies": {

--- a/packages/utils/src/eslint-plugin-template/parser-services.ts
+++ b/packages/utils/src/eslint-plugin-template/parser-services.ts
@@ -14,11 +14,25 @@ export interface TemplateParserServices {
   ) => TSESTree.SourceLocation;
 }
 
+/**
+ * Retrieves the parser services from the eslint version 8 and higher, given ESLint rule context.
+ * @param {Readonly<TSESLint.RuleContext<string, readonly unknown[]>>} context - The ESLint rule context
+ * @return {TemplateParserServices} The parser services retrieved from the context
+ */
+function getParserServices(
+  context: Readonly<TSESLint.RuleContext<string, readonly unknown[]>>,
+): TemplateParserServices {
+  // disabled deprecation warning
+  const ctx = context as any; // eslint-disable-line @typescript-eslint/no-explicit-any
+  return (ctx.parserServices ??
+    ctx.sourceCode?.parserServices) as unknown as TemplateParserServices;
+}
+
 export function getTemplateParserServices(
   context: Readonly<TSESLint.RuleContext<string, readonly unknown[]>>,
 ): TemplateParserServices {
   ensureTemplateParser(context);
-  return context.parserServices as unknown as TemplateParserServices;
+  return getParserServices(context);
 }
 
 /**
@@ -28,11 +42,10 @@ export function getTemplateParserServices(
 export function ensureTemplateParser(
   context: Readonly<TSESLint.RuleContext<string, readonly unknown[]>>,
 ): void {
+  const parserServices: TemplateParserServices = getParserServices(context);
   if (
-    !(context.parserServices as unknown as TemplateParserServices)
-      ?.convertNodeSourceSpanToLoc ||
-    !(context.parserServices as unknown as TemplateParserServices)
-      ?.convertElementSourceSpanToLoc
+    !parserServices?.convertNodeSourceSpanToLoc ||
+    !parserServices?.convertElementSourceSpanToLoc
   ) {
     /**
      * The user needs to have configured "parser" in their eslint config and set it


### PR DESCRIPTION
Fixes the issue encountered when attempting to utilize @angular-eslint/template with eslint version 9.0.0.


####  version:
 
package | version
-- | --
@angular-eslint/eslint-plugin-template | 17.3.0
@angular-eslint/template-parser | 17.3.0
ESLint | 9.0.0
node | 18.19.0

<!--EndFragment-->
</body>
</html>

####  issue: 
```js
// eslint.config.js
const angularTemplateParser = require('@angular-eslint/template-parser');
const angularTemplatePlugin = require('@angular-eslint/eslint-plugin-template');
const angularTemplateRecommendedRules = angularTemplatePlugin.configs['recommended'].rules;
const angularTemplateAccessibilityRules = angularTemplatePlugin.configs['accessibility'].rules;

module.exports = [
   {
    files: ['**/*.html'],
    languageOptions: {
      parser: angularTemplateParser,
    },
    plugins: {
      '@angular-eslint/template': angularTemplatePlugin,
    },
    rules: {
      ...angularTemplateRecommendedRules,
      ...angularTemplateAccessibilityRules,
    },
  },
]
```

```shell
yarn eslint
```

Oops! Something went wrong! :(

ESLint: 9.0.0

Error: Error while loading rule '@angular-eslint/template/banana-in-box': You have used a rule which requires '@angular-eslint/template-parser' to be used as the 'parser' in your ESLint config.