### PR TITLE
fix(eslint-plugin-template): [interactive-supports-focus] allowList with form as default option to support event bubbling

### DIFF
--- a/packages/eslint-plugin-template/docs/rules/interactive-supports-focus.md
+++ b/packages/eslint-plugin-template/docs/rules/interactive-supports-focus.md
@@ -913,6 +913,32 @@ interface Options {
 #### ✅ Valid Code
 
 ```html
+<test-component (keydown)="onKeyDown()"></test-component>
+```
+
+<br>
+
+---
+
+<br>
+
+#### Default Config
+
+```json
+{
+  "rules": {
+    "@angular-eslint/template/interactive-supports-focus": [
+      "error"
+    ]
+  }
+}
+```
+
+<br>
+
+#### ✅ Valid Code
+
+```html
 <form (keydown)="onKeyDown()"></form>
 ```
 

--- a/packages/eslint-plugin-template/docs/rules/interactive-supports-focus.md
+++ b/packages/eslint-plugin-template/docs/rules/interactive-supports-focus.md
@@ -23,7 +23,17 @@
 
 ## Rule Options
 
-The rule does not have any configuration options.
+The rule accepts an options object with the following properties:
+
+```ts
+interface Options {
+  /**
+   * Default: `["form"]`
+   */
+  allowList?: string[];
+}
+
+```
 
 <br>
 
@@ -356,6 +366,36 @@ The rule does not have any configuration options.
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 ```
 
+<br>
+
+---
+
+<br>
+
+#### Custom Config
+
+```json
+{
+  "rules": {
+    "@angular-eslint/template/interactive-supports-focus": [
+      "error",
+      {
+        "allowList": []
+      }
+    ]
+  }
+}
+```
+
+<br>
+
+#### ❌ Invalid Code
+
+```html
+<form (keydown)="onKeyDown()"></form>
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+```
+
 </details>
 
 <br>
@@ -638,6 +678,7 @@ The rule does not have any configuration options.
 
 ```html
 <a (click)="onClick()" tabindex="0">Click me</a>
+<a (click)="onClick()" tabindex={{0}}>Click me</a>
 <a (click)="onClick()" [attr.tabindex]="0">Click me</a>
 <a (click)="onClick()" tabindex="bad">Click me</a>
 <a (click)="onClick()" [attr.tabindex]="undefined"}>Click me</a>
@@ -696,33 +737,6 @@ The rule does not have any configuration options.
 <a (click)="onClick()" href="http://x.y.z">x.y.z</a>
 <a role="link" (click)="onClick()" href="http://x.y.z">x.y.z</a>
 <a (click)="onClick()" href="javascript:void(0);">Click ALL the things!</a>
-```
-
-<br>
-
----
-
-<br>
-
-#### Default Config
-
-```json
-{
-  "rules": {
-    "@angular-eslint/template/interactive-supports-focus": [
-      "error"
-    ]
-  }
-}
-```
-
-<br>
-
-#### ✅ Valid Code
-
-```html
-<a (click)="onClick()" tabindex="0">x.y.z</a>
-<a (click)="onClick()" tabindex={0}>x.y.z</a>
 ```
 
 <br>
@@ -874,6 +888,65 @@ The rule does not have any configuration options.
 <div contenteditable="true" (keyup)="onKeyUp()">Edit this text</div>
 <div [attr.contenteditable]="true" (keydown)="onKeyDown()">Edit this text</div>
 <div contenteditable (keypress)="onKeyPress()">Edit this too!</div>
+```
+
+<br>
+
+---
+
+<br>
+
+#### Default Config
+
+```json
+{
+  "rules": {
+    "@angular-eslint/template/interactive-supports-focus": [
+      "error"
+    ]
+  }
+}
+```
+
+<br>
+
+#### ✅ Valid Code
+
+```html
+<form (keydown)="onKeyDown()"></form>
+```
+
+<br>
+
+---
+
+<br>
+
+#### Custom Config
+
+```json
+{
+  "rules": {
+    "@angular-eslint/template/interactive-supports-focus": [
+      "error",
+      {
+        "allowList": [
+          "form",
+          "section"
+        ]
+      }
+    ]
+  }
+}
+```
+
+<br>
+
+#### ✅ Valid Code
+
+```html
+<form (keydown)="onKeyDown()"></form>
+<section (keydown)="onKeyDown()"></section>
 ```
 
 </details>

