### PR TITLE
fix(eslint-plugin-template): correct column adjustment for inline template message locations

### DIFF
--- a/packages/eslint-plugin-template/src/processors.ts
+++ b/packages/eslint-plugin-template/src/processors.ts
@@ -302,10 +302,23 @@ export function postprocessComponentFile(
         }
 
         return messagesFromInlineTemplateHTML.map((message) => {
-          message.line = message.line + rangeData.lineAndCharacter.start.line;
+          // The first line of the inline template starts at the column after
+          // the opening quote in the TypeScript file, so we need to adjust
+          // the message's column by that amount when the message starts on
+          // the first line. The character we recorded was the quote's column,
+          // so add one to get the column where the actual string starts.
+          if (message.line === 1) {
+            message.column += rangeData.lineAndCharacter.start.character + 1;
+          }
 
-          message.endLine =
-            message.endLine + rangeData.lineAndCharacter.start.line;
+          // The same thing applies to the end column
+          // if it also ends on the first line.
+          if (message.endLine === 1) {
+            message.endColumn += rangeData.lineAndCharacter.start.character + 1;
+          }
+
+          message.line += rangeData.lineAndCharacter.start.line;
+          message.endLine += rangeData.lineAndCharacter.start.line;
 
           if (message.fix) {
             const startOffset = rangeData.range[0] + 1;


### PR DESCRIPTION
Fixes #2356 

The problem was that the `column` and `endColumn` were not being adjusted when transforming the message locations from being within the inline template string to being within the full code file that the inline template was in. Not adjusting the columns is the correct thing to do for anything _but_ the first line, because the second and subsequent lines always start at column 1, while the first line starts wherever the string starts on that line, plus one character for the opening quote.