### PR TITLE
fix(prefer-self-closing-tags): handle both forward and backward slash

### DIFF
--- a/packages/eslint-plugin-template/src/rules/prefer-self-closing-tags.ts
+++ b/packages/eslint-plugin-template/src/rules/prefer-self-closing-tags.ts
@@ -32,7 +32,7 @@ export default createESLintRule<Options, MessageIds>({
     const parserServices = getTemplateParserServices(context);
 
     // angular 18 doesnt support self closing tags in index.html
-    if (context.physicalFilename.endsWith('src/index.html')) {
+    if (/src[\\/]index\.html$/.test(context.physicalFilename)) {
       // If it is, return an empty object to skip this rule
       return {};
     }


### PR DESCRIPTION
Updated the condition to check for both `src/index.html` and `src\index.html` paths in order to support Windows file paths.