### PR TITLE
fix(test-utils): use configured RuleTester.afterAll over global

### DIFF
--- a/packages/test-utils/src/rule-tester.ts
+++ b/packages/test-utils/src/rule-tester.ts
@@ -42,6 +42,7 @@ export class RuleTester extends TSESLintRuleTester {
 
     // make sure that the parser doesn't hold onto file handles between tests
     // on linux (i.e. our CI env), there can be very a limited number of watch handles available
+    const afterAll = RuleTester.afterAll ?? globalThis.afterAll;
     afterAll(() => {
       try {
         // instead of creating a hard dependency, just use a soft require


### PR DESCRIPTION
The `RuleTester` class from `@typescript-eslint/rule-tester` can be extended for various testing frameworks by updating `RuleTester.describe`, `RuleTester.afterAll`, etc. But the Angular one is hard-coded to a `globalThis.afterAll`, and ignores `RuleTester.afterAll`. This PR will make `@angular-eslint/test-utils` respect `RuleTester.afterAll`, by using that first if it exists.

![image](https://github.com/angular-eslint/angular-eslint/assets/8770194/f5426f0c-628d-494f-a1a0-2ed8bdb5b5fc)
