### PR TITLE
fix(template-parser): visit receiver of Call expression

### DIFF
--- a/packages/eslint-plugin-template/docs/rules/no-call-expression.md
+++ b/packages/eslint-plugin-template/docs/rules/no-call-expression.md
@@ -393,6 +393,62 @@ interface Options {
 
 <br>
 
+#### Default Config
+
+```json
+{
+  "rules": {
+    "@angular-eslint/template/no-call-expression": [
+      "error"
+    ]
+  }
+}
+```
+
+<br>
+
+#### ❌ Invalid Code
+
+```html
+{{ foo()() }}
+   ~~~~~~~
+   ~~~~~
+```
+
+<br>
+
+---
+
+<br>
+
+#### Default Config
+
+```json
+{
+  "rules": {
+    "@angular-eslint/template/no-call-expression": [
+      "error"
+    ]
+  }
+}
+```
+
+<br>
+
+#### ❌ Invalid Code
+
+```html
+{{ foo().bar() }}
+   ~~~~~~~~~~~
+   ~~~~~
+```
+
+<br>
+
+---
+
+<br>
+
 #### Custom Config
 
 ```json

--- a/packages/eslint-plugin-template/docs/rules/no-call-expression.md
+++ b/packages/eslint-plugin-template/docs/rules/no-call-expression.md
@@ -67,8 +67,8 @@ interface Options {
 #### ❌ Invalid Code
 
 ```html
-<div>{{ getInfo()() }}</div>
-        ~~~~~~~~~~~
+<div>{{ getInfo() }}</div>
+        ~~~~~~~~~
 ```
 
 <br>
@@ -148,8 +148,8 @@ interface Options {
 #### ❌ Invalid Code
 
 ```html
-<a [href]="id && createUrl() && test()($any)">info</a>
-                 ~~~~~~~~~~~    ~~~~~~~~~~~~
+<a [href]="id && createUrl() && test($any)">info</a>
+                 ~~~~~~~~~~~    ~~~~~~~~~~
 {{ id || obj?.nested1() }}
          ~~~~~~~~~~~~~~
 ```
@@ -179,8 +179,8 @@ interface Options {
 ```html
 <a [href]="id ? a?.createUrl() : editUrl(3)">info</a>
                 ~~~~~~~~~~~~~~   ~~~~~~~~~~
-{{ 1 === 2 ? 3 : obj?.nested1()() }}
-                 ~~~~~~~~~~~~~~~~
+{{ 1 === 2 ? 3 : obj?.nested1() }}
+                 ~~~~~~~~~~~~~~
 ```
 
 <br>
@@ -208,8 +208,8 @@ interface Options {
 ```html
 {{ obj?.nested1() }} {{ obj!.nested1() }}
    ~~~~~~~~~~~~~~       ~~~~~~~~~~~~~~
-<button [type]="obj!.$any(b)!.getType()()">info</button>
-                ~~~~~~~~~~~~~~~~~~~~~~~~~
+<button [type]="obj!.$any(b)!.getType()">info</button>
+                ~~~~~~~~~~~~~~~~~~~~~~~
 <a [href]="obj.propertyA?.href()">info</a>
            ~~~~~~~~~~~~~~~~~~~~~
 ```
@@ -358,6 +358,65 @@ interface Options {
   <div [id]="foo()"></div>
              ~~~~~
 }
+```
+
+<br>
+
+---
+
+<br>
+
+#### Default Config
+
+```json
+{
+  "rules": {
+    "@angular-eslint/template/no-call-expression": [
+      "error"
+    ]
+  }
+}
+```
+
+<br>
+
+#### ❌ Invalid Code
+
+```html
+{{ foo(bar(), baz()) }}
+   ~~~~~~~~~~~~~~~~~
+```
+
+<br>
+
+---
+
+<br>
+
+#### Custom Config
+
+```json
+{
+  "rules": {
+    "@angular-eslint/template/no-call-expression": [
+      "error",
+      {
+        "allowList": [
+          "ok"
+        ]
+      }
+    ]
+  }
+}
+```
+
+<br>
+
+#### ❌ Invalid Code
+
+```html
+{{ notOk().ok() }}
+   ~~~~~~~
 ```
 
 </details>

--- a/packages/eslint-plugin-template/tests/rules/no-call-expression/cases.ts
+++ b/packages/eslint-plugin-template/tests/rules/no-call-expression/cases.ts
@@ -241,32 +241,30 @@ export const invalid: readonly InvalidTestCase<MessageIds, Options>[] = [
       { char: '#', messageId },
     ],
   }),