--- a/packages/eslint-plugin-template/tests/rules/interactive-supports-focus/cases.ts
+++ b/packages/eslint-plugin-template/tests/rules/interactive-supports-focus/cases.ts
@@ -91,6 +91,7 @@ export const valid: readonly (string | ValidTestCase<Options>)[] = [
   {
     code: `
       <a (click)="onClick()" tabindex="0">Click me</a>
+      <a (click)="onClick()" tabindex={{0}}>Click me</a>
       <a (click)="onClick()" [attr.tabindex]="0">Click me</a>
       <a (click)="onClick()" tabindex="bad">Click me</a>
       <a (click)="onClick()" [attr.tabindex]="undefined"}>Click me</a>
@@ -108,13 +109,7 @@ export const valid: readonly (string | ValidTestCase<Options>)[] = [
       <a (click)="onClick()" href="javascript:void(0);">Click ALL the things!</a>
     `,
   },
-  // click and tabindex (focusable but generally not recommended)
-  {
-    code: `
-      <a (click)="onClick()" tabindex="0">x.y.z</a>
-      <a (click)="onClick()" tabindex={0}>x.y.z</a>
-    `,
-  },
+
   // routerLink
   {
     code: `
@@ -169,6 +164,24 @@ export const valid: readonly (string | ValidTestCase<Options>)[] = [
       <div [attr.contenteditable]="true" (keydown)="onKeyDown()">Edit this text</div>
       <div contenteditable (keypress)="onKeyPress()">Edit this too!</div>
     `,
+  },
+
+  // allowList: by default the form element is allowed to support click and key event bubbling
+  {
+    code: `<form (keydown)="onKeyDown()"></form>`,
+  },
+
+  // allowList: allow click and key event bubbling on additional elements
+  {
+    code: `
+      <form (keydown)="onKeyDown()"></form>
+      <section (keydown)="onKeyDown()"></section>
+    `,
+    options: [
+      {
+        allowList: ['form', 'section'],
+      },
+    ],
   },
 ];
 
@@ -292,6 +305,22 @@ export const invalid: readonly InvalidTestCase<MessageIds, Options>[] = [
       <div [attr.contenteditable]="false" (keyup)="onKeyUp()">Cannot be focused</div>
       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     `,
+    messageId,
+  }),
+
+  // allowList empty
+  convertAnnotatedSourceToFailureCase({
+    description:
+      'allowList as an empty array allows only HTML elements that can directly receive focus',
+    annotatedSource: `
+      <form (keydown)="onKeyDown()"></form>
+      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    `,
+    options: [
+      {
+        allowList: [],
+      },
+    ],
     messageId,
   }),
 ];

--- a/packages/eslint-plugin-template/tests/rules/interactive-supports-focus/cases.ts
+++ b/packages/eslint-plugin-template/tests/rules/interactive-supports-focus/cases.ts
@@ -166,6 +166,11 @@ export const valid: readonly (string | ValidTestCase<Options>)[] = [
     `,
   },
 
+  // custom element, only HTML DOM elements are validated
+  {
+    code: `<test-component (keydown)="onKeyDown()"></test-component>`,
+  },
+
   // allowList: by default the form element is allowed to support click and key event bubbling
   {
     code: `<form (keydown)="onKeyDown()"></form>`,


### PR DESCRIPTION
Resolves #1429 

Adds an `allowList` to the interactive-supports-focus template rule to with `<form>` as a default option to allow for event bubbling and capturing events from `<form>` elements. 
* The `allowList` can be configured as an empty array to more strictly permit click and key events on interactive elements only
* Additional HTML or custom elements can be configured and added to the `allowList` array to permit click and key events on elements that are otherwise not interactive