### PR TITLE
fix(prefer-static-string-properties): resolve bug with directives

### DIFF
--- a/packages/eslint-plugin-template/docs/rules/prefer-static-string-properties.md
+++ b/packages/eslint-plugin-template/docs/rules/prefer-static-string-properties.md
@@ -305,10 +305,28 @@ The rule does not have any configuration options.
 
 <br>
 
+---
+
+<br>
+
+#### Default Config
+
+```json
+{
+  "rules": {
+    "@angular-eslint/template/prefer-static-string-properties": [
+      "error"
+    ]
+  }
+}
+```
+
+<br>
+
 #### ✅ Valid Code
 
 ```html
-<my-component name="foo"/>
+<input *ngSwitchCase="'foo'" />
 ```
 
 <br>
@@ -331,27 +349,11 @@ The rule does not have any configuration options.
 
 <br>
 
-#### Default Config
-
-```json
-{
-  "rules": {
-    "@angular-eslint/template/prefer-static-string-properties": [
-      "error"
-    ]
-  }
-}
-```
-
-<br>
-
 #### ✅ Valid Code
 
 ```html
-<ng-container *ngSwitchCase="'foo'"/>
+<ng-container *ngIf="'foo'" />
 ```
-
-<br>
 
 </details>
 

--- a/packages/eslint-plugin-template/docs/rules/prefer-static-string-properties.md
+++ b/packages/eslint-plugin-template/docs/rules/prefer-static-string-properties.md
@@ -303,6 +303,56 @@ The rule does not have any configuration options.
 <my-component *name="'foo'"/>
 ```
 
+<br>
+
+#### ✅ Valid Code
+
+```html
+<my-component name="foo"/>
+```
+
+<br>
+
+---
+
+<br>
+
+#### Default Config
+
+```json
+{
+  "rules": {
+    "@angular-eslint/template/prefer-static-string-properties": [
+      "error"
+    ]
+  }
+}
+```
+
+<br>
+
+#### Default Config
+
+```json
+{
+  "rules": {
+    "@angular-eslint/template/prefer-static-string-properties": [
+      "error"
+    ]
+  }
+}
+```
+
+<br>
+
+#### ✅ Valid Code
+
+```html
+<ng-container *ngSwitchCase="'foo'"/>
+```
+
+<br>
+
 </details>
 
 <br>

--- a/packages/eslint-plugin-template/src/rules/prefer-static-string-properties.ts
+++ b/packages/eslint-plugin-template/src/rules/prefer-static-string-properties.ts
@@ -35,7 +35,12 @@ export default createESLintRule<Options, MessageIds>({
         sourceSpan,
         value,
       }: TmplAstBoundAttribute) {
+        const isStructuralDirective = sourceSpan
+          .toString()
+          .trimStart()
+          .startsWith('*');
         if (
+          !isStructuralDirective &&
           value instanceof ASTWithSource &&
           value.ast instanceof LiteralPrimitive &&
           typeof value.ast.value === 'string'
@@ -46,6 +51,7 @@ export default createESLintRule<Options, MessageIds>({
           // quotes when we convert it to a property assignment.
           const quote = value.source?.trimStart().at(0) === '"' ? "'" : '"';
           const literal = value.ast.value;
+
           context.report({
             loc: parserServices.convertNodeSourceSpanToLoc(sourceSpan),
             messageId: 'preferStaticStringProperties',

--- a/packages/eslint-plugin-template/tests/rules/prefer-static-string-properties/cases.ts
+++ b/packages/eslint-plugin-template/tests/rules/prefer-static-string-properties/cases.ts
@@ -18,6 +18,8 @@ export const valid: readonly (string | ValidTestCase<Options>)[] = [
   '<my-component [name]="undefined"/>',
   '<my-component name="foo"/>',
   `<my-component *name="'foo'"/>`,
+  `<input *ngSwitchCase="'foo'" />`,
+  `<ng-container *ngIf="'foo'" />`,
 ];
 
 export const invalid: readonly InvalidTestCase<MessageIds, Options>[] = [


### PR DESCRIPTION
We don't want to use this rule for directives like `*ngSwitchCase` or `*ngIf`

fixes https://github.com/angular-eslint/angular-eslint/issues/2265