### PR TITLE
feat(eslint-plugin)!: prefer-standalone recognizes that standalone is the default

### DIFF
--- a/packages/eslint-plugin/docs/rules/prefer-standalone.md
+++ b/packages/eslint-plugin/docs/rules/prefer-standalone.md
@@ -56,34 +56,6 @@ The rule does not have any configuration options.
 #### ❌ Invalid Code
 
 ```ts
-@Component({})
-~~~~~~~~~~~~~~
-class Test {}
-```
-
-<br>
-
----
-
-<br>
-
-#### Default Config
-
-```json
-{
-  "rules": {
-    "@angular-eslint/prefer-standalone": [
-      "error"
-    ]
-  }
-}
-```
-
-<br>
-
-#### ❌ Invalid Code
-
-```ts
 @Component({ standalone: false })
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 class Test {}
@@ -120,100 +92,6 @@ template: '<div></div>'
 ~~~~~~~~~~~~~~~~~~~~~~~
 })
 ~~
-class Test {}
-```
-
-<br>
-
----
-
-<br>
-
-#### Default Config
-
-```json
-{
-  "rules": {
-    "@angular-eslint/prefer-standalone": [
-      "error"
-    ]
-  }
-}
-```
-
-<br>
-
-#### ❌ Invalid Code
-
-```ts
-@Component({
-~~~~~~~~~~~~
-template: '<div></div>'
-~~~~~~~~~~~~~~~~~~~~~~~
-})
-~~
-class Test {}
-```
-
-<br>
-
----
-
-<br>
-
-#### Default Config
-
-```json
-{
-  "rules": {
-    "@angular-eslint/prefer-standalone": [
-      "error"
-    ]
-  }
-}
-```
-
-<br>
-
-#### ❌ Invalid Code
-
-```ts
-@Component({
-~~~~~~~~~~~~
-selector: 'my-selector',
-~~~~~~~~~~~~~~~~~~~~~~~
-template: '<div></div>'
-~~~~~~~~~~~~~~~~~~~~~~~
-})
-~~
-class Test {}
-```
-
-<br>
-
----
-
-<br>
-
-#### Default Config
-
-```json
-{
-  "rules": {
-    "@angular-eslint/prefer-standalone": [
-      "error"
-    ]
-  }
-}
-```
-
-<br>
-
-#### ❌ Invalid Code
-
-```ts
-@Directive({})
-~~~~~~~~~~~~~~
 class Test {}
 ```
 
@@ -302,100 +180,6 @@ class Test {}
 #### ❌ Invalid Code
 
 ```ts
-@Directive({
-~~~~~~~~~~~~
-  selector: 'test-selector'
-  ~~~~~~~~~~~~~~~~~~~~~~~~~
-})
-~~
-class Test {}
-```
-
-<br>
-
----
-
-<br>
-
-#### Default Config
-
-```json
-{
-  "rules": {
-    "@angular-eslint/prefer-standalone": [
-      "error"
-    ]
-  }
-}
-```
-
-<br>
-
-#### ❌ Invalid Code
-
-```ts
-@Directive({
-~~~~~~~~~~~~
-  selector: 'my-selector',
-  ~~~~~~~~~~~~~~~~~~~~~~~~
-  providers: []
-  ~~~~~~~~~~~~~
-})
-~~
-class Test {}
-```
-
-<br>
-
----
-
-<br>
-
-#### Default Config
-
-```json
-{
-  "rules": {
-    "@angular-eslint/prefer-standalone": [
-      "error"
-    ]
-  }
-}
-```
-
-<br>
-
-#### ❌ Invalid Code
-
-```ts
-@Pipe({})
-~~~~~~~~~
-class Test {}
-```
-
-<br>
-
----
-
-<br>
-
-#### Default Config
-
-```json
-{
-  "rules": {
-    "@angular-eslint/prefer-standalone": [
-      "error"
-    ]
-  }
-}
-```
-
-<br>
-
-#### ❌ Invalid Code
-
-```ts
 @Pipe({ standalone: false })
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 class Test {}
@@ -435,72 +219,6 @@ class Test {}
 class Test {}
 ```
 
-<br>
-
----
-
-<br>
-
-#### Default Config
-
-```json
-{
-  "rules": {
-    "@angular-eslint/prefer-standalone": [
-      "error"
-    ]
-  }
-}
-```
-
-<br>
-
-#### ❌ Invalid Code
-
-```ts
-@Pipe({
-~~~~~~~
-  name: 'test-name'
-  ~~~~~~~~~~~~~~~~~
-})
-~~
-class Test {}
-```
-
-<br>
-
----
-
-<br>
-
-#### Default Config
-
-```json
-{
-  "rules": {
-    "@angular-eslint/prefer-standalone": [
-      "error"
-    ]
-  }
-}
-```
-
-<br>
-
-#### ❌ Invalid Code
-
-```ts
-@Pipe({
-~~~~~~~
-  selector: 'my-selector',
-  ~~~~~~~~~~~~~~~~~~~~~~~~
-  name: 'test-name'
-  ~~~~~~~~~~~~~~~~~
-})
-~~
-class Test {}
-```
-
 </details>
 
 <br>
