### PR TITLE
refactor: Use `nx` only at build time

### DIFF
--- a/packages/builder/package.json
+++ b/packages/builder/package.json
@@ -18,10 +18,6 @@
     "LICENSE",
     "builders.json"
   ],
-  "dependencies": {
-    "@nx/devkit": "^17.2.8 || ^18.0.0",
-    "nx": "^17.2.8 || ^18.0.0"
-  },
   "builders": "./builders.json",
   "peerDependencies": {
     "eslint": "^7.20.0 || ^8.0.0",

--- a/packages/builder/src/lint.impl.ts
+++ b/packages/builder/src/lint.impl.ts
@@ -1,25 +1,21 @@
 import type { BuilderOutput } from '@angular-devkit/architect';
-import {
-  convertNxExecutor,
-  joinPathFragments,
-  workspaceRoot,
-} from '@nx/devkit';
+import { createBuilder } from '@angular-devkit/architect';
 import type { ESLint } from 'eslint';
 import { existsSync, mkdirSync, writeFileSync } from 'fs';
 import { dirname, join, resolve } from 'path';
 import type { Schema } from './schema';
 import { resolveAndInstantiateESLint } from './utils/eslint-utils';
 
-export default convertNxExecutor(
+export default createBuilder(
   async (options: Schema, context): Promise<BuilderOutput> => {
-    const systemRoot = context.root;
+    const systemRoot = context.workspaceRoot;
 
     // eslint resolves files relative to the current working directory.
     // We want these paths to always be resolved relative to the workspace
     // root to be able to run the lint executor from any subfolder.
     process.chdir(systemRoot);
 
-    const projectName = context.projectName || '<???>';
+    const projectName = context.target?.project ?? '<???>';
     const printInfo = options.format && !options.silent;
 
     if (printInfo) {
@@ -43,9 +39,7 @@ export default convertNxExecutor(
      * we only want to support it if the user has explicitly opted into it by converting
      * their root ESLint config to use eslint.config.js
      */
-    const useFlatConfig = existsSync(
-      joinPathFragments(workspaceRoot, 'eslint.config.js'),
-    );
+    const useFlatConfig = existsSync(join(systemRoot, 'eslint.config.js'));
     const { eslint, ESLint } = await resolveAndInstantiateESLint(
       eslintConfigPath,
       options,
@@ -74,8 +68,9 @@ export default convertNxExecutor(
         )
       ) {
         let eslintConfigPathForError = `for ${projectName}`;
-        if (context.projectsConfigurations?.projects?.[projectName]?.root) {
-          const { root } = context.projectsConfigurations.projects[projectName];
+        const projectMetadata = await context.getProjectMetadata(projectName);
+        if (projectMetadata?.root) {
+          const { root } = projectMetadata;
           eslintConfigPathForError = `\`${root}/.eslintrc.json\``;
         }
 
@@ -168,7 +163,7 @@ For full guidance on how to resolve this issue, please see https://github.com/an
     const formattedResults = await formatter.format(finalLintResults);
 
     if (options.outputFile) {
-      const pathToOutputFile = join(context.root, options.outputFile);
+      const pathToOutputFile = join(systemRoot, options.outputFile);
       mkdirSync(dirname(pathToOutputFile), { recursive: true });
       writeFileSync(pathToOutputFile, formattedResults);
     } else {

--- a/packages/schematics/package.json
+++ b/packages/schematics/package.json
@@ -36,9 +36,7 @@
   "dependencies": {
     "@angular-eslint/eslint-plugin": "17.4.0",
     "@angular-eslint/eslint-plugin-template": "17.4.0",
-    "@nx/devkit": "^17.2.8 || ^18.0.0",
     "ignore": "5.3.1",
-    "nx": "^17.2.8 || ^18.0.0",
     "strip-json-comments": "3.1.1",
     "tmp": "0.2.3"
   },

--- a/packages/schematics/src/add-eslint-to-project/index.ts
+++ b/packages/schematics/src/add-eslint-to-project/index.ts
@@ -1,9 +1,9 @@
-import type { Tree } from '@nx/devkit';
-import { convertNxGenerator } from '@nx/devkit';
+import type { Rule, Tree } from '@angular-devkit/schematics';
+import { chain } from '@angular-devkit/schematics';
 import {
-  addESLintTargetToProject__NX,
-  createESLintConfigForProject__NX,
-  determineTargetProjectName__NX,
+  addESLintTargetToProject,
+  createESLintConfigForProject,
+  determineTargetProjectName,
 } from '../utils';
 
 interface Schema {
@@ -11,25 +11,27 @@ interface Schema {
   setParserOptionsProject?: boolean;
 }
 
-export default convertNxGenerator(async (tree: Tree, options: Schema) => {
-  const projectName = determineTargetProjectName__NX(tree, options.project);
-  if (!projectName) {
-    throw new Error(
-      '\n' +
-        `
+export default function addESLintToProject(schema: Schema): Rule {
+  return (tree: Tree) => {
+    const projectName = determineTargetProjectName(tree, schema.project);
+    if (!projectName) {
+      throw new Error(
+        '\n' +
+          `
 Error: You must specify a project to add ESLint to because you have multiple projects in your angular.json
 
 E.g. npx ng g @angular-eslint/schematics:add-eslint-to-project {{YOUR_PROJECT_NAME_GOES_HERE}}
-      `.trim(),
-    );
-  }
-
-  // Update the lint builder and config in angular.json
-  addESLintTargetToProject__NX(tree, projectName, 'lint');
-
-  createESLintConfigForProject__NX(
-    tree,
-    projectName,
-    options.setParserOptionsProject ?? false,
-  );
-});
+        `.trim(),
+      );
+    }
+    return chain([
+      // Set the lint builder and config in angular.json
+      addESLintTargetToProject(projectName, 'lint'),
+      // Create the ESLint config file for the project
+      createESLintConfigForProject(
+        projectName,
+        schema.setParserOptionsProject ?? false,
+      ),
+    ]);
+  };
+}

--- a/packages/schematics/src/application/index.ts
+++ b/packages/schematics/src/application/index.ts
@@ -1,6 +1,5 @@
-import type { Tree } from '@nx/devkit';
-import { convertNxGenerator } from '@nx/devkit';
-import { wrapAngularDevkitSchematic } from '@nx/devkit/ngcli-adapter';
+import type { Rule, SchematicContext, Tree } from '@angular-devkit/schematics';
+import { chain, externalSchematic } from '@angular-devkit/schematics';
 /**
  * We are able to use the full, unaltered Schema directly from @schematics/angular
  * The applicable json file is copied from node_modules as a prebuiid step to ensure
@@ -8,32 +7,35 @@ import { wrapAngularDevkitSchematic } from '@nx/devkit/ngcli-adapter';
  */
 import type { Schema as AngularSchema } from '@schematics/angular/application/schema';
 import {
-  addESLintTargetToProject__NX,
-  createESLintConfigForProject__NX,
+  addESLintTargetToProject,
+  createESLintConfigForProject,
 } from '../utils';
 
 interface Schema extends AngularSchema {
   setParserOptionsProject?: boolean;
 }
 
-export default convertNxGenerator(async (tree: Tree, options: Schema) => {
-  // Remove angular-eslint specific options before passing to the Angular schematic
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const { setParserOptionsProject, ...angularOptions } = options;
+function eslintRelatedChanges(options: Schema) {
+  return chain([
+    // Update the lint builder and config in angular.json
+    addESLintTargetToProject(options.name, 'lint'),
+    // Create the ESLint config file for the project
+    createESLintConfigForProject(
+      options.name,
+      options.setParserOptionsProject ?? false,
+    ),
+  ]);
+}
 
-  const applicationGenerator = wrapAngularDevkitSchematic(
-    '@schematics/angular',
-    'application',
-  );
+export default function (options: Schema): Rule {
+  return (host: Tree, context: SchematicContext) => {
+    // Remove angular-eslint specific options before passing to the Angular schematic
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const { setParserOptionsProject, ...angularOptions } = options;
 
-  await applicationGenerator(tree, angularOptions);
-
-  // Update the lint builder and config in angular.json
-  addESLintTargetToProject__NX(tree, options.name, 'lint');
-
-  createESLintConfigForProject__NX(
-    tree,
-    options.name,
-    options.setParserOptionsProject ?? false,
-  );
-});
+    return chain([
+      externalSchematic('@schematics/angular', 'application', angularOptions),
+      eslintRelatedChanges(options),
+    ])(host, context);
+  };
+}

--- a/packages/schematics/src/library/index.ts
+++ b/packages/schematics/src/library/index.ts
@@ -1,6 +1,5 @@
-import type { Tree } from '@nx/devkit';
-import { convertNxGenerator } from '@nx/devkit';
-import { wrapAngularDevkitSchematic } from '@nx/devkit/ngcli-adapter';
+import type { Rule, SchematicContext, Tree } from '@angular-devkit/schematics';
+import { chain, externalSchematic } from '@angular-devkit/schematics';
 /**
  * We are able to use the full, unaltered Schema directly from @schematics/angular
  * The applicable json file is copied from node_modules as a prebuiid step to ensure
@@ -8,32 +7,35 @@ import { wrapAngularDevkitSchematic } from '@nx/devkit/ngcli-adapter';
  */
 import type { Schema as AngularSchema } from '@schematics/angular/library/schema';
 import {
-  addESLintTargetToProject__NX,
-  createESLintConfigForProject__NX,
+  addESLintTargetToProject,
+  createESLintConfigForProject,
 } from '../utils';
 
 interface Schema extends AngularSchema {
   setParserOptionsProject?: boolean;
 }
 
-export default convertNxGenerator(async (tree: Tree, options: Schema) => {
-  // Remove angular-eslint specific options before passing to the Angular schematic
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const { setParserOptionsProject, ...angularOptions } = options;
+function eslintRelatedChanges(options: Schema) {
+  return chain([
+    // Update the lint builder and config in angular.json
+    addESLintTargetToProject(options.name, 'lint'),
+    // Create the ESLint config file for the project
+    createESLintConfigForProject(
+      options.name,
+      options.setParserOptionsProject ?? false,
+    ),
+  ]);
+}
 
-  const libraryGenerator = wrapAngularDevkitSchematic(
-    '@schematics/angular',
-    'library',
-  );
+export default function (options: Schema): Rule {
+  return (host: Tree, context: SchematicContext) => {
+    // Remove angular-eslint specific options before passing to the Angular schematic
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const { setParserOptionsProject, ...angularOptions } = options;
 
-  await libraryGenerator(tree, angularOptions);
-
-  // Update the lint builder and config in angular.json
-  addESLintTargetToProject__NX(tree, options.name, 'lint');
-
-  createESLintConfigForProject__NX(
-    tree,
-    options.name,
-    options.setParserOptionsProject ?? false,
-  );
-});
+    return chain([
+      externalSchematic('@schematics/angular', 'library', angularOptions),
+      eslintRelatedChanges(options),
+    ])(host, context);
+  };
+}

--- a/packages/schematics/src/utils.ts
+++ b/packages/schematics/src/utils.ts
@@ -8,17 +8,9 @@ import type { Path } from '@angular-devkit/core';
 import { join, normalize } from '@angular-devkit/core';
 import type { Rule, SchematicContext, Tree } from '@angular-devkit/schematics';
 import { callRule, chain } from '@angular-devkit/schematics';
-import type { Tree as NxTree, ProjectConfiguration } from '@nx/devkit';
-import {
-  offsetFromRoot as offsetFromRoot__NX,
-  readJson,
-  writeJson,
-} from '@nx/devkit';
 import type { Ignore } from 'ignore';
 import ignore from 'ignore';
 import stripJsonComments from 'strip-json-comments';
-
-const DEFAULT_PREFIX = 'app';
 
 /**
  * This method is specifically for reading JSON files in a Tree
@@ -116,53 +108,6 @@ function updateWorkspaceInTree<T = any, O = T>(
     );
     return host;
   };
-}
-
-function readProjectConfiguration(tree: NxTree, projectName: string) {
-  const angularJSON = readJson(tree, 'angular.json');
-  return angularJSON.projects[projectName];
-}
-
-function updateProjectConfiguration(
-  tree: NxTree,
-  projectName: string,
-  projectConfig: ProjectConfiguration,
-) {
-  const angularJSON = readJson(tree, 'angular.json');
-  angularJSON.projects[projectName] = projectConfig;
-  writeJson(tree, 'angular.json', angularJSON);
-}
-
-export function addESLintTargetToProject__NX(
-  tree: NxTree,
-  projectName: string,
-  targetName: 'eslint' | 'lint',
-) {
-  const existingProjectConfig = readProjectConfiguration(tree, projectName);
-
-  let lintFilePatternsRoot = '';
-
-  // Default Angular CLI project at the root of the workspace
-  if (existingProjectConfig.root === '') {
-    lintFilePatternsRoot = existingProjectConfig.sourceRoot || 'src';
-  } else {
-    lintFilePatternsRoot = existingProjectConfig.root;
-  }
-
-  const eslintTargetConfig = {
-    builder: '@angular-eslint/builder:lint',
-    options: {
-      lintFilePatterns: [
-        `${lintFilePatternsRoot}/**/*.ts`,
-        `${lintFilePatternsRoot}/**/*.html`,
-      ],
-    },
-  };
-
-  existingProjectConfig.architect = existingProjectConfig.architect || {};
-  existingProjectConfig.architect[targetName] = eslintTargetConfig;
-
-  updateProjectConfiguration(tree, projectName, existingProjectConfig);
 }
 
 export function addESLintTargetToProject(
@@ -346,88 +291,6 @@ function createProjectESLintConfig(
   };
 }
 
-function createProjectESLintConfig__NX(
-  projectRoot: string,
-  projectType: ProjectType,
-  prefix: string,
-  setParserOptionsProject: boolean,
-  hasE2e: boolean,
-) {
-  return {
-    extends: `${offsetFromRoot__NX(projectRoot)}.eslintrc.json`,
-    ignorePatterns: ['!**/*'],
-    overrides: [
-      {
-        files: ['*.ts'],
-        ...(setParserOptionsProject
-          ? {
-              parserOptions: {
-                project: setESLintProjectBasedOnProjectType(
-                  projectRoot,
-                  projectType,
-                  hasE2e,
-                ),
-              },
-            }
-          : null),
-        rules: {
-          '@angular-eslint/directive-selector': [
-            'error',
-            { type: 'attribute', prefix, style: 'camelCase' },
-          ],
-          '@angular-eslint/component-selector': [
-            'error',
-            { type: 'element', prefix, style: 'kebab-case' },
-          ],
-        },
-      },
-
-      {
-        files: ['*.html'],
-        rules: {},
-      },
-    ],
-  };
-}
-
-export function createESLintConfigForProject__NX(
-  tree: NxTree,
-  projectName: string,
-  setParserOptionsProject: boolean,
-) {
-  const existingProjectConfig = readProjectConfiguration(tree, projectName);
-  const targets =
-    existingProjectConfig.architect || existingProjectConfig.targets;
-  const { root: projectRoot, projectType, prefix } = existingProjectConfig;
-
-  const hasE2e = !!targets?.e2e;
-
-  /**
-   * If the root is an empty string it must be the initial project created at the
-   * root by the Angular CLI's workspace schematic
-   */
-  if (projectRoot === '') {
-    return createRootESLintConfigFile__NX(tree, prefix || DEFAULT_PREFIX);
-  }
-
-  // If, for whatever reason, the root .eslintrc.json doesn't exist yet, create it
-  if (!tree.exists('.eslintrc.json')) {
-    createRootESLintConfigFile__NX(tree, prefix || DEFAULT_PREFIX);
-  }
-
-  writeJson(
-    tree,
-    join(normalize(projectRoot), '.eslintrc.json'),
-    createProjectESLintConfig__NX(
-      projectRoot,
-      projectType || 'library',
-      prefix || DEFAULT_PREFIX,
-      setParserOptionsProject,
-      hasE2e,
-    ),
-  );
-}
-
 export function createESLintConfigForProject(
   projectName: string,
   setParserOptionsProject: boolean,
@@ -484,10 +347,6 @@ function createRootESLintConfigFile(projectName: string): Rule {
   };
 }
 
-function createRootESLintConfigFile__NX(tree: NxTree, prefix: string) {
-  return writeJson(tree, '.eslintrc.json', createRootESLintConfig(prefix));
-}
-
 export function sortObjectByKeys(
   obj: Record<string, unknown>,
 ): Record<string, unknown> {
@@ -499,25 +358,6 @@ export function sortObjectByKeys(
         [key]: obj[key],
       };
     }, {});
-}
-
-/**
- * To make certain schematic usage conversion more ergonomic, if the user does not specify a project
- * and only has a single project in their angular.json we will just go ahead and use that one.
- */
-export function determineTargetProjectName__NX(
-  tree: NxTree,
-  maybeProject?: string,
-): string | null {
-  if (maybeProject) {
-    return maybeProject;
-  }
-  const workspaceJson = readJson(tree, 'angular.json');
-  const projects = Object.keys(workspaceJson.projects);
-  if (projects.length === 1) {
-    return projects[0];
-  }
-  return null;
 }
 
 /**

--- a/yarn.lock
+++ b/yarn.lock
@@ -2070,13 +2070,6 @@
     read-package-json-fast "^3.0.0"
     which "^4.0.0"
 
-"@nrwl/devkit@18.0.8":
-  version "18.0.8"
-  resolved "https://registry.yarnpkg.com/@nrwl/devkit/-/devkit-18.0.8.tgz#9f412c9793615e18f49565a0e58a28207c6d9c21"
-  integrity sha512-cKtXq2I/3y/t1I+jMn8XVfhtSjGxJHKGSmxStMdRPMcUim8iaS2V3fDUdF2CGrXrtbmDtYwBC8413YY+nVh0Gw==
-  dependencies:
-    "@nx/devkit" "18.0.8"
-
 "@nrwl/devkit@19.0.0-beta.8":
   version "19.0.0-beta.8"
   resolved "https://registry.yarnpkg.com/@nrwl/devkit/-/devkit-19.0.0-beta.8.tgz#8b4ba715923780a43951e8d6ac8e99b5fe82b4c1"
@@ -2112,14 +2105,6 @@
   dependencies:
     "@nx/plugin" "19.0.0-beta.8"
 
-"@nrwl/tao@18.0.8":
-  version "18.0.8"
-  resolved "https://registry.yarnpkg.com/@nrwl/tao/-/tao-18.0.8.tgz#78b87d179e71d10bdf87778ea3e5ae4443fec9e5"
-  integrity sha512-zBzdv9mGBaWtBbujbLCVzG7ZI5npUg9fnUz8VtjN6jydAQEL/Uqj5mPlFYQPPBAw2xwF8TL9ZX/rOoAWHnJtjw==
-  dependencies:
-    nx "18.0.8"
-    tslib "^2.3.0"
-
 "@nrwl/tao@19.0.0-beta.8":
   version "19.0.0-beta.8"
   resolved "https://registry.yarnpkg.com/@nrwl/tao/-/tao-19.0.0-beta.8.tgz#a142826ae2e29f425146433b3e6557ddc32f708b"
@@ -2134,20 +2119,6 @@
   integrity sha512-lAEA+YzENF6dosGcLihMPi/TAEgOGpoFRipy/VCWVXWj+xL2aGLA4KaTZgyc6uyVR/2vG8JkkJ1FSg+DtDEuzw==
   dependencies:
     "@nx/workspace" "19.0.0-beta.8"
-
-"@nx/devkit@18.0.8", "@nx/devkit@^17.2.8 || ^18.0.0":
-  version "18.0.8"
-  resolved "https://registry.yarnpkg.com/@nx/devkit/-/devkit-18.0.8.tgz#4d7ce2f31984a9e61bd18e364f85d5f45779c8ac"
-  integrity sha512-df56bzmhF8yhVCCChe0ATjCsc9r9SNcpks5/bABGqR91vHVGfsz0H33RYO7P2jrPwFBRYnf+aWWFY1d6NpEdxw==
-  dependencies:
-    "@nrwl/devkit" "18.0.8"
-    ejs "^3.1.7"
-    enquirer "~2.3.6"
-    ignore "^5.0.4"
-    semver "^7.5.3"
-    tmp "~0.2.1"
-    tslib "^2.3.0"
-    yargs-parser "21.1.1"
 
 "@nx/devkit@19.0.0-beta.8":
   version "19.0.0-beta.8"
@@ -2256,100 +2227,50 @@
   dependencies:
     "@nx/eslint" "19.0.0-beta.8"
 
-"@nx/nx-darwin-arm64@18.0.8":
-  version "18.0.8"
-  resolved "https://registry.yarnpkg.com/@nx/nx-darwin-arm64/-/nx-darwin-arm64-18.0.8.tgz#0c51e43cd7dbd7a25e63562aafdecc478661801f"
-  integrity sha512-B2vX90j1Ex9Mki/Fai45UJ0r7mPc/xLBzQYQ9MFI2XoUXKhYl5BVBfJ+EbJ2PBcIXAnp44qY0wyxEpp+8Glxcg==
-
 "@nx/nx-darwin-arm64@19.0.0-beta.8":
   version "19.0.0-beta.8"
   resolved "https://registry.yarnpkg.com/@nx/nx-darwin-arm64/-/nx-darwin-arm64-19.0.0-beta.8.tgz#74919cadc18b61ed9008dcf2c56a756e97201356"
   integrity sha512-s9q8dKibTWLTZZVVsxTs94hXNkfgKeOq/v6Xz4Q/vXp4K+RHQPziDZ9oYSsm8pfF80wwlMu78DCJZLR99x22aA==
-
-"@nx/nx-darwin-x64@18.0.8":
-  version "18.0.8"
-  resolved "https://registry.yarnpkg.com/@nx/nx-darwin-x64/-/nx-darwin-x64-18.0.8.tgz#df8d5ea87565afbf86dfe46bd1ea646ed5721e62"
-  integrity sha512-nC172j4LwOqc22BtJGsrjPYGhZ6EFXhYi0ceb6yzEA1Z32Wl98OXbAcbbhyEcuL3iYI9VrZgzAAzIUo7l4injw==
 
 "@nx/nx-darwin-x64@19.0.0-beta.8":
   version "19.0.0-beta.8"
   resolved "https://registry.yarnpkg.com/@nx/nx-darwin-x64/-/nx-darwin-x64-19.0.0-beta.8.tgz#9bba5683c842d21c9b20445e758beb7e7a6d1b10"
   integrity sha512-JEOJ86Q9rJf/UVI+mTuOvmWzWuZ3s4H4unfJCpFrsJDRn+P1xldEMLDWaqwOuXOKkIyv/ZH8czKqGMr1z0Yevw==
 
-"@nx/nx-freebsd-x64@18.0.8":
-  version "18.0.8"
-  resolved "https://registry.yarnpkg.com/@nx/nx-freebsd-x64/-/nx-freebsd-x64-18.0.8.tgz#415085b231eab5a3887e55fe5e110be681a441a8"
-  integrity sha512-Qoz668WMB6nxdMFG5X88B7W72+d5K/95XEFKY2022EPm88DQFFcJAfdkMrRkeO3yBJtwLAAK+Jyni9uAfOXzGQ==
-
 "@nx/nx-freebsd-x64@19.0.0-beta.8":
   version "19.0.0-beta.8"
   resolved "https://registry.yarnpkg.com/@nx/nx-freebsd-x64/-/nx-freebsd-x64-19.0.0-beta.8.tgz#c5684d24b084b08b7d2a829f295e9af72715da49"
   integrity sha512-w8OXsK4tdRHPQMU2nLOaLUXSaoGKQZQeasvVe2tRc7ZFLZpXVTRwv6CMLuhmrD3ath0GfE3CWVl7JLKXBL47FQ==
-
-"@nx/nx-linux-arm-gnueabihf@18.0.8":
-  version "18.0.8"
-  resolved "https://registry.yarnpkg.com/@nx/nx-linux-arm-gnueabihf/-/nx-linux-arm-gnueabihf-18.0.8.tgz#b7aeffb7c10ca6f4169ae01179bd14891097bddd"
-  integrity sha512-0RTuJTaAmE7Xjc0P0DIbbYEhPGBILCii2nOz6vwTEzIqxSMgXW4T1g1zSDKCiUUyS6HVffGvCTNvuHuoYY2DMg==
 
 "@nx/nx-linux-arm-gnueabihf@19.0.0-beta.8":
   version "19.0.0-beta.8"
   resolved "https://registry.yarnpkg.com/@nx/nx-linux-arm-gnueabihf/-/nx-linux-arm-gnueabihf-19.0.0-beta.8.tgz#5abd35a5aa2daa59bd2059222ee66fb014468a73"
   integrity sha512-5agEQtktr64LzCZBY/9kgnG3fEigWOYOOvLNmh+8v1qSraFiX8+xc0LDIlmr00bAoi4Yq9h2YD05quJLpiMu1g==
 
-"@nx/nx-linux-arm64-gnu@18.0.8":
-  version "18.0.8"
-  resolved "https://registry.yarnpkg.com/@nx/nx-linux-arm64-gnu/-/nx-linux-arm64-gnu-18.0.8.tgz#8b52f40e79056ba8d1af46f7787c0d95caa55b80"
-  integrity sha512-fmwsrDeeY44f6cCnfrXNuvFEzqvD/A5yg3TVwZoKldWRAG5gexj4AWpBHqgGTcCj6ky1NGxnlaktKC5geGhJhA==
-
 "@nx/nx-linux-arm64-gnu@19.0.0-beta.8":
   version "19.0.0-beta.8"
   resolved "https://registry.yarnpkg.com/@nx/nx-linux-arm64-gnu/-/nx-linux-arm64-gnu-19.0.0-beta.8.tgz#02b70c3c0013a41119af85dc0a02393204fff5ff"
   integrity sha512-the6iIHEuI0CXc4afGxDjBQU1W9P3WP5gnBr5pydC3ozjigIl9z4i4Lek0gcjUiOb493/A5YFM/exIK+0eIXbg==
-
-"@nx/nx-linux-arm64-musl@18.0.8":
-  version "18.0.8"
-  resolved "https://registry.yarnpkg.com/@nx/nx-linux-arm64-musl/-/nx-linux-arm64-musl-18.0.8.tgz#725258e5c15c1f9f788bab0af30a56e29beb85d1"
-  integrity sha512-jz1dzQlrfZteJdsEJ1MbjI7m2jkBLhLe5y9x+96/KgmJbCV7LD9RLevWIzz7FDuhfJziMOoSrGdaW47G13p/Fw==
 
 "@nx/nx-linux-arm64-musl@19.0.0-beta.8":
   version "19.0.0-beta.8"
   resolved "https://registry.yarnpkg.com/@nx/nx-linux-arm64-musl/-/nx-linux-arm64-musl-19.0.0-beta.8.tgz#2bda0df84e908a27e357d2f57ab0f1e85ac96c2d"
   integrity sha512-BNPtmAUaBwAHZuOzT/0KrsPdESb5kG6LglvlwG42yDM+shCyZGWlzvl/vlG28sOgLdT+wVbR95WzdFdtnCktQg==
 
-"@nx/nx-linux-x64-gnu@18.0.8":
-  version "18.0.8"
-  resolved "https://registry.yarnpkg.com/@nx/nx-linux-x64-gnu/-/nx-linux-x64-gnu-18.0.8.tgz#98c5456e1cfdaad65bfae0c188a2f8676b634f5d"
-  integrity sha512-eq2AAZN4fsjhABtU76eroFHcNK6QWo4eMAH7tcZUoGLwfBAo+wPYggxm9LNZ5weKVxwqySHavlXd5rNA26WrbA==
-
 "@nx/nx-linux-x64-gnu@19.0.0-beta.8":
   version "19.0.0-beta.8"
   resolved "https://registry.yarnpkg.com/@nx/nx-linux-x64-gnu/-/nx-linux-x64-gnu-19.0.0-beta.8.tgz#04eba3733ed203a3063db0f7851431b51aee7d91"
   integrity sha512-IOrIrVWUsvN5hZINZJbTcI2KjAyM4ro1/FLOpFp7RpL/uJszrLJuFo1eOImiOjqWpr3iR5lDt1S0wtsLMs003A==
-
-"@nx/nx-linux-x64-musl@18.0.8":
-  version "18.0.8"
-  resolved "https://registry.yarnpkg.com/@nx/nx-linux-x64-musl/-/nx-linux-x64-musl-18.0.8.tgz#53bfaf2432d1a8988995136e45d22b278927b003"
-  integrity sha512-FBHVJ0DtBqQynbQImg1kc9/WfRGSvbRNzaqI2rO/zO0j2BeT9BQ8byTn2EiMBxz72LSbqEmtQtqe5w50hAsKcA==
 
 "@nx/nx-linux-x64-musl@19.0.0-beta.8":
   version "19.0.0-beta.8"
   resolved "https://registry.yarnpkg.com/@nx/nx-linux-x64-musl/-/nx-linux-x64-musl-19.0.0-beta.8.tgz#a38e0afccff217921c68b24b337edc7fff152dd6"
   integrity sha512-accL6xwIrJQLHphOqzvT9VlH9Gsr8cCoyJJpXhpYGBHWIkpLDM2GcB/0Z+qEFrzlDEi36yCqBbc5HahLvJ+Geg==
 
-"@nx/nx-win32-arm64-msvc@18.0.8":
-  version "18.0.8"
-  resolved "https://registry.yarnpkg.com/@nx/nx-win32-arm64-msvc/-/nx-win32-arm64-msvc-18.0.8.tgz#dd70a40a5f8345587eee3950adcb3d36aa396c61"
-  integrity sha512-qphQIIfwAR03s7ifPVc0XhjdOeep2hOoZN2jN5ShG1QD/DIipNnMrRK21M6JcoP7soRPpkJFlI5Yaleh9/EJhg==
-
 "@nx/nx-win32-arm64-msvc@19.0.0-beta.8":
   version "19.0.0-beta.8"
   resolved "https://registry.yarnpkg.com/@nx/nx-win32-arm64-msvc/-/nx-win32-arm64-msvc-19.0.0-beta.8.tgz#f7c4999728da3a473386c54b11773cec1119acbc"
   integrity sha512-fhhGlzzThh7BIq5tVHFEHL11pfOzTJXqU7q9EYkro88qwQIKynkTthtU+8vuQzBVjldbpDpgIFUwecTQXrbnfQ==
-
-"@nx/nx-win32-x64-msvc@18.0.8":
-  version "18.0.8"
-  resolved "https://registry.yarnpkg.com/@nx/nx-win32-x64-msvc/-/nx-win32-x64-msvc-18.0.8.tgz#fe1ae3d1b1eec2ef4291a700500cc96bbfb81cec"
-  integrity sha512-XP8hle+cPNH5n18iTM7l0q07zEdvoPcHYVr5IoYOA54Ke9ZUxau4owUeok2HhLr61o2u0CTwf1vWoV+Y1AUAdg==
 
 "@nx/nx-win32-x64-msvc@19.0.0-beta.8":
   version "19.0.0-beta.8"
@@ -7920,57 +7841,6 @@ npmlog@^6.0.0:
     console-control-strings "^1.1.0"
     gauge "^4.0.3"
     set-blocking "^2.0.0"
-
-nx@18.0.8, "nx@^17.2.8 || ^18.0.0":
-  version "18.0.8"
-  resolved "https://registry.yarnpkg.com/nx/-/nx-18.0.8.tgz#5d0ac8b53663cc53045c63005ff3fc7592a0bc5d"
-  integrity sha512-IhzRLCZaiR9zKGJ3Jm79bhi8nOdyRORQkFc/YDO6xubLSQ5mLPAeg789Q/SlGRzU5oMwLhm5D/gvvMJCAvUmXQ==
-  dependencies:
-    "@nrwl/tao" "18.0.8"
-    "@yarnpkg/lockfile" "^1.1.0"
-    "@yarnpkg/parsers" "3.0.0-rc.46"
-    "@zkochan/js-yaml" "0.0.6"
-    axios "^1.6.0"
-    chalk "^4.1.0"
-    cli-cursor "3.1.0"
-    cli-spinners "2.6.1"
-    cliui "^8.0.1"
-    dotenv "~16.3.1"
-    dotenv-expand "~10.0.0"
-    enquirer "~2.3.6"
-    figures "3.2.0"
-    flat "^5.0.2"
-    fs-extra "^11.1.0"
-    ignore "^5.0.4"
-    jest-diff "^29.4.1"
-    js-yaml "4.1.0"
-    jsonc-parser "3.2.0"
-    lines-and-columns "~2.0.3"
-    minimatch "9.0.3"
-    node-machine-id "1.1.12"
-    npm-run-path "^4.0.1"
-    open "^8.4.0"
-    ora "5.3.0"
-    semver "^7.5.3"
-    string-width "^4.2.3"
-    strong-log-transformer "^2.1.0"
-    tar-stream "~2.2.0"
-    tmp "~0.2.1"
-    tsconfig-paths "^4.1.2"
-    tslib "^2.3.0"
-    yargs "^17.6.2"
-    yargs-parser "21.1.1"
-  optionalDependencies:
-    "@nx/nx-darwin-arm64" "18.0.8"
-    "@nx/nx-darwin-x64" "18.0.8"
-    "@nx/nx-freebsd-x64" "18.0.8"
-    "@nx/nx-linux-arm-gnueabihf" "18.0.8"
-    "@nx/nx-linux-arm64-gnu" "18.0.8"
-    "@nx/nx-linux-arm64-musl" "18.0.8"
-    "@nx/nx-linux-x64-gnu" "18.0.8"
-    "@nx/nx-linux-x64-musl" "18.0.8"
-    "@nx/nx-win32-arm64-msvc" "18.0.8"
-    "@nx/nx-win32-x64-msvc" "18.0.8"
 
 nx@19.0.0-beta.8:
   version "19.0.0-beta.8"


### PR DESCRIPTION
and rely on `@angular-devkit` at runtime.