-  extendError(
-    convertAnnotatedSourceToFailureCase({
-      description: 'should fail multiple times for nested calls',
-      annotatedSource: `
+  convertAnnotatedSourceToFailureCase({
+    description: 'should fail multiple times for nested calls',
+    annotatedSource: `
     {{ foo()() }}
-       ^^^^^~~
+       ~~~~~~~
+       ^^^^^
     `,
-      messages: [
-        { char: '~', messageId },
-        { char: '^', messageId },
-      ],
-    }),
-  ),
-  extendError(
-    convertAnnotatedSourceToFailureCase({
-      description: 'should fail multiple times for chained calls',
-      annotatedSource: `
+    messages: [
+      { char: '~', messageId },
+      { char: '^', messageId },
+    ],
+  }),
+  convertAnnotatedSourceToFailureCase({
+    description: 'should fail multiple times for chained calls',
+    annotatedSource: `
     {{ foo().bar() }}
-       ^^^^^~~~~~~
+       ~~~~~~~~~~~
+       ^^^^^
     `,
-      messages: [
-        { char: '~', messageId },
-        { char: '^', messageId },
-      ],
-    }),
-  ),
+    messages: [
+      { char: '~', messageId },
+      { char: '^', messageId },
+    ],
+  }),
   convertAnnotatedSourceToFailureCase({
     description: 'should fail for nested call not in allowList',
     annotatedSource: `
@@ -277,12 +275,3 @@ export const invalid: readonly InvalidTestCase<MessageIds, Options>[] = [
     messages: [{ char: '~', messageId }],
   }),
 ];
-
-// convertAnnotatedSourceToFailureCase unfortunately cannot handle multiple errors starting/ending at the same position;
-// manually adjust the outer error (~) to start at the same column as the inner error (^)
-function extendError<T extends InvalidTestCase<MessageIds, Options>>(
-  testCase: T,
-): T {
-  (testCase.errors[0] as any).column = testCase.errors[1].column;
-  return testCase;
-}

--- a/packages/template-parser/src/index.ts
+++ b/packages/template-parser/src/index.ts
@@ -42,6 +42,7 @@ const KEYS: VisitorKeys = {
   BoundEvent: ['handler'],
   BoundText: ['value'],
   Call: ['receiver', 'args'],
+  SafeCall: ['receiver', 'args'],
   Conditional: ['condition', 'trueExp', 'falseExp'],
   Element$1: ['children', 'inputs', 'outputs', 'attributes'],
   Interpolation$1: ['expressions'],

--- a/packages/template-parser/src/index.ts
+++ b/packages/template-parser/src/index.ts
@@ -41,6 +41,7 @@ const KEYS: VisitorKeys = {
   BoundAttribute: ['value'],
   BoundEvent: ['handler'],
   BoundText: ['value'],
+  Call: ['receiver', 'args'],
   Conditional: ['condition', 'trueExp', 'falseExp'],
   Element$1: ['children', 'inputs', 'outputs', 'attributes'],
   Interpolation$1: ['expressions'],

--- a/packages/template-parser/tests/index.test.ts
+++ b/packages/template-parser/tests/index.test.ts
@@ -15123,4 +15123,278 @@ describe('parseForESLint()', () => {
       `);
     });
   });