@@ -531,8 +249,64 @@ class Test {}
 #### ✅ Valid Code
 
 ```ts
+@Component({})
+class Test {}
+```
+
+<br>
+
+---
+
+<br>
+
+#### Default Config
+
+```json
+{
+  "rules": {
+    "@angular-eslint/prefer-standalone": [
+      "error"
+    ]
+  }
+}
+```
+
+<br>
+
+#### ✅ Valid Code
+
+```ts
 @Component({
   standalone: true,
+})
+class Test {}
+```
+
+<br>
+
+---
+
+<br>
+
+#### Default Config
+
+```json
+{
+  "rules": {
+    "@angular-eslint/prefer-standalone": [
+      "error"
+    ]
+  }
+}
+```
+
+<br>
+
+#### ✅ Valid Code
+
+```ts
+@Component({
+  selector: 'test-selector'
 })
 class Test {}
 ```
@@ -592,6 +366,37 @@ class Test {}
 ```ts
 @Component({
   selector: 'test-selector',
+  template: '<div></div>',
+  styleUrls: ['./test.css']
+})
+class Test {}
+```
+
+<br>
+
+---
+
+<br>
+
+#### Default Config
+
+```json
+{
+  "rules": {
+    "@angular-eslint/prefer-standalone": [
+      "error"
+    ]
+  }
+}
+```
+
+<br>
+
+#### ✅ Valid Code
+
+```ts
+@Component({
+  selector: 'test-selector',
   standalone: true,
   template: '<div></div>',
   styleUrls: ['./test.css']
@@ -622,6 +427,33 @@ class Test {}
 #### ✅ Valid Code
 
 ```ts
+@Directive({})
+class Test {}
+```
+
+<br>
+
+---
+
+<br>
+
+#### Default Config
+
+```json
+{
+  "rules": {
+    "@angular-eslint/prefer-standalone": [
+      "error"
+    ]
+  }
+}
+```
+
+<br>
+
+#### ✅ Valid Code
+
+```ts
 @Directive({
   standalone: true,
 })
@@ -652,8 +484,67 @@ class Test {}
 
 ```ts
 @Directive({
+  selector: 'test-selector'
+})
+class Test {}
+```
+
+<br>
+
+---
+
+<br>
+
+#### Default Config
+
+```json
+{
+  "rules": {
+    "@angular-eslint/prefer-standalone": [
+      "error"
+    ]
+  }
+}
+```
+
+<br>
+
+#### ✅ Valid Code
+
+```ts
+@Directive({
   standalone: true,
   selector: 'test-selector'
+})
+class Test {}
+```
+
+<br>
+
+---
+
+<br>
+
+#### Default Config
+
+```json
+{
+  "rules": {
+    "@angular-eslint/prefer-standalone": [
+      "error"
+    ]
+  }
+}
+```
+
+<br>
+
+#### ✅ Valid Code
+
+```ts
+@Directive({
+  selector: 'test-selector',
+  providers: []
 })
 class Test {}
 ```
@@ -739,6 +630,33 @@ abstract class Test {}
 #### ✅ Valid Code
 
 ```ts
+@Pipe({})
+class Test {}
+```
+
+<br>
+
+---
+
+<br>
+
+#### Default Config
+
+```json
+{
+  "rules": {
+    "@angular-eslint/prefer-standalone": [
+      "error"
+    ]
+  }
+}
+```
+
+<br>
+
+#### ✅ Valid Code
+
+```ts
 @Pipe({
   standalone: true,
 })
@@ -769,8 +687,67 @@ class Test {}
 
 ```ts
 @Pipe({
+  name: 'test-pipe'
+})
+class Test {}
+```
+
+<br>
+
+---
+
+<br>
+
+#### Default Config
+
+```json
+{
+  "rules": {
+    "@angular-eslint/prefer-standalone": [
+      "error"
+    ]
+  }
+}
+```
+
+<br>
+
+#### ✅ Valid Code
+
+```ts
+@Pipe({
   standalone: true,
   name: 'test-pipe'
+})
+class Test {}
+```
+
+<br>
+
+---
+
+<br>
+
+#### Default Config
+
+```json
+{
+  "rules": {
+    "@angular-eslint/prefer-standalone": [
+      "error"
+    ]
+  }
+}
+```
+
+<br>
+
+#### ✅ Valid Code
+
+```ts
+@Pipe({
+  name: 'my-pipe',
+  pure: true
 })
 class Test {}
 ```

--- a/packages/eslint-plugin/src/rules/prefer-standalone.ts
+++ b/packages/eslint-plugin/src/rules/prefer-standalone.ts
@@ -37,9 +37,8 @@ export default createESLintRule<Options, MessageIds>({
         );
 
         if (
-          standalone &&
-          ASTUtils.isLiteral(standalone) &&
-          standalone.value === true
+          !standalone ||
+          (ASTUtils.isLiteral(standalone) && standalone.value === true)
         ) {
           return;
         }

--- a/packages/eslint-plugin/tests/rules/prefer-standalone/cases.ts
+++ b/packages/eslint-plugin/tests/rules/prefer-standalone/cases.ts
@@ -9,8 +9,18 @@ const messageId: MessageIds = 'preferStandalone';
 
 export const valid: readonly (string | ValidTestCase<Options>)[] = [
   `
