### PR TITLE
fix(eslint-plugin-template): [prefer-self-closing-tags] allow nested ng-content

### DIFF
--- a/packages/eslint-plugin-template/docs/rules/prefer-self-closing-tags.md
+++ b/packages/eslint-plugin-template/docs/rules/prefer-self-closing-tags.md
@@ -287,6 +287,34 @@ The rule does not have any configuration options.
 ~~~~~~~~~~~~~
 ```
 
+<br>
+
+---
+
+<br>
+
+#### Default Config
+
+```json
+{
+  "rules": {
+    "@angular-eslint/template/prefer-self-closing-tags": [
+      "error"
+    ]
+  }
+}
+```
+
+<br>
+
+#### ❌ Invalid Code
+
+```html
+<ng-content select="foo>bar">
+</ng-content>
+~~~~~~~~~~~~~
+```
+
 </details>
 
 <br>
@@ -606,11 +634,143 @@ The rule does not have any configuration options.
 #### ✅ Valid Code
 
 ```html
+<ng-content>&nbsp;</ng-content>
+```
+
+<br>
+
+---
+
+<br>
+
+#### Default Config
+
+```json
+{
+  "rules": {
+    "@angular-eslint/template/prefer-self-closing-tags": [
+      "error"
+    ]
+  }
+}
+```
+
+<br>
+
+#### ✅ Valid Code
+
+```html
+<ng-content> <!-- comment --> </ng-content>
+```
+
+<br>
+
+---
+
+<br>
+
+#### Default Config
+
+```json
+{
+  "rules": {
+    "@angular-eslint/template/prefer-self-closing-tags": [
+      "error"
+    ]
+  }
+}
+```
+
+<br>
+
+#### ✅ Valid Code
+
+```html
 <ng-content
      select="content"
    >
     <p>Fallback content</p>
   </ng-content>
+```
+
+<br>
+
+---
+
+<br>
+
+#### Default Config
+
+```json
+{
+  "rules": {
+    "@angular-eslint/template/prefer-self-closing-tags": [
+      "error"
+    ]
+  }
+}
+```
+
+<br>
+
+#### ✅ Valid Code
+
+```html
+<ng-content select="[slot='icon-only']">
+    <ng-content select="[slot=text]" />
+  </ng-content>
+```
+
+<br>
+
+---
+
+<br>
+
+#### Default Config
+
+```json
+{
+  "rules": {
+    "@angular-eslint/template/prefer-self-closing-tags": [
+      "error"
+    ]
+  }
+}
+```
+
+<br>
+
+#### ✅ Valid Code
+
+```html
+<ng-content select="[slot='foo>bar']" />
+```
+
+<br>
+
+---
+
+<br>
+
+#### Default Config
+
+```json
+{
+  "rules": {
+    "@angular-eslint/template/prefer-self-closing-tags": [
+      "error"
+    ]
+  }
+}
+```
+
+<br>
+
+#### ✅ Valid Code
+
+```html
+<ng-content select="[slot='foo>bar']">Fallback</ng-content>
 ```
 
 <br>

--- a/packages/eslint-plugin-template/tests/rules/prefer-self-closing-tags/cases.ts
+++ b/packages/eslint-plugin-template/tests/rules/prefer-self-closing-tags/cases.ts
@@ -28,11 +28,18 @@ export const valid: readonly (string | ValidTestCase<Options>)[] = [
   '<ng-content/>',
   '<ng-content select="my-selector" />',
   `<ng-content>Fallback content</ng-content>`,
+  `<ng-content>&nbsp;</ng-content>`,
+  `<ng-content> <!-- comment --> </ng-content>`,
   `<ng-content
      select="content"
    >
     <p>Fallback content</p>
   </ng-content>`,
+  `<ng-content select="[slot='icon-only']">
+    <ng-content select="[slot=text]" />
+  </ng-content>`,
+  `<ng-content select="[slot='foo>bar']" />`,
+  `<ng-content select="[slot='foo>bar']">Fallback</ng-content>`,
   { code: '<app-root></app-root>', filename: 'src/index.html' },
   '<ng-container>&nbsp;</ng-container>',
   '<my-component>  <!-- not empty -->  </ng-container>',
@@ -167,6 +174,20 @@ export const invalid: readonly InvalidTestCase<MessageIds, Options>[] = [
     `,
     annotatedOutput: `
       <ng-content />
+      
+    `,
+    messageId,
+  }),
+  convertAnnotatedSourceToFailureCase({
+    description:
+      'it should fail on ng-content elements with no content and > in the selector',
+    annotatedSource: `
+      <ng-content select="foo>bar">
+      </ng-content>
+      ~~~~~~~~~~~~~
+    `,
+    annotatedOutput: `
+      <ng-content select="foo>bar" />
       
     `,
     messageId,


### PR DESCRIPTION
Fixes #2060 

The immediate fix was actually quite simple - anchor the regular expression at the start and end of the string. The problem was that when there were nested `ng-content` nodes, the regular expression might not match to the first `<ng-content` tag and/or not match to the last `</ng-content>` tag. In the example from #2060:

```html
<ng-content select="[slot='icon-only']">
  <ng-content select="[slot=start]" />
  <ng-content />
  <ng-content select="[slot=end]" />
</ng-content>
```

The regular expression matches to:
```
<ng-content select="[slot=end]" />
</ng-content>
```

Adding `^` and `$` anchors to the regular expression would fix that, but the problem with using a regular expression is that it doesn't handle quotes. If a selector contained a ">" then it would incorrectly find the end of the opening tag and deduce that there is non-whitespace characters in the inner HTML which may not be true.

I've replaced the regular expression with a search through the string to find the end of the opening tag that handles quoted values, and a simple `.endsWith('</ng-content>')` check. If there is any non-whitespace characters after the opening tag and before the closing tag, then it's not empty.