### PR TITLE
fix(eslint-plugin): remove `no-host-metadata-property` from the recommended list.

### DIFF
--- a/packages/eslint-plugin/src/configs/recommended.json
+++ b/packages/eslint-plugin/src/configs/recommended.json
@@ -1,12 +1,13 @@
 {
   "parser": "@typescript-eslint/parser",
-  "plugins": ["@angular-eslint"],
+  "plugins": [
+    "@angular-eslint"
+  ],
   "rules": {
     "@angular-eslint/component-class-suffix": "error",
     "@angular-eslint/contextual-lifecycle": "error",
     "@angular-eslint/directive-class-suffix": "error",
     "@angular-eslint/no-empty-lifecycle-method": "error",
-    "@angular-eslint/no-host-metadata-property": "error",
     "@angular-eslint/no-input-rename": "error",
     "@angular-eslint/no-inputs-metadata-property": "error",
     "@angular-eslint/no-output-native": "error",


### PR DESCRIPTION
As part of the v18 release  and as discussed in angular/angular#53888 & angular/angular#54284, the styling guide will now recommend using the host property instead of the `@HostBinding`/`@HostListener`.

The change reflect in the recommended rule list reflect this change. 