### PR TITLE
fix(eslint-plugin-template): [attributes-order] treat inputs without square brackets as attributes

### DIFF
--- a/packages/eslint-plugin-template/docs/rules/attributes-order.md
+++ b/packages/eslint-plugin-template/docs/rules/attributes-order.md
@@ -812,13 +812,16 @@ interface Options {
 
 <br>
 
-#### Default Config
+#### Custom Config
 
 ```json
 {
   "rules": {
     "@angular-eslint/template/attributes-order": [
-      "error"
+      "error",
+      {
+        "alphabetical": true
+      }
     ]
   }
 }
@@ -839,13 +842,16 @@ interface Options {
 
 <br>
 
-#### Default Config
+#### Custom Config
 
 ```json
 {
   "rules": {
     "@angular-eslint/template/attributes-order": [
-      "error"
+      "error",
+      {
+        "alphabetical": true
+      }
     ]
   }
 }
@@ -866,13 +872,16 @@ interface Options {
 
 <br>
 
-#### Default Config
+#### Custom Config
 
 ```json
 {
   "rules": {
     "@angular-eslint/template/attributes-order": [
-      "error"
+      "error",
+      {
+        "alphabetical": true
+      }
     ]
   }
 }
@@ -893,13 +902,16 @@ interface Options {
 
 <br>
 
-#### Default Config
+#### Custom Config
 
 ```json
 {
   "rules": {
     "@angular-eslint/template/attributes-order": [
-      "error"
+      "error",
+      {
+        "alphabetical": true
+      }
     ]
   }
 }
@@ -920,13 +932,16 @@ interface Options {
 
 <br>
 
-#### Default Config
+#### Custom Config
 
 ```json
 {
   "rules": {
     "@angular-eslint/template/attributes-order": [
-      "error"
+      "error",
+      {
+        "alphabetical": true
+      }
     ]
   }
 }
@@ -939,6 +954,44 @@ interface Options {
 ```html
 <ng-template i18n="@@a:b" let-foo #template>The value is {{ foo }}.</ng-template>
              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+```
+
+<br>
+
+---
+
+<br>
+
+#### Custom Config
+
+```json
+{
+  "rules": {
+    "@angular-eslint/template/attributes-order": [
+      "error",
+      {
+        "alphabetical": true,
+        "order": [
+          "ATTRIBUTE_BINDING",
+          "OUTPUT_BINDING",
+          "INPUT_BINDING",
+          "STRUCTURAL_DIRECTIVE",
+          "TEMPLATE_REFERENCE",
+          "TWO_WAY_BINDING"
+        ]
+      }
+    ]
+  }
+}
+```
+
+<br>
+
+#### ❌ Invalid Code
+
+```html
+<div alpha="a" (gamma)="g()" beta="{{ b }}" [delta]="d"></div>
+               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 ```
 
 </details>
@@ -1457,7 +1510,14 @@ interface Options {
       "error",
       {
         "alphabetical": true,
-        "order": []
+        "order": [
+          "STRUCTURAL_DIRECTIVE",
+          "TEMPLATE_REFERENCE",
+          "ATTRIBUTE_BINDING",
+          "INPUT_BINDING",
+          "TWO_WAY_BINDING",
+          "OUTPUT_BINDING"
+        ]
       }
     ]
   }
@@ -1487,7 +1547,14 @@ interface Options {
       "error",
       {
         "alphabetical": true,
-        "order": []
+        "order": [
+          "STRUCTURAL_DIRECTIVE",
+          "TEMPLATE_REFERENCE",
+          "ATTRIBUTE_BINDING",
+          "INPUT_BINDING",
+          "TWO_WAY_BINDING",
+          "OUTPUT_BINDING"
+        ]
       }
     ]
   }
@@ -1500,6 +1567,43 @@ interface Options {
 
 ```html
 <div alpha="a" i18n-alpha="a18n" beta="b" i18n-beta="b18n" gamma="g" i18n-gamma="g18n"></div>
+```
+
+<br>
+
+---
+
+<br>
+
+#### Custom Config
+
+```json
+{
+  "rules": {
+    "@angular-eslint/template/attributes-order": [
+      "error",
+      {
+        "alphabetical": true,
+        "order": [
+          "ATTRIBUTE_BINDING",
+          "OUTPUT_BINDING",
+          "INPUT_BINDING",
+          "STRUCTURAL_DIRECTIVE",
+          "TEMPLATE_REFERENCE",
+          "TWO_WAY_BINDING"
+        ]
+      }
+    ]
+  }
+}
+```
+
+<br>
+
+#### ✅ Valid Code
+
+```html
+<div alpha="a" beta="{{ b }}" (gamma)="g()" [delta]="d"></div>
 ```
 
 </details>

--- a/packages/eslint-plugin-template/tests/rules/attributes-order/cases.ts
+++ b/packages/eslint-plugin-template/tests/rules/attributes-order/cases.ts
@@ -63,6 +63,22 @@ export const valid: readonly (string | ValidTestCase<Options>)[] = [
       },
     ],
   },
+  {
+    code: '<div alpha="a" beta="{{ b }}" (gamma)="g()" [delta]="d"></div>',
+    options: [
+      {
+        alphabetical: true,
+        order: [
+          OrderType.AttributeBinding,
+          OrderType.OutputBinding,
+          OrderType.InputBinding,
+          OrderType.StructuralDirective,
+          OrderType.TemplateReferenceVariable,
+          OrderType.TwoWayBinding,
+        ],
+      },
+    ],
+  },
 ];
 
 export const invalid: readonly InvalidTestCase<MessageIds, Options>[] = [
@@ -620,6 +636,36 @@ export const invalid: readonly InvalidTestCase<MessageIds, Options>[] = [
     annotatedOutput: `
       <ng-template #template i18n="@@a:b" let-foo>The value is {{ foo }}.</ng-template>
                    
+    `,
+  }),
+  convertAnnotatedSourceToFailureCase({
+    messageId,
+    description:
+      'should treat attribute with dynamic value as an attribute binding',
+    annotatedSource: `
+      <div alpha="a" (gamma)="g()" beta="{{ b }}" [delta]="d"></div>
+                     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    `,
+    options: [
+      {
+        alphabetical: true,
+        order: [
+          OrderType.AttributeBinding,
+          OrderType.OutputBinding,
+          OrderType.InputBinding,
+          OrderType.StructuralDirective,
+          OrderType.TemplateReferenceVariable,
+          OrderType.TwoWayBinding,
+        ],
+      },
+    ],
+    data: {
+      expected: '`beta`, `(gamma)`',
+      actual: '`(gamma)`, `beta`',
+    },
+    annotatedOutput: `
+      <div alpha="a" beta="{{ b }}" (gamma)="g()" [delta]="d"></div>
+                     
     `,
   }),
 ];


### PR DESCRIPTION
Fixes #1914 

Given an element with two attributes, where one sets a static valid and the other uses interpolation, Angular classifies the first attribute as an "attribute" and the second attribute as an "input". 
```html
<div a="b" c="{{ d }}"></div>
```
See here for an example of the AST (the template parser it uses is quite a few versions behind, but the same behavior exists with v19):
https://astexplorer.net/#/gist/cd84edb20d811a8896c9f28f6f5031d9/1567654ea0ba120f0c3844e9786387bb3c921d17

This pull request changes the `attributes-order` rule such that an input will only be classified as an input if it's surrounded with square brackets.

> [!NOTE]
> ~~This PR is piggy-backing off #2307 since that PR made large changes to the `attributes-order` rule. Once/if that is merged, then I'll rebase this PR to remove the extra commits.~~
>
> ~~The specific commit that is relevant to this PR is 6fc0cd5106dd5aecb4f89be891526614feb37b71.~~