### PR TITLE
chore(eslint-plugin): [sort-ngmodule-metadata-arrays] deprecate rule

### DIFF
--- a/packages/eslint-plugin/README.md
+++ b/packages/eslint-plugin/README.md
@@ -67,7 +67,6 @@
 | [`prefer-standalone`](https://github.com/angular-eslint/angular-eslint/blob/main/packages/eslint-plugin/docs/rules/prefer-standalone.md) | Ensures component, directive and pipe `standalone` property is set to `true` in the component decorator |  | :wrench: |  |
 | [`relative-url-prefix`](https://github.com/angular-eslint/angular-eslint/blob/main/packages/eslint-plugin/docs/rules/relative-url-prefix.md) | The ./ and ../ prefix is standard syntax for relative URLs; don't depend on Angular's current ability to do without that prefix. See more at https://angular.io/styleguide#style-05-04 |  |  |  |
 | [`require-localize-metadata`](https://github.com/angular-eslint/angular-eslint/blob/main/packages/eslint-plugin/docs/rules/require-localize-metadata.md) | Ensures that $localize tagged messages contain helpful metadata to aid with translations. |  |  |  |
-| [`sort-ngmodule-metadata-arrays`](https://github.com/angular-eslint/angular-eslint/blob/main/packages/eslint-plugin/docs/rules/sort-ngmodule-metadata-arrays.md) | Ensures ASC alphabetical order for `NgModule` metadata arrays for easy visual scanning |  | :wrench: |  |
 | [`use-component-selector`](https://github.com/angular-eslint/angular-eslint/blob/main/packages/eslint-plugin/docs/rules/use-component-selector.md) | Component selector must be declared |  |  |  |
 | [`use-component-view-encapsulation`](https://github.com/angular-eslint/angular-eslint/blob/main/packages/eslint-plugin/docs/rules/use-component-view-encapsulation.md) | Disallows using `ViewEncapsulation.None` |  |  | :bulb: |
 | [`use-injectable-provided-in`](https://github.com/angular-eslint/angular-eslint/blob/main/packages/eslint-plugin/docs/rules/use-injectable-provided-in.md) | Using the `providedIn` property makes `Injectables` tree-shakable |  |  | :bulb: |
@@ -89,6 +88,7 @@
 | Rule | Replaced by |
 | --- | --- |
 | [`prefer-standalone-component`](https://github.com/angular-eslint/angular-eslint/blob/main/packages/eslint-plugin/docs/rules/prefer-standalone-component.md) | [`prefer-standalone`](https://github.com/angular-eslint/angular-eslint/blob/main/packages/eslint-plugin/docs/rules/prefer-standalone.md) |
+| [`sort-ngmodule-metadata-arrays`](https://github.com/angular-eslint/angular-eslint/blob/main/packages/eslint-plugin/docs/rules/sort-ngmodule-metadata-arrays.md) |  |
 <!-- prettier-ignore-end -->
 
 <!-- end deprecated rule list -->

--- a/packages/eslint-plugin/docs/rules/sort-ngmodule-metadata-arrays.md
+++ b/packages/eslint-plugin/docs/rules/sort-ngmodule-metadata-arrays.md
@@ -15,6 +15,10 @@
 
 # `@angular-eslint/sort-ngmodule-metadata-arrays`
 
+## ⚠️ THIS RULE IS DEPRECATED
+
+---
+
 Ensures ASC alphabetical order for `NgModule` metadata arrays for easy visual scanning
 
 - Type: suggestion

--- a/packages/eslint-plugin/src/rules/sort-ngmodule-metadata-arrays.ts
+++ b/packages/eslint-plugin/src/rules/sort-ngmodule-metadata-arrays.ts
@@ -16,6 +16,7 @@ export default createESLintRule<Options, MessageIds>({
   name: RULE_NAME,
   meta: {
     type: 'suggestion',
+    deprecated: true,
     docs: {
       description:
         'Ensures ASC alphabetical order for `NgModule` metadata arrays for easy visual scanning',

--- a/tools/scripts/generate-rule-docs.ts
+++ b/tools/scripts/generate-rule-docs.ts
@@ -111,14 +111,18 @@ const testDirs = readdirSync(testDirsDir);
 
 ${
   deprecated
-    ? `## ⚠️ THIS RULE IS DEPRECATED\n\nPlease use ${(replacedBy || [])
-        .map(
-          (r: string) =>
-            `\`@angular-eslint/${
-              plugin === 'eslint-plugin-template' ? 'template/' : ''
-            }${r}\``,
-        )
-        .join(', ')} instead.\n\n---\n\n`
+    ? `## ⚠️ THIS RULE IS DEPRECATED\n\n${
+        replacedBy
+          ? `Please use ${(replacedBy || [])
+              .map(
+                (r: string) =>
+                  `\`@angular-eslint/${
+                    plugin === 'eslint-plugin-template' ? 'template/' : ''
+                  }${r}\``,
+              )
+              .join(', ')} instead.`
+          : ''
+      }\n\n---\n\n`
     : ''
 }${description}
 


### PR DESCRIPTION
This pull request deprecates rule `sort-ngmodule-metadata-arrays`; see discussions in #1232.

Because there is no replacement for this rule, this pull request also updates the rule doc generator to not include a rule replacement note if one is not available.

Closes #1232