### PR TITLE
feat: support eslint.config.mjs and eslint.config.cjs

### DIFF
--- a/packages/builder/src/lint.impl.ts
+++ b/packages/builder/src/lint.impl.ts
@@ -41,10 +41,14 @@ export default convertNxExecutor(
     /**
      * Until ESLint v9 is released and the new so called flat config is the default
      * we only want to support it if the user has explicitly opted into it by converting
-     * their root ESLint config to use eslint.config.js
+     * their root ESLint config to use eslint.config.(js|mjs|cjs).
      */
     const useFlatConfig = existsSync(
       joinPathFragments(workspaceRoot, 'eslint.config.js'),
+    ) || existsSync(
+      joinPathFragments(workspaceRoot, 'eslint.config.mjs'),
+    ) || existsSync(
+      joinPathFragments(workspaceRoot, 'eslint.config.cjs'),
     );
     const { eslint, ESLint } = await resolveAndInstantiateESLint(
       eslintConfigPath,

--- a/packages/builder/src/utils/eslint-utils.spec.ts
+++ b/packages/builder/src/utils/eslint-utils.spec.ts
@@ -147,12 +147,18 @@ describe('eslint-utils', () => {
   });
 
   describe('ESLint Flat Config', () => {
-    it('should throw if a non eslint.config.js file is used with ESLint Flat Config', async () => {
+    it('should throw if an .eslintrc.json file is used with ESLint Flat Config', async () => {
       await expect(
         resolveAndInstantiateESLint('./.eslintrc.json', {} as any, true),
       ).rejects.toThrowErrorMatchingInlineSnapshot(
-        `"When using the new Flat Config with ESLint, all configs must be named eslint.config.js and .eslintrc files may not be used. See https://eslint.org/docs/latest/use/configure/configuration-files-new"`,
+        `"When using the new Flat Config with ESLint, all configs must be named eslint.config.(js|mjs|cjs) and .eslintrc files may not be used. See https://eslint.org/docs/latest/use/configure/configuration-files-new"`,
       );
+    });
+
+    it('should not throw if an eslint.config.mjs file is used with ESLint Flat Config', async () => {
+      await expect(
+        resolveAndInstantiateESLint('./eslint.config.mjs', {} as any, true),
+      ).resolves.not.toThrow();
     });
 
     it('should throw if invalid options are used with ESLint Flat Config', async () => {

--- a/packages/builder/src/utils/eslint-utils.ts
+++ b/packages/builder/src/utils/eslint-utils.ts
@@ -30,10 +30,12 @@ export async function resolveAndInstantiateESLint(
   if (
     useFlatConfig &&
     eslintConfigPath &&
-    !eslintConfigPath?.endsWith('eslint.config.js')
+    !eslintConfigPath?.endsWith('eslint.config.js') &&
+    !eslintConfigPath?.endsWith('eslint.config.mjs') &&
+    !eslintConfigPath?.endsWith('eslint.config.cjs')
   ) {
     throw new Error(
-      'When using the new Flat Config with ESLint, all configs must be named eslint.config.js and .eslintrc files may not be used. See https://eslint.org/docs/latest/use/configure/configuration-files-new',
+      'When using the new Flat Config with ESLint, all configs must be named eslint.config.(js|mjs|cjs) and .eslintrc files may not be used. See https://eslint.org/docs/latest/use/configure/configuration-files-new',
     );
   }
   const ESLint = await resolveESLintClass(useFlatConfig);

--- a/packages/schematics/src/utils.ts
+++ b/packages/schematics/src/utils.ts
@@ -404,7 +404,7 @@ export function createESLintConfigForProject(
   const hasE2e = !!targets?.e2e;
 
   const useFlatConfig = shouldUseFlatConfig(tree);
-  const alreadyHasRootFlatConfig = tree.exists('eslint.config.js');
+  const alreadyHasRootFlatConfig = tree.exists('eslint.config.js') || tree.exists('eslint.config.mjs') || tree.exists('eslint.config.cjs');
   const alreadyHasRootESLintRC = tree.exists('.eslintrc.json');
 
   /**
@@ -538,7 +538,7 @@ export function shouldUseFlatConfig(
 ): boolean {
   let useFlatConfig = true;
   try {
-    const alreadyHasRootFlatConfig = tree.exists('eslint.config.js');
+    const alreadyHasRootFlatConfig = tree.exists('eslint.config.js') || tree.exists('eslint.config.mjs') || tree.exists('eslint.config.cjs');
     const alreadyHasRootESLintRC = tree.exists('.eslintrc.json');
 
     if (alreadyHasRootFlatConfig) {


### PR DESCRIPTION
ESLint supports `mjs` and `cjs` file extensions for their flat configs: https://eslint.org/docs/latest/use/configure/configuration-files.  It would be nice to support particularly `mjs` configs so users can use `import`/`export` ESM syntax.

This does not change the schematic to generate an ESM config file; the user would need to manually write/convert their own config.