### PR TITLE
fix(eslint-plugin-template): [prefer-self-closing-tags] fix ng-content with rich default content

### DIFF
--- a/packages/eslint-plugin-template/docs/rules/prefer-self-closing-tags.md
+++ b/packages/eslint-plugin-template/docs/rules/prefer-self-closing-tags.md
@@ -579,6 +579,36 @@ The rule does not have any configuration options.
 
 #### ✅ Valid Code
 
+```html
+<ng-content
+     select="content"
+   >
+    <p>Fallback content</p>
+  </ng-content>
+```
+
+<br>
+
+---
+
+<br>
+
+#### Default Config
+
+```json
+{
+  "rules": {
+    "@angular-eslint/template/prefer-self-closing-tags": [
+      "error"
+    ]
+  }
+}
+```
+
+<br>
+
+#### ✅ Valid Code
+
 **Filename: src/index.html**
 
 ```html

--- a/packages/eslint-plugin-template/src/rules/prefer-self-closing-tags.ts
+++ b/packages/eslint-plugin-template/src/rules/prefer-self-closing-tags.ts
@@ -99,7 +99,7 @@ export default createESLintRule<Options, MessageIds>({
       if (sourceSpan.toString().includes(ngContentCloseTag)) {
         const whiteSpaceContent = sourceSpan
           .toString()
-          .match(/>(\s*)</m)
+          .match(/<ng-content[^>]*>(\s*)<\/ng-content>/m)
           ?.at(1);
         const hasContent = typeof whiteSpaceContent === 'undefined';
         if (hasContent) {

--- a/packages/eslint-plugin-template/tests/rules/prefer-self-closing-tags/cases.ts
+++ b/packages/eslint-plugin-template/tests/rules/prefer-self-closing-tags/cases.ts
@@ -26,6 +26,11 @@ export const valid: readonly (string | ValidTestCase<Options>)[] = [
   '<ng-content/>',
   '<ng-content select="my-selector" />',
   `<ng-content>Fallback content</ng-content>`,
+  `<ng-content
+     select="content"
+   >
+    <p>Fallback content</p>
+  </ng-content>`,
   { code: '<app-root></app-root>', filename: 'src/index.html' },
 ];
 


### PR DESCRIPTION
Currently if the `prefer-self-closing-tags` rule is used, and the template contains an `<ng-content>` with default content containing HTML markup, a false positive error is reported.

Closes #1970