### PR TITLE
fix(eslint-plugin-template): [prefer-self-closing-tags] resolve wrong reports when structural directive + no content + no self-closing

### DIFF
--- a/packages/eslint-plugin-template/docs/rules/prefer-self-closing-tags.md
+++ b/packages/eslint-plugin-template/docs/rules/prefer-self-closing-tags.md
@@ -83,8 +83,8 @@ The rule does not have any configuration options.
 #### ❌ Invalid Code
 
 ```html
-<my-component type="text" [name]="foo"></my-component>
-                                       ~~~~~~~~~~~~~~~
+<my-component *ngIf="condition" type="text" [name]="foo"></my-component>
+                                                         ~~~~~~~~~~~~~~~
 ```
 
 <br>
@@ -398,6 +398,7 @@ The rule does not have any configuration options.
 
 ```html
 <my-component
+  *ngIf="condition"
   type="text"
   [name]="foo"
   [items]="items" />
@@ -452,6 +453,32 @@ The rule does not have any configuration options.
 #### ✅ Valid Code
 
 ```html
+<img src="foo" *ngIf="condition" />
+```
+
+<br>
+
+---
+
+<br>
+
+#### Default Config
+
+```json
+{
+  "rules": {
+    "@angular-eslint/template/prefer-self-closing-tags": [
+      "error"
+    ]
+  }
+}
+```
+
+<br>
+
+#### ✅ Valid Code
+
+```html
 <slot></slot><math></math><rb></rb><svg></svg><template></template>
 ```
 
@@ -479,6 +506,84 @@ The rule does not have any configuration options.
 
 ```html
 <div></div>
+```
+
+<br>
+
+---
+
+<br>
+
+#### Default Config
+
+```json
+{
+  "rules": {
+    "@angular-eslint/template/prefer-self-closing-tags": [
+      "error"
+    ]
+  }
+}
+```
+
+<br>
+
+#### ✅ Valid Code
+
+```html
+<div *ngIf="condition"></div>
+```
+
+<br>
+
+---
+
+<br>
+
+#### Default Config
+
+```json
+{
+  "rules": {
+    "@angular-eslint/template/prefer-self-closing-tags": [
+      "error"
+    ]
+  }
+}
+```
+
+<br>
+
+#### ✅ Valid Code
+
+```html
+<th scope="col"></th>
+```
+
+<br>
+
+---
+
+<br>
+
+#### Default Config
+
+```json
+{
+  "rules": {
+    "@angular-eslint/template/prefer-self-closing-tags": [
+      "error"
+    ]
+  }
+}
+```
+
+<br>
+
+#### ✅ Valid Code
+
+```html
+<th *ngIf="condition" scope="col"></th>
 ```
 
 <br>

--- a/packages/eslint-plugin-template/tests/rules/prefer-self-closing-tags/cases.ts
+++ b/packages/eslint-plugin-template/tests/rules/prefer-self-closing-tags/cases.ts
@@ -15,14 +15,19 @@ export const valid: readonly (string | ValidTestCase<Options>)[] = [
   '<my-component />',
   `
     <my-component
+      *ngIf="condition"
       type="text"
       [name]="foo"
       [items]="items" />
   `,
   '<img />',
+  '<img src="foo" *ngIf="condition" />',
   // These elements cannot be self-closing
   '<slot></slot><math></math><rb></rb><svg></svg><template></template>',
   '<div></div>',
+  '<div *ngIf="condition"></div>',
+  '<th scope="col"></th>',
+  '<th *ngIf="condition" scope="col"></th>',
   '<ng-template/>',
   '<ng-template>Content</ng-template>',
   '<ng-content/>',
@@ -63,12 +68,12 @@ export const invalid: readonly InvalidTestCase<MessageIds, Options>[] = [
     description:
       'it should fail if an element with attributes has a closing tag but no content',
     annotatedSource: `
-      <my-component type="text" [name]="foo"></my-component>
-                                             ~~~~~~~~~~~~~~~
+      <my-component *ngIf="condition" type="text" [name]="foo"></my-component>
+                                                               ~~~~~~~~~~~~~~~
     `,
     annotatedOutput: `
-      <my-component type="text" [name]="foo" />
-                                             
+      <my-component *ngIf="condition" type="text" [name]="foo" />
+                                                               
     `,
     messageId,
   }),


### PR DESCRIPTION
Fixes #2280

Regression from https://github.com/angular-eslint/angular-eslint/pull/2256