+    @Component({})
+    class Test {}
+  `,
+  `
     @Component({
       standalone: true,
+    })
+    class Test {}
+  `,
+  `
+    @Component({
+      selector: 'test-selector'
     })
     class Test {}
   `,
@@ -24,6 +34,14 @@ export const valid: readonly (string | ValidTestCase<Options>)[] = [
   `
     @Component({
       selector: 'test-selector',
+      template: '<div></div>',
+      styleUrls: ['./test.css']
+    })
+    class Test {}
+  `,
+  `
+    @Component({
+      selector: 'test-selector',
       standalone: true,
       template: '<div></div>',
       styleUrls: ['./test.css']
@@ -31,6 +49,10 @@ export const valid: readonly (string | ValidTestCase<Options>)[] = [
     class Test {}
   `,
   `
+    @Directive({})
+    class Test {}
+  `,
+  `
     @Directive({
       standalone: true,
     })
@@ -38,8 +60,21 @@ export const valid: readonly (string | ValidTestCase<Options>)[] = [
   `,
   `
     @Directive({
+      selector: 'test-selector'
+    })
+    class Test {}
+  `,
+  `
+    @Directive({
       standalone: true,
       selector: 'test-selector'
+    })
+    class Test {}
+  `,
+  `
+    @Directive({
+      selector: 'test-selector',
+      providers: []
     })
     class Test {}
   `,
@@ -56,6 +91,10 @@ export const valid: readonly (string | ValidTestCase<Options>)[] = [
     abstract class Test {}
   `,
   `
+    @Pipe({})
+    class Test {}
+  `,
+  `
     @Pipe({
       standalone: true,
     })
@@ -63,8 +102,21 @@ export const valid: readonly (string | ValidTestCase<Options>)[] = [
   `,
   `
     @Pipe({
+      name: 'test-pipe'
+    })
+    class Test {}
+  `,
+  `
+    @Pipe({
       standalone: true,
       name: 'test-pipe'
+    })
+    class Test {}
+  `,
+  `
+    @Pipe({
+      name: 'my-pipe',
+      pure: true
     })
     class Test {}
   `,
@@ -79,22 +131,6 @@ export const valid: readonly (string | ValidTestCase<Options>)[] = [
 ];
 
 export const invalid: readonly InvalidTestCase<MessageIds, Options>[] = [
-  convertAnnotatedSourceToFailureCase({
-    description:
-      'should fail when a component does not have the standalone property in the decorator',
-    annotatedSource: `
-        @Component({})
-        ~~~~~~~~~~~~~~
-        class Test {}
-      `,
-    messageId,
-    data: { type: 'component' },
-    annotatedOutput: `
-        @Component({standalone: true})
-        
-        class Test {}
-      `,
-  }),
   convertAnnotatedSourceToFailureCase({
     description:
       'should fail when a component has the standalone property set to false in the decorator',
@@ -138,74 +174,6 @@ export const invalid: readonly InvalidTestCase<MessageIds, Options>[] = [
         
         class Test {}
 `,
-  }),
-  convertAnnotatedSourceToFailureCase({
-    description:
-      'should fail when a component has no standalone property in a decorator with one property',
-    annotatedSource: `
-        @Component({
-        ~~~~~~~~~~~~
-        template: '<div></div>'
-        ~~~~~~~~~~~~~~~~~~~~~~~
-        })
-        ~~
-        class Test {}
-`,
-    messageId,
-    data: { type: 'component' },
-    annotatedOutput: `
-        @Component({
-        
-        standalone: true,template: '<div></div>'
-        
-        })
-        
-        class Test {}
-`,
-  }),
-  convertAnnotatedSourceToFailureCase({
-    description:
-      'should fail when a component has no standalone property in a decorator with multiple properties',
-    annotatedSource: `
-        @Component({
-        ~~~~~~~~~~~~
-        selector: 'my-selector',
-        ~~~~~~~~~~~~~~~~~~~~~~~
-        template: '<div></div>'
-        ~~~~~~~~~~~~~~~~~~~~~~~
-        })
-        ~~
-        class Test {}
-`,
-    messageId,
-    data: { type: 'component' },
-    annotatedOutput: `
-        @Component({
-        
-        standalone: true,selector: 'my-selector',
-        
-        template: '<div></div>'
-        
-        })
-        
-        class Test {}
-`,
-  }),
-  convertAnnotatedSourceToFailureCase({
-    description:
-      'should fail when a directive does not have the standalone property in the decorator',
-    annotatedSource: `
-        @Directive({})
-        ~~~~~~~~~~~~~~
-        class Test {}
-      `,
-    messageId,
-    data: { type: 'directive' },
-    annotatedOutput: `
-        @Directive({standalone: true})
-        
-        class Test {}
-      `,
   }),
   convertAnnotatedSourceToFailureCase({
     description:
@@ -253,74 +221,6 @@ export const invalid: readonly InvalidTestCase<MessageIds, Options>[] = [
   }),
   convertAnnotatedSourceToFailureCase({
     description:
-      'should fail when a directive has no standalone property in a decorator with one property',
-    annotatedSource: `
-      @Directive({
-      ~~~~~~~~~~~~
-        selector: 'test-selector'
-        ~~~~~~~~~~~~~~~~~~~~~~~~~
-      })
-      ~~
-      class Test {}
-`,
-    messageId,
-    data: { type: 'directive' },
-    annotatedOutput: `
-      @Directive({
-      
-        standalone: true,selector: 'test-selector'
-        
-      })
-      
-      class Test {}
-`,
-  }),
-  convertAnnotatedSourceToFailureCase({
-    description:
-      'should fail when a directive has no standalone property in a decorator with multiple properties',
-    annotatedSource: `
-      @Directive({
-      ~~~~~~~~~~~~
-        selector: 'my-selector',
-        ~~~~~~~~~~~~~~~~~~~~~~~~
-        providers: []
-        ~~~~~~~~~~~~~
-      })
-      ~~
-      class Test {}
-`,
-    messageId,
-    data: { type: 'directive' },
-    annotatedOutput: `
-      @Directive({
-      
-        standalone: true,selector: 'my-selector',
-        
-        providers: []
-        
-      })
-      
-      class Test {}
-`,
-  }),
-  convertAnnotatedSourceToFailureCase({
-    description:
-      'should fail when a pipe does not have the standalone property in the decorator',
-    annotatedSource: `
-        @Pipe({})
-        ~~~~~~~~~
-        class Test {}
-      `,
-    messageId,
-    data: { type: 'pipe' },
-    annotatedOutput: `
-        @Pipe({standalone: true})
-        
-        class Test {}
-      `,
-  }),
-  convertAnnotatedSourceToFailureCase({
-    description:
       'should fail when a pipe has the standalone property set to false in the decorator',
     annotatedSource: `
         @Pipe({ standalone: false })
@@ -357,58 +257,6 @@ export const invalid: readonly InvalidTestCase<MessageIds, Options>[] = [
           standalone: true,
           
           name: 'pipe-name'
-          
-        })
-        
-        class Test {}
-`,
-  }),
-  convertAnnotatedSourceToFailureCase({
-    description:
-      'should fail when a pipe has no standalone property in a decorator with one property',
-    annotatedSource: `
-        @Pipe({
-        ~~~~~~~
-          name: 'test-name'
-          ~~~~~~~~~~~~~~~~~
-        })
-        ~~
-        class Test {}
-`,
-    messageId,
-    data: { type: 'pipe' },
-    annotatedOutput: `
-        @Pipe({
-        
-          standalone: true,name: 'test-name'
-          
-        })
-        
-        class Test {}
-`,
-  }),
-  convertAnnotatedSourceToFailureCase({
-    description:
-      'should fail when a pipe has no standalone property in a decorator with multiple properties',
-    annotatedSource: `
-        @Pipe({
-        ~~~~~~~
-          selector: 'my-selector',
-          ~~~~~~~~~~~~~~~~~~~~~~~~
-          name: 'test-name'
-          ~~~~~~~~~~~~~~~~~
-        })
-        ~~
-        class Test {}
-`,
-    messageId,
-    data: { type: 'pipe' },
-    annotatedOutput: `
-        @Pipe({
-        
-          standalone: true,selector: 'my-selector',
-          
-          name: 'test-name'
           
         })
         


### PR DESCRIPTION
In Angular 19, [standalone will be the new default](https://blog.angular.dev/the-future-is-standalone-475d7edbc706). There will also be an automigration which removes the `standalone: true` property from the metadata. This plugin needs to be updated in order to adapt to those changes.

Note: It would be better if the fixer would remove the whole attribute, but with the given tooling this is not so easy to achieve. For now the fixer will transform the `standalone: false` attribute to `standalone: true`.