### PR TITLE
fix(eslint-plugin-template): [prefer-self-closing-tags] support ng-content with fallback content

### DIFF
--- a/packages/eslint-plugin-template/docs/rules/prefer-self-closing-tags.md
+++ b/packages/eslint-plugin-template/docs/rules/prefer-self-closing-tags.md
@@ -553,6 +553,32 @@ The rule does not have any configuration options.
 
 #### ✅ Valid Code
 
+```html
+<ng-content>Fallback content</ng-content>
+```
+
+<br>
+
+---
+
+<br>
+
+#### Default Config
+
+```json
+{
+  "rules": {
+    "@angular-eslint/template/prefer-self-closing-tags": [
+      "error"
+    ]
+  }
+}
+```
+
+<br>
+
+#### ✅ Valid Code
+
 **Filename: src/index.html**
 
 ```html

--- a/packages/eslint-plugin-template/src/rules/prefer-self-closing-tags.ts
+++ b/packages/eslint-plugin-template/src/rules/prefer-self-closing-tags.ts
@@ -96,18 +96,20 @@ export default createESLintRule<[], typeof MESSAGE_ID>({
       const { sourceSpan } = node;
       const ngContentCloseTag = '</ng-content>';
       if (sourceSpan.toString().includes(ngContentCloseTag)) {
-        // content nodes can only contain whitespaces
-        const content =
-          sourceSpan
-            .toString()
-            .match(/>(\s*)</m)
-            ?.at(1) ?? '';
+        const whiteSpaceContent = sourceSpan
+          .toString()
+          .match(/>(\s*)</m)
+          ?.at(1);
+        const hasContent = typeof whiteSpaceContent === 'undefined';
+        if (hasContent) {
+          return;
+        }
         const openingTagLastChar =
           // This is more than the minimum length of a ng-content element
           // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
           sourceSpan
             .toString()
-            .at(-2 - ngContentCloseTag.length - content.length)!;
+            .at(-2 - ngContentCloseTag.length - whiteSpaceContent.length)!;
         const closingTagPrefix = getClosingTagPrefix(openingTagLastChar);
 
         context.report({
@@ -129,7 +131,7 @@ export default createESLintRule<[], typeof MESSAGE_ID>({
               [
                 sourceSpan.end.offset -
                   ngContentCloseTag.length -
-                  content.length -
+                  whiteSpaceContent.length -
                   1,
                 sourceSpan.end.offset,
               ],

--- a/packages/eslint-plugin-template/tests/rules/prefer-self-closing-tags/cases.ts
+++ b/packages/eslint-plugin-template/tests/rules/prefer-self-closing-tags/cases.ts
@@ -16,6 +16,7 @@ export const valid = [
   '<ng-template>Content</ng-template>',
   '<ng-content/>',
   '<ng-content select="my-selector" />',
+  `<ng-content>Fallback content</ng-content>`,
   { code: '<app-root></app-root>', filename: 'src/index.html' },
 ];
 


### PR DESCRIPTION
Since Angular 18, `<ng-content>` can be used with a fallback content. The `prefer-self-closing-tags` rule currently raises an error when using this feature, see https://github.com/angular-eslint/angular-eslint/issues/1567#issuecomment-2156430905.