### PR TITLE
fix(prefer-static-string-properties): exclude special attributes

### DIFF
--- a/packages/eslint-plugin-template/docs/rules/prefer-static-string-properties.md
+++ b/packages/eslint-plugin-template/docs/rules/prefer-static-string-properties.md
@@ -430,6 +430,32 @@ The rule does not have any configuration options.
 #### ✅ Valid Code
 
 ```html
+<my-component [class.foo]="'foo'" />
+```
+
+<br>
+
+---
+
+<br>
+
+#### Default Config
+
+```json
+{
+  "rules": {
+    "@angular-eslint/template/prefer-static-string-properties": [
+      "error"
+    ]
+  }
+}
+```
+
+<br>
+
+#### ✅ Valid Code
+
+```html
 <my-component [@fade]="'foo'" />
 ```
 

--- a/packages/eslint-plugin-template/docs/rules/prefer-static-string-properties.md
+++ b/packages/eslint-plugin-template/docs/rules/prefer-static-string-properties.md
@@ -378,7 +378,7 @@ The rule does not have any configuration options.
 #### ✅ Valid Code
 
 ```html
-<my-component [style.color]="'var(--tui-background-accent-2-pressed)'" />
+<my-component [style.color]="'foo'" />
 ```
 
 <br>

--- a/packages/eslint-plugin-template/docs/rules/prefer-static-string-properties.md
+++ b/packages/eslint-plugin-template/docs/rules/prefer-static-string-properties.md
@@ -355,6 +355,84 @@ The rule does not have any configuration options.
 <ng-container *ngIf="'foo'" />
 ```
 
+<br>
+
+---
+
+<br>
+
+#### Default Config
+
+```json
+{
+  "rules": {
+    "@angular-eslint/template/prefer-static-string-properties": [
+      "error"
+    ]
+  }
+}
+```
+
+<br>
+
+#### ✅ Valid Code
+
+```html
+<my-component [style.color]="'var(--tui-background-accent-2-pressed)'" />
+```
+
+<br>
+
+---
+
+<br>
+
+#### Default Config
+
+```json
+{
+  "rules": {
+    "@angular-eslint/template/prefer-static-string-properties": [
+      "error"
+    ]
+  }
+}
+```
+
+<br>
+
+#### ✅ Valid Code
+
+```html
+<my-component [attr.aria-label]="'foo'" />
+```
+
+<br>
+
+---
+
+<br>
+
+#### Default Config
+
+```json
+{
+  "rules": {
+    "@angular-eslint/template/prefer-static-string-properties": [
+      "error"
+    ]
+  }
+}
+```
+
+<br>
+
+#### ✅ Valid Code
+
+```html
+<my-component [@fade]="'foo'" />
+```
+
 </details>
 
 <br>

--- a/packages/eslint-plugin-template/src/rules/prefer-static-string-properties.ts
+++ b/packages/eslint-plugin-template/src/rules/prefer-static-string-properties.ts
@@ -33,14 +33,17 @@ export default createESLintRule<Options, MessageIds>({
       ['BoundAttribute.inputs']({
         name,
         sourceSpan,
+        keySpan,
         value,
       }: TmplAstBoundAttribute) {
-        const isStructuralDirective = sourceSpan
-          .toString()
-          .trimStart()
-          .startsWith('*');
+        // Exclude @xxx (Animation) and xx.color
+        // When attribute start with "*", keySpan details is null so *ngSwitchCase is excluded
+        const isBindingProperty =
+          keySpan?.details &&
+          !keySpan.details.includes('@') &&
+          !keySpan.details.includes('.');
         if (
-          !isStructuralDirective &&
+          isBindingProperty &&
           value instanceof ASTWithSource &&
           value.ast instanceof LiteralPrimitive &&
           typeof value.ast.value === 'string'

--- a/packages/eslint-plugin-template/tests/rules/prefer-static-string-properties/cases.ts
+++ b/packages/eslint-plugin-template/tests/rules/prefer-static-string-properties/cases.ts
@@ -20,7 +20,7 @@ export const valid: readonly (string | ValidTestCase<Options>)[] = [
   `<my-component *name="'foo'"/>`,
   `<input *ngSwitchCase="'foo'" />`,
   `<ng-container *ngIf="'foo'" />`,
-  `<my-component [style.color]="'var(--tui-background-accent-2-pressed)'" />`,
+  `<my-component [style.color]="'foo'" />`,
   `<my-component [attr.aria-label]="'foo'" />`,
   `<my-component [@fade]="'foo'" />`,
 ];

--- a/packages/eslint-plugin-template/tests/rules/prefer-static-string-properties/cases.ts
+++ b/packages/eslint-plugin-template/tests/rules/prefer-static-string-properties/cases.ts
@@ -22,6 +22,7 @@ export const valid: readonly (string | ValidTestCase<Options>)[] = [
   `<ng-container *ngIf="'foo'" />`,
   `<my-component [style.color]="'foo'" />`,
   `<my-component [attr.aria-label]="'foo'" />`,
+  `<my-component [class.foo]="'foo'" />`,
   `<my-component [@fade]="'foo'" />`,
 ];
 

--- a/packages/eslint-plugin-template/tests/rules/prefer-static-string-properties/cases.ts
+++ b/packages/eslint-plugin-template/tests/rules/prefer-static-string-properties/cases.ts
@@ -20,6 +20,9 @@ export const valid: readonly (string | ValidTestCase<Options>)[] = [
   `<my-component *name="'foo'"/>`,
   `<input *ngSwitchCase="'foo'" />`,
   `<ng-container *ngIf="'foo'" />`,
+  `<my-component [style.color]="'var(--tui-background-accent-2-pressed)'" />`,
+  `<my-component [attr.aria-label]="'foo'" />`,
+  `<my-component [@fade]="'foo'" />`,
 ];
 
 export const invalid: readonly InvalidTestCase<MessageIds, Options>[] = [


### PR DESCRIPTION
Exclude some attributes : 

```
<my-component *ngSwitchCase="'foo'" />
```

```
<my-component [style.color]="'foo'" />
```

```
<my-component [attr.aria-label]="'foo'" />
```

```
<my-component [@fade]="'foo'" />
```

```
<my-component [class.foo]="'foo'" />
```

fixes: #2265 