### PR TITLE
feat(template-parser)!: do not suppress parse errors by default

### DIFF
--- a/packages/eslint-plugin-template/docs/rules/eqeqeq.md
+++ b/packages/eslint-plugin-template/docs/rules/eqeqeq.md
@@ -182,7 +182,7 @@ interface Options {
 #### ❌ Invalid Code
 
 ```html
-<div [prop]="condition1 === 'value1' ? true : (condition2 != 'value2' ? true : false)}"></div>
+<div [prop]="condition1 === 'value1' ? true : (condition2 != 'value2' ? true : false)"></div>
                                                ~~~~~~~~~~~~~~~~~~~~~~
 ```
 

--- a/packages/eslint-plugin-template/docs/rules/no-call-expression.md
+++ b/packages/eslint-plugin-template/docs/rules/no-call-expression.md
@@ -794,7 +794,7 @@ interface Options {
 #### ✅ Valid Code
 
 ```html
-@for (item of list; track item.id)) {
+@for (item of list; track item.id) {
   <div></div>
 } @empty {
   <div></div>

--- a/packages/eslint-plugin-template/docs/rules/prefer-ngsrc.md
+++ b/packages/eslint-plugin-template/docs/rules/prefer-ngsrc.md
@@ -164,7 +164,7 @@ The rule does not have any configuration options.
 #### ✅ Valid Code
 
 ```html
-<img [ngSrc]="'http://localhost'>
+<img [ngSrc]="'http://localhost'">
 ```
 
 <br>

--- a/packages/eslint-plugin-template/tests/rules/eqeqeq/cases.ts
+++ b/packages/eslint-plugin-template/tests/rules/eqeqeq/cases.ts
@@ -95,7 +95,7 @@ export const invalid: readonly InvalidTestCase<MessageIds, Options>[] = [
     description:
       'it should fail if the operation is not strict within attribute directive with nested ternary',
     annotatedSource: `
-      <div [prop]="condition1 === 'value1' ? true : (condition2 != 'value2' ? true : false)}"></div>
+      <div [prop]="condition1 === 'value1' ? true : (condition2 != 'value2' ? true : false)"></div>
                                                      ~~~~~~~~~~~~~~~~~~~~~~
       `,
     messageId,
@@ -104,7 +104,7 @@ export const invalid: readonly InvalidTestCase<MessageIds, Options>[] = [
       expectedOperation: '!==',
     },
     annotatedOutput: `
-      <div [prop]="condition1 === 'value1' ? true : (condition2 !== 'value2' ? true : false)}"></div>
+      <div [prop]="condition1 === 'value1' ? true : (condition2 !== 'value2' ? true : false)"></div>
                                                      ~~~~~~~~~~~~~~~~~~~~~~~
       `,
   }),

--- a/packages/eslint-plugin-template/tests/rules/i18n/cases.ts
+++ b/packages/eslint-plugin-template/tests/rules/i18n/cases.ts
@@ -502,6 +502,7 @@ export const invalid: readonly InvalidTestCase<MessageIds, Options>[] = [
       <p>Lorem ipsum <em i18n="@@dolor">dolor</em> sit amet.</p>
          ~~~~~~~~~~~~                              ^^^^^^^^^
     `,
+    languageOptions: { parserOptions: { suppressParseErrors: true } },
     messages: [
       {
         char: '~',
@@ -876,6 +877,7 @@ export const invalid: readonly InvalidTestCase<MessageIds, Options>[] = [
       <ng-template>Lorem ipsum <ng-template i18n="@@dolor">dolor</ng-template> sit amet.</ng-template>
                    ~~~~~~~~~~~~                                                ^^^^^^^^^
     `,
+    languageOptions: { parserOptions: { suppressParseErrors: true } },
     messages: [
       {
         char: '~',
@@ -1176,5 +1178,6 @@ export const invalid: readonly InvalidTestCase<MessageIds, Options>[] = [
     `,
     messageId: i18nMarkupInContent,
     options: [{ allowMarkupInContent: false, checkId: false }],
+    languageOptions: { parserOptions: { suppressParseErrors: true } },
   }),
 ];

--- a/packages/eslint-plugin-template/tests/rules/no-call-expression/cases.ts
+++ b/packages/eslint-plugin-template/tests/rules/no-call-expression/cases.ts
@@ -50,7 +50,7 @@ export const valid: readonly (string | ValidTestCase<Options>)[] = [
     } 
   }`,
   `
-  @for (item of list; track item.id)) {
+  @for (item of list; track item.id) {
     <div></div>
   } @empty {
     <div></div>

--- a/packages/eslint-plugin-template/tests/rules/prefer-ngsrc/cases.ts
+++ b/packages/eslint-plugin-template/tests/rules/prefer-ngsrc/cases.ts
@@ -10,7 +10,7 @@ const invalidDoubleSource: MessageIds = 'invalidDoubleSource';
 
 export const valid: readonly (string | ValidTestCase<Options>)[] = [
   '<img ngSrc="http://localhost">',
-  "<img [ngSrc]=\"'http://localhost'>",
+  '<img [ngSrc]="\'http://localhost\'">',
   '<img [ngSrc]="value">',
   '<img src="data:image/jpeg;base64">',
 ];

--- a/packages/template-parser/src/index.ts
+++ b/packages/template-parser/src/index.ts
@@ -300,10 +300,7 @@ function parseForESLint(
     };
   }
 
-  // TODO: Investigate no longer suppressing parse errors by default in v19
-  const suppressParseErrors = options.suppressParseErrors ?? true;
-
-  if (!suppressParseErrors && angularCompilerResult.errors?.length) {
+  if (!options.suppressParseErrors && angularCompilerResult.errors?.length) {
     throw createTemplateParseError(angularCompilerResult.errors[0]);
   }
 

--- a/packages/template-parser/tests/index.test.ts
+++ b/packages/template-parser/tests/index.test.ts
@@ -511,20 +511,7 @@ describe('parseForESLint()', () => {
   });
 
   describe('parse errors', () => {
-    it('should not throw if the Angular compiler produced parse errors by default', () => {
-      expect.assertions(1);
-
-      const { ast } = parseForESLint(
-        '<p>consumed resources are at {{ ${percent} | formatPercentLocale }}</p>',
-        {
-          filePath:
-            './inline-template-source-using-template-literal-interpolation.html',
-        },
-      );
-      expect(ast).toBeDefined();
-    });
-
-    it('should appropriately throw if the Angular compiler produced parse errors and `parserOptions.suppressParseErrors` is set to false', () => {
+    it('should throw if the Angular compiler produced parse errors by default', () => {
       expect.assertions(2);
 
       let error: TemplateParseError;
@@ -533,7 +520,6 @@ describe('parseForESLint()', () => {
           '<p i18n>Lorem ipsum <em i18n="@@dolor">dolor</em> sit amet.</p>',
           {
             filePath: './invalid-nested-i18ns.html',
-            suppressParseErrors: false,
           },
         );
       } catch (err: any) {
@@ -550,6 +536,20 @@ describe('parseForESLint()', () => {
           }"
         `);
       }
+    });
+
+    it('should not throw if the Angular compiler produced parse errors and `parserOptions.suppressParseErrors` is set to true', () => {
+      expect.assertions(1);
+
+      const { ast } = parseForESLint(
+        '<p>consumed resources are at {{ ${percent} | formatPercentLocale }}</p>',
+        {
+          filePath:
+            './inline-template-source-using-template-literal-interpolation.html',
+          suppressParseErrors: true,
+        },
+      );
+      expect(ast).toBeDefined();
     });
   });
 

--- a/packages/test-utils/src/convert-annotated-source-to-failure-case.ts
+++ b/packages/test-utils/src/convert-annotated-source-to-failure-case.ts
@@ -2,6 +2,7 @@ import type {
   InvalidTestCase,
   SuggestionOutput,
   TestCaseError,
+  TestLanguageOptions,
 } from '@typescript-eslint/rule-tester';
 
 /**
@@ -28,6 +29,7 @@ type MultipleErrorOptions<
   TMessageIds extends string,
   Options extends readonly unknown[],
 > = BaseErrorOptions<Options> & {
+  readonly languageOptions?: TestLanguageOptions;
   readonly messages: readonly (Message<TMessageIds> & {
     readonly char: (typeof SPECIAL_UNDERLINE_CHARS)[number];
   })[];
@@ -52,7 +54,10 @@ type Message<TMessageIds extends string> = {
 type SingleErrorOptions<
   TMessageIds extends string,
   Options extends readonly unknown[],
-> = BaseErrorOptions<Options> & Message<TMessageIds>;
+> = BaseErrorOptions<Options> &
+  Message<TMessageIds> & {
+    readonly languageOptions?: TestLanguageOptions;
+  };
 
 /**
  * convertAnnotatedSourceToFailureCase() provides an ergonomic way to easily write
@@ -156,6 +161,7 @@ export function convertAnnotatedSourceToFailureCase<
         : parsedSource,
     filename: errorOptions.filename,
     options: errorOptions.options ?? ([] as any),
+    languageOptions: errorOptions.languageOptions,
     errors,
     only: errorOptions.only ?? false,
     output: errorOptions.annotatedOutputs


### PR DESCRIPTION
Fixes #1641

🚨 Breaking change 🚨

Template parse errors will now result in an error from ESLint.

~~Note: This is currently blocked by #2256.~~