### PR TITLE
docs: show falsy default values

### DIFF
--- a/packages/eslint-plugin-template/docs/rules/attributes-order.md
+++ b/packages/eslint-plugin-template/docs/rules/attributes-order.md
@@ -28,6 +28,9 @@ The rule accepts an options object with the following properties:
 
 ```ts
 interface Options {
+  /**
+   * Default: `false`
+   */
   alphabetical?: boolean;
   /**
    * Default: `["STRUCTURAL_DIRECTIVE","TEMPLATE_REFERENCE","ATTRIBUTE_BINDING","INPUT_BINDING","TWO_WAY_BINDING","OUTPUT_BINDING"]`

--- a/packages/eslint-plugin-template/docs/rules/eqeqeq.md
+++ b/packages/eslint-plugin-template/docs/rules/eqeqeq.md
@@ -30,6 +30,9 @@ The rule accepts an options object with the following properties:
 
 ```ts
 interface Options {
+  /**
+   * Default: `false`
+   */
   allowNullOrUndefined?: boolean;
 }
 

--- a/packages/eslint-plugin-template/docs/rules/label-has-associated-control.md
+++ b/packages/eslint-plugin-template/docs/rules/label-has-associated-control.md
@@ -27,6 +27,9 @@ The rule accepts an options object with the following properties:
 
 ```ts
 interface Options {
+  /**
+   * Default: `false`
+   */
   checkIds?: boolean;
   /**
    * Default: `["input","meter","output","progress","select","textarea"]`

--- a/packages/eslint-plugin-template/docs/rules/no-call-expression.md
+++ b/packages/eslint-plugin-template/docs/rules/no-call-expression.md
@@ -31,7 +31,13 @@ interface Options {
    * Default: `[]`
    */
   allowList?: string[];
+  /**
+   * Default: `undefined`
+   */
   allowPrefix?: string;
+  /**
+   * Default: `undefined`
+   */
   allowSuffix?: string;
 }
 

--- a/packages/eslint-plugin-template/docs/rules/no-duplicate-attributes.md
+++ b/packages/eslint-plugin-template/docs/rules/no-duplicate-attributes.md
@@ -37,6 +37,8 @@ interface Options {
   allowTwoWayDataBinding?: boolean;
   /**
    * Whether or not Angular style precedence is allowed as an exception to the rule. See https://angular.dev/guide/templates/class-binding#styling-precedence
+   *
+   * Default: `false`
    */
   allowStylePrecedenceDuplicates?: boolean;
   /**

--- a/packages/eslint-plugin-template/docs/rules/no-inline-styles.md
+++ b/packages/eslint-plugin-template/docs/rules/no-inline-styles.md
@@ -27,7 +27,13 @@ The rule accepts an options object with the following properties:
 
 ```ts
 interface Options {
+  /**
+   * Default: `false`
+   */
   allowNgStyle?: boolean;
+  /**
+   * Default: `false`
+   */
   allowBindToStyle?: boolean;
 }
 

--- a/packages/eslint-plugin/docs/rules/component-selector.md
+++ b/packages/eslint-plugin/docs/rules/component-selector.md
@@ -28,8 +28,17 @@ The rule accepts an options object with the following properties:
 
 ```ts
 interface Options {
+  /**
+   * Default: `""`
+   */
   type?: string | ("element" | "attribute")[];
+  /**
+   * Default: `""`
+   */
   prefix?: string | unknown[];
+  /**
+   * Default: `""`
+   */
   style?: "camelCase" | "kebab-case";
 }
 

--- a/packages/eslint-plugin/docs/rules/directive-selector.md
+++ b/packages/eslint-plugin/docs/rules/directive-selector.md
@@ -27,8 +27,17 @@ The rule accepts an options object with the following properties:
 
 ```ts
 interface Options {
+  /**
+   * Default: `""`
+   */
   type?: string | ("element" | "attribute")[];
+  /**
+   * Default: `""`
+   */
   prefix?: string | unknown[];
+  /**
+   * Default: `""`
+   */
   style?: "camelCase" | "kebab-case";
 }
 

--- a/packages/eslint-plugin/docs/rules/prefer-signals.md
+++ b/packages/eslint-plugin/docs/rules/prefer-signals.md
@@ -40,6 +40,9 @@ interface Options {
    * Default: `true`
    */
   preferQuerySignals?: boolean;
+  /**
+   * Default: `false`
+   */
   useTypeChecking?: boolean;
   /**
    * Default: `[]`

--- a/packages/eslint-plugin/docs/rules/require-localize-metadata.md
+++ b/packages/eslint-plugin/docs/rules/require-localize-metadata.md
@@ -27,7 +27,13 @@ The rule accepts an options object with the following properties:
 
 ```ts
 interface Options {
+  /**
+   * Default: `false`
+   */
   requireDescription?: boolean;
+  /**
+   * Default: `false`
+   */
   requireMeaning?: boolean;
 }
 

--- a/tools/scripts/generate-rule-docs.ts
+++ b/tools/scripts/generate-rule-docs.ts
@@ -67,20 +67,25 @@ const testDirs = readdirSync(testDirsDir);
         cb: (...data) => {
           const [schemaNode, , , , , , keyIndex] = data;
 
-          let defaultValue = null;
+          let defaultValue = undefined;
+          let hasDefaultValue = false;
 
           if (typeof schemaNode.default !== 'undefined') {
             defaultValue = schemaNode.default;
+            hasDefaultValue = true;
           } else if (defaultOptions?.length) {
             for (const defaultOption of defaultOptions) {
-              const defaultValueForNode = defaultOption[keyIndex as string];
-              if (defaultValueForNode) {
-                defaultValue = defaultValueForNode;
+              if (
+                typeof defaultOption === 'object' &&
+                (keyIndex as string) in defaultOption
+              ) {
+                defaultValue = defaultOption[keyIndex as string];
+                hasDefaultValue = true;
               }
             }
           }
 
-          if (defaultValue) {
+          if (hasDefaultValue) {
             if (schemaNode.description) {
               schemaNode.description += '\n\n';
             } else {


### PR DESCRIPTION
Fixes #1749 

Options that had a default value of `false`, `0`, `""`, `null` or `undefined` would not show their default value in the docs.