### PR TITLE
fix(eslint-plugin): [prefer-standalone] ignore empty Directive decorators

### DIFF
--- a/packages/eslint-plugin/docs/rules/prefer-standalone.md
+++ b/packages/eslint-plugin/docs/rules/prefer-standalone.md
@@ -712,6 +712,33 @@ class Test {}
 #### ✅ Valid Code
 
 ```ts
+@Directive()
+abstract class Test {}
+```
+
+<br>
+
+---
+
+<br>
+
+#### Default Config
+
+```json
+{
+  "rules": {
+    "@angular-eslint/prefer-standalone": [
+      "error"
+    ]
+  }
+}
+```
+
+<br>
+
+#### ✅ Valid Code
+
+```ts
 @Pipe({
   standalone: true,
 })

--- a/packages/eslint-plugin/src/rules/prefer-standalone.ts
+++ b/packages/eslint-plugin/src/rules/prefer-standalone.ts
@@ -44,6 +44,10 @@ export default createESLintRule<Options, MessageIds>({
           return;
         }
 
+        if (!ASTUtils.getDecoratorArgument(node)) {
+          return;
+        }
+
         context.report({
           node: nodeToReport(node),
           messageId: 'preferStandalone',

--- a/packages/eslint-plugin/tests/rules/prefer-standalone/cases.ts
+++ b/packages/eslint-plugin/tests/rules/prefer-standalone/cases.ts
@@ -48,6 +48,10 @@ export const valid = [
     class Test {}
   `,
   `
+    @Directive()
+    abstract class Test {}
+  `,
+  `
     @Pipe({
       standalone: true,
     })


### PR DESCRIPTION
Do not report `@Decorator()` as not standalone. Empty decorator is needed on base classes of directives and components if the base class uses Angular features.

Similar exception already exists on e.g. directive-class-suffix (#394)

Closes #1910