### PR TITLE
feat(eslint-plugin-template): [button-has-type] add option to ignore missing type

### DIFF
--- a/packages/eslint-plugin-template/docs/rules/button-has-type.md
+++ b/packages/eslint-plugin-template/docs/rules/button-has-type.md
@@ -23,7 +23,17 @@ Ensures that a button has a valid type specified
 
 ## Rule Options
 
-The rule does not have any configuration options.
+The rule accepts an options object with the following properties:
+
+```ts
+interface Options {
+  /**
+   * Default: `[]`
+   */
+  ignoreWithDirectives?: string[];
+}
+
+```
 
 <br>
 
@@ -138,6 +148,71 @@ The rule does not have any configuration options.
 ```html
 <button [attr.type]="'whatever'"></button>
         ~~~~~~~~~~~~~~~~~~~~~~~~
+```
+
+<br>
+
+---
+
+<br>
+
+#### Custom Config
+
+```json
+{
+  "rules": {
+    "@angular-eslint/template/button-has-type": [
+      "error",
+      {
+        "ignoreWithDirectives": [
+          "myButton",
+          "uiButton"
+        ]
+      }
+    ]
+  }
+}
+```
+
+<br>
+
+#### ❌ Invalid Code
+
+```html
+<button myDirective></button>
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+```
+
+<br>
+
+---
+
+<br>
+
+#### Custom Config
+
+```json
+{
+  "rules": {
+    "@angular-eslint/template/button-has-type": [
+      "error",
+      {
+        "ignoreWithDirectives": [
+          "myButton"
+        ]
+      }
+    ]
+  }
+}
+```
+
+<br>
+
+#### ❌ Invalid Code
+
+```html
+<button myButton type="whatever"></button>
+                 ~~~~~~~~~~~~~~~
 ```
 
 </details>
@@ -405,6 +480,68 @@ The rule does not have any configuration options.
 
 ```html
 <button [disabled]="true" [attr.type]="'button'"></button>
+```
+
+<br>
+
+---
+
+<br>
+
+#### Custom Config
+
+```json
+{
+  "rules": {
+    "@angular-eslint/template/button-has-type": [
+      "error",
+      {
+        "ignoreWithDirectives": [
+          "myButton"
+        ]
+      }
+    ]
+  }
+}
+```
+
+<br>
+
+#### ✅ Valid Code
+
+```html
+<button myButton></button>
+```
+
+<br>
+
+---
+
+<br>
+
+#### Custom Config
+
+```json
+{
+  "rules": {
+    "@angular-eslint/template/button-has-type": [
+      "error",
+      {
+        "ignoreWithDirectives": [
+          "myButton"
+        ]
+      }
+    ]
+  }
+}
+```
+
+<br>
+
+#### ✅ Valid Code
+
+```html
+<button [myButton]></button>
 ```
 
 </details>

--- a/packages/eslint-plugin-template/tests/rules/button-has-type/cases.ts
+++ b/packages/eslint-plugin-template/tests/rules/button-has-type/cases.ts
@@ -20,6 +20,14 @@ export const valid: readonly (string | ValidTestCase<Options>)[] = [
   `<button (click)="onClick()" type="button"></button>`,
   `<button [class.primary]="true" [attr.type]="'submit'"></button>`,
   `<button [disabled]="true" [attr.type]="'button'"></button>`,
+  {
+    code: `<button myButton></button>`,
+    options: [{ ignoreWithDirectives: ['myButton'] }],
+  },
+  {
+    code: `<button [myButton]></button>`,
+    options: [{ ignoreWithDirectives: ['myButton'] }],
+  },
 ];
 
 export const invalid: readonly InvalidTestCase<MessageIds, Options>[] = [
@@ -56,6 +64,29 @@ export const invalid: readonly InvalidTestCase<MessageIds, Options>[] = [
       <button [attr.type]="'whatever'"></button>
               ~~~~~~~~~~~~~~~~~~~~~~~~
     `,
+    messageId: invalidType,
+    data: {
+      [INVALID_TYPE_DATA_KEY]: 'whatever',
+    },
+  }),
+  convertAnnotatedSourceToFailureCase({
+    description:
+      'should fail if button has no type attribute, and ignoreWithDirectives option specifies directives, but none of the directives are present',
+    annotatedSource: `
+      <button myDirective></button>
+      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    `,
+    options: [{ ignoreWithDirectives: ['myButton', 'uiButton'] }],
+    messageId: missingType,
+  }),
+  convertAnnotatedSourceToFailureCase({
+    description:
+      'should fail if button has invalid attribute type, and ignoreWithDirectives option specifies directives and element has one of them',
+    annotatedSource: `
+      <button myButton type="whatever"></button>
+                       ~~~~~~~~~~~~~~~
+    `,
+    options: [{ ignoreWithDirectives: ['myButton'] }],
     messageId: invalidType,
     data: {
       [INVALID_TYPE_DATA_KEY]: 'whatever',


### PR DESCRIPTION
Fixes #2193 

Adds an `ignoreWithDirectives` option that specifies the names of directives (or attributes) that, when present on the `button` element, will cause the `button-has-type` rule to _not_ report a problem.

I went with "ignore" rather than "allow", but I'm happy to change it to something else if needed.

I've still kept the "invalidType" check, so even if the "missingType" check is skipped, if you specify a `type` attribute with an invalid value, the rule will still report a problem.