### PR TITLE
fix(eslint-plugin-template): [label-has-associated-control] allow custom inputs for default labelComponents

### DIFF
--- a/packages/eslint-plugin-template/src/rules/label-has-associated-control.ts
+++ b/packages/eslint-plugin-template/src/rules/label-has-associated-control.ts
@@ -88,8 +88,8 @@ export default createESLintRule<Options, MessageIds>({
       ...(controlComponents ?? []),
     ]);
     const allLabelComponents = [
-      ...DEFAULT_LABEL_COMPONENTS,
       ...(labelComponents ?? []),
+      ...DEFAULT_LABEL_COMPONENTS,
     ] as const;
     let inputItems: TmplAstElement[] = [];
     let labelItems: TmplAstElement[] = [];


### PR DESCRIPTION
**Description and reproduction of the issue**

With [ng-zorro's checkbox](https://ng.ant.design/components/checkbox/en), the label is used with the `nz-checkbox` directive to create a checkbox element. However, `"@angular-eslint/template/label-has-associated-control"` does not recognize the directive even with the following config:

```JSON
{
  "rules": {
    "@angular-eslint/template/label-has-associated-control": [
      "error",
      {
        "labelComponents": [
          {
            "selector": "label",
            "inputs": [
              "nz-checkbox"
            ]
          }
        ]
      }
    ],
  }
}
```

```HTML
<label nz-checkbox [(ngModel)]="checked">Checkbox</label>
```

**Proposed fix**

By spreading the configured `labelComponents` before the default config, we can override the `inputs` value for the given selector.
