### PR TITLE
fix(eslint-plugin-template): find inline templates on components in blocks

### DIFF
--- a/packages/angular-eslint/tsconfig.spec.json
+++ b/packages/angular-eslint/tsconfig.spec.json
@@ -2,7 +2,8 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "outDir": "../../dist/out-tsc/angular-eslint",
-    "types": ["jest", "node"]
+    "types": ["jest", "node"],
+    "sourceMap": true
   },
   "include": [
     "**/*.spec.ts",

--- a/packages/builder/tsconfig.spec.json
+++ b/packages/builder/tsconfig.spec.json
@@ -2,7 +2,8 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "outDir": "../../dist/out-tsc/builder",
-    "types": ["jest", "node"]
+    "types": ["jest", "node"],
+    "sourceMap": true
   },
   "include": [
     "**/*.spec.ts",

--- a/packages/eslint-plugin-template/src/processors.ts
+++ b/packages/eslint-plugin-template/src/processors.ts
@@ -219,43 +219,26 @@ function getClassDeclarationFromSourceFile(
 
     // Keywords, tokens and trivia all come before `FirstNode`. They won't
     // contain child nodes anyway, but we can skip them to save some time.
+    // Likewise, we can skip nodes that are part of JSDoc comments.
     if (
-      node.kind < ts.SyntaxKind.FirstNode &&
+      node.kind < ts.SyntaxKind.FirstNode ||
       node.kind > ts.SyntaxKind.FirstJSDocNode
-    ) {
-      return;
-    }
-
-    // Some names, parameters and signatures can be skipped.
-    if (
-      node.kind >= ts.SyntaxKind.QualifiedName &&
-      node.kind <= ts.SyntaxKind.MethodSignature
     ) {
       return;
     }
 
     // Type nodes can be skipped.
     if (
-      node.kind >= ts.SyntaxKind.TypeReference &&
+      node.kind >= ts.SyntaxKind.TypePredicate &&
       node.kind <= ts.SyntaxKind.ImportType
     ) {
       return;
     }
 
-    // JSX nodes won't contain class declarations
-    // that have Angular templates.
-    if (
-      node.kind >= ts.SyntaxKind.JsxElement &&
-      node.kind <= ts.SyntaxKind.JsxNamespacedName
-    ) {
-      return;
-    }
-
-    // Some specific kinds of nodes can be skipped.
+    // Some specific kinds of nodes can be skipped because
+    // we know that they cannot contain class declarations.
     switch (node.kind) {
-      case ts.SyntaxKind.CallSignature:
-      case ts.SyntaxKind.ConstructSignature:
-      case ts.SyntaxKind.IndexSignature:
+      case ts.SyntaxKind.InterfaceDeclaration:
       case ts.SyntaxKind.EnumDeclaration:
       case ts.SyntaxKind.ImportEqualsDeclaration:
       case ts.SyntaxKind.ImportDeclaration:

--- a/packages/eslint-plugin-template/tests/processors.spec.ts
+++ b/packages/eslint-plugin-template/tests/processors.spec.ts
@@ -465,6 +465,22 @@ describe('extract-inline-html', () => {
               class ParenthesizedComponent {}
             });
           });
+
+          // The following statements test the early-exiting
+          // logic in the processor when it walks the
+          // syntax tree to find class declarations.
+
+          type A = number;
+
+          let b: string[] = [1, 2, 3];
+
+          enum C {
+            D = 1,
+          }
+
+          interface E {
+            f: string;
+          }
         `;
         expect(
           processors['extract-inline-html'].preprocess(

--- a/packages/eslint-plugin-template/tests/processors.spec.ts
+++ b/packages/eslint-plugin-template/tests/processors.spec.ts
@@ -431,6 +431,66 @@ describe('extract-inline-html', () => {
         ]);
       });
     });
+
+    describe('components within blocks', () => {
+      it(`should support extracting inline templates from components that are not at the top-level`, () => {
+        const input = `
+          import { Component } from '@angular/core';
+
+          describe('nested', () => {
+            describe('arrow', () => {
+              @Component({
+                selector: 'app-a',
+                template: '<h1>Arrow</h1>',
+                styleUrls: ['./a.component.scss']
+              })
+              class ArrowComponent {}
+            });
+
+            describe('function', function () {
+              @Component({
+                selector: 'app-b',
+                template: '<h1>Function</h1>',
+                styleUrls: ['./b.component.scss']
+              })
+              class FunctionComponent {}
+            });
+
+            (() => {
+              @Component({
+                selector: 'app-b',
+                template: '<h1>Parenthesized</h1>',
+                styleUrls: ['./b.component.scss']
+              })
+              class ParenthesizedComponent {}
+            });
+          });
+        `;
+        expect(
+          processors['extract-inline-html'].preprocess(
+            input,
+            'multiple-in-blocks.spec.ts',
+          ),
+        ).toEqual([
+          input,
+          {
+            filename:
+              'inline-template-multiple-in-blocks.spec.ts-1.component.html',
+            text: '<h1>Arrow</h1>',
+          },
+          {
+            filename:
+              'inline-template-multiple-in-blocks.spec.ts-2.component.html',
+            text: '<h1>Function</h1>',
+          },
+          {
+            filename:
+              'inline-template-multiple-in-blocks.spec.ts-3.component.html',
+            text: '<h1>Parenthesized</h1>',
+          },
+        ]);
+      });
+    });
   });
 
   describe('postprocess()', () => {

--- a/packages/eslint-plugin-template/tsconfig.spec.json
+++ b/packages/eslint-plugin-template/tsconfig.spec.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "outDir": "../../dist/out-tsc/eslint-plugin-template",
     "types": ["jest", "node"],
-    "resolveJsonModule": true
+    "resolveJsonModule": true,
+    "sourceMap": true
   },
   "include": [
     "**/*.spec.ts",

--- a/packages/eslint-plugin/tsconfig.spec.json
+++ b/packages/eslint-plugin/tsconfig.spec.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "outDir": "../../dist/out-tsc/eslint-plugin",
     "types": ["jest", "node"],
-    "resolveJsonModule": true
+    "resolveJsonModule": true,
+    "sourceMap": true
   },
   "include": [
     "**/*.spec.ts",

--- a/packages/nx-plugin/tsconfig.spec.json
+++ b/packages/nx-plugin/tsconfig.spec.json
@@ -2,7 +2,8 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "outDir": "../../dist/out-tsc/nx-plugin",
-    "types": ["jest", "node"]
+    "types": ["jest", "node"],
+    "sourceMap": true
   },
   "include": [
     "**/*.spec.ts",

--- a/packages/schematics/tsconfig.spec.json
+++ b/packages/schematics/tsconfig.spec.json
@@ -2,7 +2,8 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "outDir": "../../dist/out-tsc/schematics",
-    "types": ["jest", "node"]
+    "types": ["jest", "node"],
+    "sourceMap": true
   },
   "include": [
     "**/*.test.ts",

--- a/packages/template-parser/tsconfig.spec.json
+++ b/packages/template-parser/tsconfig.spec.json
@@ -2,7 +2,8 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "outDir": "../../dist/out-tsc/schematics",
-    "types": ["jest", "node"]
+    "types": ["jest", "node"],
+    "sourceMap": true
   },
   "include": [
     "**/*.test.ts",

--- a/packages/test-utils/tsconfig.spec.json
+++ b/packages/test-utils/tsconfig.spec.json
@@ -2,7 +2,8 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "outDir": "../../dist/out-tsc/test-utils",
-    "types": ["jest", "node"]
+    "types": ["jest", "node"],
+    "sourceMap": true
   },
   "include": [
     "**/*.spec.ts",

--- a/packages/utils/tsconfig.spec.json
+++ b/packages/utils/tsconfig.spec.json
@@ -2,7 +2,8 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "outDir": "../../dist/out-tsc/utils",
-    "types": ["jest", "node"]
+    "types": ["jest", "node"],
+    "sourceMap": true
   },
   "include": [
     "**/*.spec.ts",


### PR DESCRIPTION
Fixes #1825 

Rather than only looking at the statements in a source file to find the class declarations, the preprocessor now walks down the syntax tree to find the class declarations.

This might seem like it will add a bit more work to the processor, but I don't think it will have much of an impact on performance. 

For a typical component file that contains some `import` statements and a class declaration, nothing will change - the syntax tree walking explicitly avoids stepping down into `ImportDeclaration` nodes, and it doesn't step into `ClassDeclaration` nodes, so the net result would be no change to performance.

For a file that contains some more things like type exports, top-level variable assignments and enum declarations, _most_ of those things are also skipped. Variable assignments cannot be skipped because a class could be defined somewhere within the value being assigned (the value being assigned could be a function that defines a class, for example).

For any other files, it will end up doing a bit more work, but its worth remembering that the heuristics will filter out most files anyway.

One thought I did have is adjusting those heuristics to look for `template:` rather than `Component` (or maybe look for both). If you are testing a component, there's a good chance that the file would contain both `Component` and `@angular/core`, but won't necessarily define a component class. By looking for `template:`, the preprocessor could avoid looking at more files.

Anyway, I haven't changed any of the heuristics, but if you think that's a good idea, I can make that change as well.