### PR TITLE
fix(eslint-plugin-template): [attributes-order] order i18n attributes

### DIFF
--- a/packages/eslint-plugin-template/docs/rules/attributes-order.md
+++ b/packages/eslint-plugin-template/docs/rules/attributes-order.md
@@ -758,6 +758,141 @@ interface Options {
      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 ```
 
+<br>
+
+---
+
+<br>
+
+#### Default Config
+
+```json
+{
+  "rules": {
+    "@angular-eslint/template/attributes-order": [
+      "error"
+    ]
+  }
+}
+```
+
+<br>
+
+#### ❌ Invalid Code
+
+```html
+<div i18n-alpha="a1" beta="b" alpha="a" i18n-beta="b1"></div>
+     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+```
+
+<br>
+
+---
+
+<br>
+
+#### Default Config
+
+```json
+{
+  "rules": {
+    "@angular-eslint/template/attributes-order": [
+      "error"
+    ]
+  }
+}
+```
+
+<br>
+
+#### ❌ Invalid Code
+
+```html
+<div i18n="i" beta="b" alpha="a" pi="p">x</div>
+     ~~~~~~~~~~~~~~~~~~~~~~~~~~~
+```
+
+<br>
+
+---
+
+<br>
+
+#### Default Config
+
+```json
+{
+  "rules": {
+    "@angular-eslint/template/attributes-order": [
+      "error"
+    ]
+  }
+}
+```
+
+<br>
+
+#### ❌ Invalid Code
+
+```html
+<div #alpha *ngIf="true" (epsilon)="e" beta="b" [gamma]="'g'" i18n-beta="b18" [(delta)]="d" pi="p"></div>
+     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+```
+
+<br>
+
+---
+
+<br>
+
+#### Default Config
+
+```json
+{
+  "rules": {
+    "@angular-eslint/template/attributes-order": [
+      "error"
+    ]
+  }
+}
+```
+
+<br>
+
+#### ❌ Invalid Code
+
+```html
+<div [beta]="'b'" alpha="a" [gamma]="g" i18n-alpha="a18" i18n-beta="b18"></div>
+     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+```
+
+<br>
+
+---
+
+<br>
+
+#### Default Config
+
+```json
+{
+  "rules": {
+    "@angular-eslint/template/attributes-order": [
+      "error"
+    ]
+  }
+}
+```
+
+<br>
+
+#### ❌ Invalid Code
+
+```html
+<ng-template i18n="@@a:b" let-foo #template>The value is {{ foo }}.</ng-template>
+             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+```
+
 </details>
 
 <br>
@@ -996,7 +1131,59 @@ interface Options {
 #### ✅ Valid Code
 
 ```html
+<ng-template #Template i18n="@@test"><div>a</div></ng-template>
+```
+
+<br>
+
+---
+
+<br>
+
+#### Default Config
+
+```json
+{
+  "rules": {
+    "@angular-eslint/template/attributes-order": [
+      "error"
+    ]
+  }
+}
+```
+
+<br>
+
+#### ✅ Valid Code
+
+```html
 <ng-template [ngIf]="condition" [ngIfThen]="If" [ngIfElse]="Else"><div></div></ng-template>
+```
+
+<br>
+
+---
+
+<br>
+
+#### Default Config
+
+```json
+{
+  "rules": {
+    "@angular-eslint/template/attributes-order": [
+      "error"
+    ]
+  }
+}
+```
+
+<br>
+
+#### ✅ Valid Code
+
+```html
+<ng-template i18n="@@test" [ngIf]="condition" [ngIfThen]="If" [ngIfElse]="Else"><div></div></ng-template>
 ```
 
 <br>
@@ -1048,7 +1235,137 @@ interface Options {
 #### ✅ Valid Code
 
 ```html
-<div i18n test1="test1" i18n-test1="@@TEST1" test2="test2" i18n-test2="@@TEST2"></div>
+<ng-template #Template let-value i18n="@@test">c</ng-template>
+```
+
+<br>
+
+---
+
+<br>
+
+#### Default Config
+
+```json
+{
+  "rules": {
+    "@angular-eslint/template/attributes-order": [
+      "error"
+    ]
+  }
+}
+```
+
+<br>
+
+#### ✅ Valid Code
+
+```html
+<div test1="test1" test2="test2"></div>
+```
+
+<br>
+
+---
+
+<br>
+
+#### Default Config
+
+```json
+{
+  "rules": {
+    "@angular-eslint/template/attributes-order": [
+      "error"
+    ]
+  }
+}
+```
+
+<br>
+
+#### ✅ Valid Code
+
+```html
+<div i18n="@@test" test1="test1" test2="test2"></div>
+```
+
+<br>
+
+---
+
+<br>
+
+#### Default Config
+
+```json
+{
+  "rules": {
+    "@angular-eslint/template/attributes-order": [
+      "error"
+    ]
+  }
+}
+```
+
+<br>
+
+#### ✅ Valid Code
+
+```html
+<div i18n="@@test" test1="test1" i18n-test1="@@TEST1" test2="test2" i18n-test2="@@TEST2"></div>
+```
+
+<br>
+
+---
+
+<br>
+
+#### Default Config
+
+```json
+{
+  "rules": {
+    "@angular-eslint/template/attributes-order": [
+      "error"
+    ]
+  }
+}
+```
+
+<br>
+
+#### ✅ Valid Code
+
+```html
+<div test1="test1" i18n-test1="@@TEST1" test2="test2" i18n-test2="@@TEST2"></div>
+```
+
+<br>
+
+---
+
+<br>
+
+#### Default Config
+
+```json
+{
+  "rules": {
+    "@angular-eslint/template/attributes-order": [
+      "error"
+    ]
+  }
+}
+```
+
+<br>
+
+#### ✅ Valid Code
+
+```html
+<div beta="" [alpha]="" i18n-alpha="a" [gamma]="" i18n-gamma="g"></div>
 ```
 
 <br>
@@ -1075,6 +1392,66 @@ interface Options {
 
 ```html
 <svg><ng-template #Template let-value><line x1="1" x2="2" y1="3" y2="4"></line></ng-template></svg>
+```
+
+<br>
+
+---
+
+<br>
+
+#### Custom Config
+
+```json
+{
+  "rules": {
+    "@angular-eslint/template/attributes-order": [
+      "error",
+      {
+        "alphabetical": true,
+        "order": []
+      }
+    ]
+  }
+}
+```
+
+<br>
+
+#### ✅ Valid Code
+
+```html
+<div alpha="a" beta="b" gamma="g"></div>
+```
+
+<br>
+
+---
+
+<br>
+
+#### Custom Config
+
+```json
+{
+  "rules": {
+    "@angular-eslint/template/attributes-order": [
+      "error",
+      {
+        "alphabetical": true,
+        "order": []
+      }
+    ]
+  }
+}
+```
+
+<br>
+
+#### ✅ Valid Code
+
+```html
+<div alpha="a" i18n-alpha="a18n" beta="b" i18n-beta="b18n" gamma="g" i18n-gamma="g18n"></div>
 ```
 
 </details>

--- a/packages/eslint-plugin-template/tests/rules/attributes-order/cases.ts
+++ b/packages/eslint-plugin-template/tests/rules/attributes-order/cases.ts
@@ -20,10 +20,49 @@ export const valid: readonly (string | ValidTestCase<Options>)[] = [
   '<input [(ngModel)]="model" (ngModelChange)="onChange($event)">',
   '<ng-template></ng-template>',
   '<ng-template #Template><div></div></ng-template>',
+  '<ng-template #Template i18n="@@test"><div>a</div></ng-template>',
   '<ng-template [ngIf]="condition" [ngIfThen]="If" [ngIfElse]="Else"><div></div></ng-template>',
+  '<ng-template i18n="@@test" [ngIf]="condition" [ngIfThen]="If" [ngIfElse]="Else"><div></div></ng-template>',
   '<ng-template #Template let-value><div></div></ng-template>',
-  '<div i18n test1="test1" i18n-test1="@@TEST1" test2="test2" i18n-test2="@@TEST2"></div>',
+  '<ng-template #Template let-value i18n="@@test">c</ng-template>',
+  '<div test1="test1" test2="test2"></div>',
+  '<div i18n="@@test" test1="test1" test2="test2"></div>',
+  '<div i18n="@@test" test1="test1" i18n-test1="@@TEST1" test2="test2" i18n-test2="@@TEST2"></div>',
+  '<div test1="test1" i18n-test1="@@TEST1" test2="test2" i18n-test2="@@TEST2"></div>',
+  '<div beta="" [alpha]="" i18n-alpha="a" [gamma]="" i18n-gamma="g"></div>',
   '<svg><ng-template #Template let-value><line x1="1" x2="2" y1="3" y2="4"></line></ng-template></svg>',
+  {
+    code: '<div alpha="a" beta="b" gamma="g"></div>',
+    options: [
+      {
+        alphabetical: true,
+        order: [
+          OrderType.StructuralDirective,
+          OrderType.TemplateReferenceVariable,
+          OrderType.AttributeBinding,
+          OrderType.InputBinding,
+          OrderType.TwoWayBinding,
+          OrderType.OutputBinding,
+        ],
+      },
+    ],
+  },
+  {
+    code: '<div alpha="a" i18n-alpha="a18n" beta="b" i18n-beta="b18n" gamma="g" i18n-gamma="g18n"></div>',
+    options: [
+      {
+        alphabetical: true,
+        order: [
+          OrderType.StructuralDirective,
+          OrderType.TemplateReferenceVariable,
+          OrderType.AttributeBinding,
+          OrderType.InputBinding,
+          OrderType.TwoWayBinding,
+          OrderType.OutputBinding,
+        ],
+      },
+    ],
+  },
 ];
 
 export const invalid: readonly InvalidTestCase<MessageIds, Options>[] = [
@@ -457,7 +496,6 @@ export const invalid: readonly InvalidTestCase<MessageIds, Options>[] = [
            
     `,
   }),