+
+  describe('call expressions', () => {
+    it('should support normal and safe calls', () => {
+      expect(
+        parseForESLint(`{{ foo() }} {{ bar?.() }}`, { filePath: './foo.html' })
+          .ast,
+      ).toMatchInlineSnapshot(`
+        Object {
+          "comments": Array [],
+          "loc": Object {
+            "end": Object {
+              "column": 25,
+              "line": 1,
+            },
+            "start": Object {
+              "column": 0,
+              "line": 1,
+            },
+          },
+          "range": Array [
+            0,
+            25,
+          ],
+          "templateNodes": Array [
+            BoundText {
+              "i18n": undefined,
+              "loc": Object {
+                "end": Object {
+                  "column": 25,
+                  "line": 1,
+                },
+                "start": Object {
+                  "column": 0,
+                  "line": 1,
+                },
+              },
+              "sourceSpan": ParseSourceSpan {
+                "details": null,
+                "end": ParseLocation {
+                  "col": 25,
+                  "file": ParseSourceFile {
+                    "content": "{{ foo() }} {{ bar?.() }}",
+                    "url": "./foo.html",
+                  },
+                  "line": 0,
+                  "offset": 25,
+                },
+                "fullStart": ParseLocation {
+                  "col": 0,
+                  "file": ParseSourceFile {
+                    "content": "{{ foo() }} {{ bar?.() }}",
+                    "url": "./foo.html",
+                  },
+                  "line": 0,
+                  "offset": 0,
+                },
+                "start": ParseLocation {
+                  "col": 0,
+                  "file": ParseSourceFile {
+                    "content": "{{ foo() }} {{ bar?.() }}",
+                    "url": "./foo.html",
+                  },
+                  "line": 0,
+                  "offset": 0,
+                },
+              },
+              "type": "BoundText",
+              "value": ASTWithSource {
+                "ast": Interpolation$1 {
+                  "expressions": Array [
+                    Call {
+                      "args": Array [],
+                      "argumentSpan": AbsoluteSourceSpan {
+                        "end": 7,
+                        "start": 7,
+                      },
+                      "loc": Object {
+                        "end": Object {
+                          "column": undefined,
+                          "line": NaN,
+                        },
+                        "start": Object {
+                          "column": undefined,
+                          "line": NaN,
+                        },
+                      },
+                      "receiver": PropertyRead {
+                        "loc": Object {
+                          "end": Object {
+                            "column": undefined,
+                            "line": NaN,
+                          },
+                          "start": Object {
+                            "column": undefined,
+                            "line": NaN,
+                          },
+                        },
+                        "name": "foo",
+                        "nameSpan": AbsoluteSourceSpan {
+                          "end": 6,
+                          "start": 3,
+                        },
+                        "receiver": ImplicitReceiver {
+                          "loc": Object {
+                            "end": Object {
+                              "column": undefined,
+                              "line": NaN,
+                            },
+                            "start": Object {
+                              "column": undefined,
+                              "line": NaN,
+                            },
+                          },
+                          "sourceSpan": AbsoluteSourceSpan {
+                            "end": 3,
+                            "start": 3,
+                          },
+                          "span": ParseSpan {
+                            "end": 3,
+                            "start": 3,
+                          },
+                          "type": "ImplicitReceiver",
+                        },
+                        "sourceSpan": AbsoluteSourceSpan {
+                          "end": 6,
+                          "start": 3,
+                        },
+                        "span": ParseSpan {
+                          "end": 6,
+                          "start": 3,
+                        },
+                        "type": "PropertyRead",
+                      },
+                      "sourceSpan": AbsoluteSourceSpan {
+                        "end": 8,
+                        "start": 3,
+                      },
+                      "span": ParseSpan {
+                        "end": 8,
+                        "start": 3,
+                      },
+                      "type": "Call",
+                    },
+                    SafeCall {
+                      "args": Array [],
+                      "argumentSpan": AbsoluteSourceSpan {
+                        "end": 21,
+                        "start": 21,
+                      },
+                      "loc": Object {
+                        "end": Object {
+                          "column": undefined,
+                          "line": NaN,
+                        },
+                        "start": Object {
+                          "column": undefined,
+                          "line": NaN,
+                        },
+                      },
+                      "receiver": PropertyRead {
+                        "loc": Object {
+                          "end": Object {
+                            "column": undefined,
+                            "line": NaN,
+                          },
+                          "start": Object {
+                            "column": undefined,
+                            "line": NaN,
+                          },
+                        },
+                        "name": "bar",
+                        "nameSpan": AbsoluteSourceSpan {
+                          "end": 18,
+                          "start": 15,
+                        },
+                        "receiver": ImplicitReceiver {
+                          "loc": Object {
+                            "end": Object {
+                              "column": undefined,
+                              "line": NaN,
+                            },
+                            "start": Object {
+                              "column": undefined,
+                              "line": NaN,
+                            },
+                          },
+                          "sourceSpan": AbsoluteSourceSpan {
+                            "end": 15,
+                            "start": 15,
+                          },
+                          "span": ParseSpan {
+                            "end": 15,
+                            "start": 15,
+                          },
+                          "type": "ImplicitReceiver",
+                        },
+                        "sourceSpan": AbsoluteSourceSpan {
+                          "end": 18,
+                          "start": 15,
+                        },
+                        "span": ParseSpan {
+                          "end": 18,
+                          "start": 15,
+                        },
+                        "type": "PropertyRead",
+                      },
+                      "sourceSpan": AbsoluteSourceSpan {
+                        "end": 22,
+                        "start": 15,
+                      },
+                      "span": ParseSpan {
+                        "end": 22,
+                        "start": 15,
+                      },
+                      "type": "SafeCall",
+                    },
+                  ],
+                  "loc": Object {
+                    "end": Object {
+                      "column": undefined,
+                      "line": NaN,
+                    },
+                    "start": Object {
+                      "column": undefined,
+                      "line": NaN,
+                    },
+                  },
+                  "sourceSpan": AbsoluteSourceSpan {
+                    "end": 25,
+                    "start": 0,
+                  },
+                  "span": ParseSpan {
+                    "end": 25,
+                    "start": 0,
+                  },
+                  "strings": Array [
+                    "",
+                    " ",
+                    "",
+                  ],
+                  "type": "Interpolation$1",
+                },
+                "errors": Array [],
+                "loc": Object {
+                  "end": Object {
+                    "column": undefined,
+                    "line": NaN,
+                  },
+                  "start": Object {
+                    "column": undefined,
+                    "line": NaN,
+                  },
+                },
+                "location": "./foo.html@0:0",
+                "source": "{{ foo() }} {{ bar?.() }}",
+                "sourceSpan": AbsoluteSourceSpan {
+                  "end": 25,
+                  "start": 0,
+                },
+                "span": ParseSpan {
+                  "end": 25,
+                  "start": 0,
+                },
+                "type": "ASTWithSource",
+              },
+            },
+          ],
+          "tokens": Array [],
+          "type": "Program",
+          "value": "{{ foo() }} {{ bar?.() }}",
+        }
+      `);
+    });
+  });
 });

