### PR TITLE
feat(eslint-plugin): prefer-signals now checks .asReadonly() calls

### DIFF
--- a/packages/eslint-plugin/docs/rules/prefer-signals.md
+++ b/packages/eslint-plugin/docs/rules/prefer-signals.md
@@ -486,6 +486,35 @@ class Test {
 
 ```ts
 class Test {
+  testSignal = signal(42).asReadonly();
+  ~~~~~~~~~~
+}
+```
+
+<br>
+
+---
+
+<br>
+
+#### Default Config
+
+```json
+{
+  "rules": {
+    "@angular-eslint/prefer-signals": [
+      "error"
+    ]
+  }
+}
+```
+
+<br>
+
+#### ❌ Invalid Code
+
+```ts
+class Test {
   testSignal = toSignal(source);
   ~~~~~~~~~~
 }
@@ -1305,6 +1334,34 @@ class Test {
 ```ts
 class Test {
   readonly testSignal = signal(true);
+}
+```
+
+<br>
+
+---
+
+<br>
+
+#### Default Config
+
+```json
+{
+  "rules": {
+    "@angular-eslint/prefer-signals": [
+      "error"
+    ]
+  }
+}
+```
+
+<br>
+
+#### ✅ Valid Code
+
+```ts
+class Test {
+  readonly testSignal = signal(true).asReadonly();
 }
 ```
 

--- a/packages/eslint-plugin/src/rules/prefer-signals.ts
+++ b/packages/eslint-plugin/src/rules/prefer-signals.ts
@@ -138,8 +138,24 @@ export default createESLintRule<Options, MessageIds>({
           // There is no type annotation, so try to
           // use the value assigned to the property
           // to determine whether it would be a signal.
-          if (node.value?.type === AST_NODE_TYPES.CallExpression) {
-            let callee: TSESTree.Node = node.value.callee;
+          let value = node.value;
+          if (value?.type === AST_NODE_TYPES.CallExpression) {
+            const callee = value.callee;
+            // A `WritableSignal` can be turned into a `Signal` using
+            // the `.asReadonly()` method. If that method is being,
+            // called, then we need to look at the object that the method
+            // is called on to determine if it's being called on a `Signal`.
+            if (callee.type === AST_NODE_TYPES.MemberExpression) {
+              if (
+                callee.property.type === AST_NODE_TYPES.Identifier &&
+                callee.property.name === 'asReadonly'
+              ) {
+                value = callee.object;
+              }
+            }
+          }
+          if (value?.type === AST_NODE_TYPES.CallExpression) {
+            let callee: TSESTree.Node = value.callee;
             // Some signal-creating functions have a `.required`
             // member. For example, `input.required()`.
             if (callee.type === AST_NODE_TYPES.MemberExpression) {

--- a/packages/eslint-plugin/tests/rules/prefer-signals/cases.ts
+++ b/packages/eslint-plugin/tests/rules/prefer-signals/cases.ts
@@ -102,6 +102,11 @@ export const valid = [
     `,
   `
     class Test {
+      readonly testSignal = signal(true).asReadonly();
+    }
+    `,
+  `
+    class Test {
       readonly testSignal = toSignal(source);
     }
     `,
@@ -472,6 +477,22 @@ export const invalid = [
     annotatedOutput: `
       class Test {
         readonly testSignal = signal(42);
+        
+      }
+      `,
+  }),
+  convertAnnotatedSourceToFailureCase({
+    description: 'should fail when a signal.asReadonly() is not readonly',
+    annotatedSource: `
+      class Test {
+        testSignal = signal(42).asReadonly();
+        ~~~~~~~~~~
+      }
+      `,
+    messageId: messageIdPreferReadonlySignalProperties,
+    annotatedOutput: `
+      class Test {
+        readonly testSignal = signal(42).asReadonly();
         
       }
       `,


### PR DESCRIPTION
Fixes #2216