### PR TITLE
fix(eslint-plugin-template): [prefer-self-closing-tags] do not remove HTML-encoded whitespace

### DIFF
--- a/packages/eslint-plugin-template/docs/rules/prefer-self-closing-tags.md
+++ b/packages/eslint-plugin-template/docs/rules/prefer-self-closing-tags.md
@@ -641,6 +641,58 @@ The rule does not have any configuration options.
 <app-root></app-root>
 ```
 
+<br>
+
+---
+
+<br>
+
+#### Default Config
+
+```json
+{
+  "rules": {
+    "@angular-eslint/template/prefer-self-closing-tags": [
+      "error"
+    ]
+  }
+}
+```
+
+<br>
+
+#### ✅ Valid Code
+
+```html
+<ng-container>&nbsp;</ng-container>
+```
+
+<br>
+
+---
+
+<br>
+
+#### Default Config
+
+```json
+{
+  "rules": {
+    "@angular-eslint/template/prefer-self-closing-tags": [
+      "error"
+    ]
+  }
+}
+```
+
+<br>
+
+#### ✅ Valid Code
+
+```html
+<my-component>  <!-- not empty -->  </ng-container>
+```
+
 </details>
 
 <br>

--- a/packages/eslint-plugin-template/tests/rules/prefer-self-closing-tags/cases.ts
+++ b/packages/eslint-plugin-template/tests/rules/prefer-self-closing-tags/cases.ts
@@ -34,6 +34,8 @@ export const valid: readonly (string | ValidTestCase<Options>)[] = [
     <p>Fallback content</p>
   </ng-content>`,
   { code: '<app-root></app-root>', filename: 'src/index.html' },
+  '<ng-container>&nbsp;</ng-container>',
+  '<my-component>  <!-- not empty -->  </ng-container>',
 ];
 
 export const invalid: readonly InvalidTestCase<MessageIds, Options>[] = [


### PR DESCRIPTION
Fixes #1700
Fixes #1715

The bug was caused by the fact that the template parser decodes HTML entities. For example if the text content of a node is "&nbsp;", then that is parsed to a `TmplAstText` object with a value of " ". Likewise, `&#9;` is parsed to "\t", and so on.

So rather than checking if the `TmplAstText.value` property is whitespace, we need to get the corresponding text from the _source code_ and see if that text is whitespace.