-
   convertAnnotatedSourceToFailureCase({
     messageId,
     description:
@@ -476,7 +514,6 @@ export const invalid: readonly InvalidTestCase<MessageIds, Options>[] = [
            
     `,
   }),
-
   convertAnnotatedSourceToFailureCase({
     messageId,
     description:
@@ -492,6 +529,97 @@ export const invalid: readonly InvalidTestCase<MessageIds, Options>[] = [
     annotatedOutput: `
       <div *structuralDirective class="abc"></div>
            
+    `,
+  }),
+  convertAnnotatedSourceToFailureCase({
+    messageId,
+    description:
+      'should order i18n attributes for other attributes after their corresponding attribute',
+    annotatedSource: `
+      <div i18n-alpha="a1" beta="b" alpha="a" i18n-beta="b1"></div>
+           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    `,
+    options: [{ alphabetical: true }] as Options,
+    data: {
+      expected: '`alpha`, `i18n-alpha`, `beta`',
+      actual: '`i18n-alpha`, `beta`, `alpha`',
+    },
+    annotatedOutput: `
+      <div alpha="a" i18n-alpha="a1" beta="b" i18n-beta="b1"></div>
+           
+    `,
+  }),
+  convertAnnotatedSourceToFailureCase({
+    messageId,
+    description:
+      'should order i18n attribute for element alphabetically with other attributes',
+    annotatedSource: `
+      <div i18n="i" beta="b" alpha="a" pi="p">x</div>
+           ~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    `,
+    options: [{ alphabetical: true }] as Options,
+    data: {
+      expected: '`alpha`, `beta`, `i18n`',
+      actual: '`i18n`, `beta`, `alpha`',
+    },
+    annotatedOutput: `
+      <div alpha="a" beta="b" i18n="i" pi="p">x</div>
+           ~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    `,
+  }),
+  convertAnnotatedSourceToFailureCase({
+    messageId,
+    description:
+      'should order i18n attributes along with all other types of attributes',
+    annotatedSource: `
+      <div #alpha *ngIf="true" (epsilon)="e" beta="b" [gamma]="'g'" i18n-beta="b18" [(delta)]="d" pi="p"></div>
+           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    `,
+    options: [{ alphabetical: true }] as Options,
+    data: {
+      expected:
+        '`*ngIf`, `#alpha`, `beta`, `i18n-beta`, `pi`, `[gamma]`, `[(delta)]`, `(epsilon)`',
+      actual:
+        '`#alpha`, `*ngIf`, `(epsilon)`, `beta`, `[gamma]`, `i18n-beta`, `[(delta)]`, `pi`',
+    },
+    annotatedOutput: `
+      <div *ngIf="true" #alpha beta="b" i18n-beta="b18" pi="p" [gamma]="'g'" [(delta)]="d" (epsilon)="e"></div>
+           
+    `,
+  }),
+  convertAnnotatedSourceToFailureCase({
+    messageId,
+    description:
+      'should order i18n attribute for input after the corresponding input',
+    annotatedSource: `
+      <div [beta]="'b'" alpha="a" [gamma]="g" i18n-alpha="a18" i18n-beta="b18"></div>
+           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    `,
+    options: [{ alphabetical: true }] as Options,
+    data: {
+      expected: '`alpha`, `i18n-alpha`, `[beta]`, `i18n-beta`, `[gamma]`',
+      actual: '`[beta]`, `alpha`, `[gamma]`, `i18n-alpha`, `i18n-beta`',
+    },
+    annotatedOutput: `
+      <div alpha="a" i18n-alpha="a18" [beta]="'b'" i18n-beta="b18" [gamma]="g"></div>
+           
+    `,
+  }),
+  convertAnnotatedSourceToFailureCase({
+    messageId,
+    description: 'should order i18n in template correctly',
+    annotatedSource: `
+      <ng-template i18n="@@a:b" let-foo #template>The value is {{ foo }}.</ng-template>
+                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    `,
+    options: [{ alphabetical: true }] as Options,
+    data: {
+      expected: '`#template`, `i18n`, `let-foo`',
+      actual: '`i18n`, `let-foo`, `#template`',
+    },
+    annotatedOutput: `
+      <ng-template #template i18n="@@a:b" let-foo>The value is {{ foo }}.</ng-template>
+                   
     `,
   }),
 ];


### PR DESCRIPTION
Fixes #1519 

i18n attributes are not exposed in the template AST. Instead, the element or attribute that the i18n attribute is associated with has an `i18n` property that stores an `I18nMeta` object, but that object does not define the span of the attribute, so it cannot be used to determine whether the attribute is in the correct order.

This PR changes how attributes are sourced when there is i18n data. If the element or any attribute or input has i18n metadata, then instead of getting the attributes from the template AST, Angular's `HtmlParser` is used to parse the element to get the raw attributes before they were manipulated into the template AST.

This technique is only used when i18n metadata exists to avoid re-parsing the attributes when they are all present in the template AST. Because the HTML parser just parses them as attributes, we need to classify them manually. This is done by looking at what the attribute starts with, and in some cases, what it ends with. For example, if it starts with `*` then it's a structural directive.

One difference between the attributes from the HTML parser and the AST is that structural directives from the AST don't include the leading `*` in their span. There were a few different places in the rule that accounted for this. I've refactored that logic into a single function so that the logic (which now needs to account for the attribute coming from the HTML parser) is all in one place.