### PR TITLE
fix(eslint-plugin-template): [prefer-static-string-properties] do not check structural directives

### DIFF
--- a/packages/eslint-plugin-template/docs/rules/prefer-static-string-properties.md
+++ b/packages/eslint-plugin-template/docs/rules/prefer-static-string-properties.md
@@ -277,6 +277,32 @@ The rule does not have any configuration options.
 <my-component name="foo"/>
 ```
 
+<br>
+
+---
+
+<br>
+
+#### Default Config
+
+```json
+{
+  "rules": {
+    "@angular-eslint/template/prefer-static-string-properties": [
+      "error"
+    ]
+  }
+}
+```
+
+<br>
+
+#### ✅ Valid Code
+
+```html
+<my-component *name="'foo'"/>
+```
+
 </details>
 
 <br>

--- a/packages/eslint-plugin-template/src/rules/prefer-static-string-properties.ts
+++ b/packages/eslint-plugin-template/src/rules/prefer-static-string-properties.ts
@@ -30,7 +30,11 @@ export default createESLintRule<Options, MessageIds>({
     const parserServices = getTemplateParserServices(context);
 
     return {
-      BoundAttribute({ name, sourceSpan, value }: TmplAstBoundAttribute) {
+      ['BoundAttribute.inputs']({
+        name,
+        sourceSpan,
+        value,
+      }: TmplAstBoundAttribute) {
         if (
           value instanceof ASTWithSource &&
           value.ast instanceof LiteralPrimitive &&

--- a/packages/eslint-plugin-template/tests/rules/prefer-static-string-properties/cases.ts
+++ b/packages/eslint-plugin-template/tests/rules/prefer-static-string-properties/cases.ts
@@ -17,6 +17,7 @@ export const valid: readonly (string | ValidTestCase<Options>)[] = [
   '<my-component [name]="null"/>',
   '<my-component [name]="undefined"/>',
   '<my-component name="foo"/>',
+  `<my-component *name="'foo'"/>`,
 ];
 
 export const invalid: readonly InvalidTestCase<MessageIds, Options>[] = [


### PR DESCRIPTION
Fixes #2237 

A simple fix. The rule should only check `BoundAttribute` nodes that are in the `inputs` collection of an element, and not in the `templateAttrs` collection.