--- a/packages/test-utils/src/convert-annotated-source-to-failure-case.ts
+++ b/packages/test-utils/src/convert-annotated-source-to-failure-case.ts
@@ -219,31 +219,35 @@ function parseInvalidSource(
 
   let col = 0;
   let line = 0;
+  let sourceLine = 0;
+  let isAnnotationLine = false;
   let lastCol = 0;
   let lastLine = 0;
   let startPosition: SourcePosition | undefined;
-
-  for (const currentChar of replacedSource) {
+  for (const currentChar of source) {
     if (currentChar === '\n') {
+      if (isAnnotationLine) isAnnotationLine = false;
+      else sourceLine = line;
       col = 0;
       line++;
-
       continue;
     }
 
     col++;
 
+    if (otherChars.includes(currentChar)) isAnnotationLine = true;
     if (currentChar !== specialChar) continue;
+    isAnnotationLine = true;
 
     if (!startPosition) {
       startPosition = {
         character: col - 1,
-        line: line - 1,
+        line: sourceLine,
       };
     }
 
     lastCol = col;
-    lastLine = line - 1;
+    lastLine = sourceLine;
   }
 
   const endPosition: SourcePosition = {


### PR DESCRIPTION
When traversing a Call AST node, ESLint would never visit its receiver/callee. Since Call didn't have visitor keys listed explicitly, the parser would use `getFallbackKeys`, which seems to be buggy as it only returns `args` and not `receiver`.

Update test cases for no-call-expression to deal with new call expressions being reported.

Since convertAnnotatedSourceToFailureCase doesn't deal well with overlapping errors at the moment, instances of `()()` were removed from existing tests and added as separate cases for nested calls.

Closes #1885