### PR TITLE
ci(github-action): skip publish on forks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -141,7 +141,8 @@ jobs:
     permissions:
       id-token: write # needed for provenance data generation
     needs: [primary]
-    if: github.ref == 'refs/heads/main'
+    # prevents this action from running on forks
+    if: (github.repository == 'angular-eslint/angular-eslint') && (github.ref == 'refs/heads/main')
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,6 +14,8 @@ on:
 
 jobs:
   publish:
+    # prevents this action from running on forks
+    if: github.repository == 'angular-eslint/angular-eslint'
     name: Publish to npm
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
## Improvement

Skip publish workflow on forked repositories

## Currently

Publish workflow is executed on forks:

https://github.com/chimurai/angular-eslint/actions/runs/9324614358

<img width="645" alt="image" src="https://github.com/angular-eslint/angular-eslint/assets/655241/52030ef1-5113-4292-a97b-20a03507e09e">


