### PR TITLE
fix(eslint-plugin-template): [label-has-associated-control] labelComponents should override default label inputs

### DIFF
--- a/packages/eslint-plugin-template/docs/rules/label-has-associated-control.md
+++ b/packages/eslint-plugin-template/docs/rules/label-has-associated-control.md
@@ -203,6 +203,48 @@ interface Options {
       "error",
       {
         "controlComponents": [
+          "my-custom-control"
+        ],
+        "labelComponents": [
+          {
+            "inputs": [
+              "for",
+              "htmlFor",
+              "myCustomFor"
+            ],
+            "selector": "label"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+<br>
+
+#### ✅ Valid Code
+
+```html
+<label [myCustomFor]="customId">Label</label>
+<my-custom-control [id]="customId"></my-custom-control>
+```
+
+<br>
+
+---
+
+<br>
+
+#### Custom Config
+
+```json
+{
+  "rules": {
+    "@angular-eslint/template/label-has-associated-control": [
+      "error",
+      {
+        "controlComponents": [
           "app-input"
         ],
         "labelComponents": [

--- a/packages/eslint-plugin-template/src/rules/label-has-associated-control.ts
+++ b/packages/eslint-plugin-template/src/rules/label-has-associated-control.ts
@@ -87,10 +87,16 @@ export default createESLintRule<Options, MessageIds>({
       ...DEFAULT_CONTROL_COMPONENTS,
       ...(controlComponents ?? []),
     ]);
-    const allLabelComponents = [
-      ...DEFAULT_LABEL_COMPONENTS,
-      ...(labelComponents ?? []),
-    ] as const;
+
+    const labelMap = new Map(
+      DEFAULT_LABEL_COMPONENTS.map(comp => [comp.selector, comp])
+    );    
+    // Add custom components, overriding defaults with same selector
+    if (labelComponents) {
+      labelComponents.forEach(comp => labelMap.set(comp.selector, comp));
+    }
+    
+    const allLabelComponents = Array.from(labelMap.values());
     let inputItems: TmplAstElement[] = [];
     let labelItems: TmplAstElement[] = [];
 

--- a/packages/eslint-plugin-template/src/rules/label-has-associated-control.ts
+++ b/packages/eslint-plugin-template/src/rules/label-has-associated-control.ts
@@ -89,13 +89,13 @@ export default createESLintRule<Options, MessageIds>({
     ]);
 
     const labelMap = new Map(
-      DEFAULT_LABEL_COMPONENTS.map(comp => [comp.selector, comp])
-    );    
+      DEFAULT_LABEL_COMPONENTS.map((comp) => [comp.selector, comp]),
+    );
     // Add custom components, overriding defaults with same selector
     if (labelComponents) {
-      labelComponents.forEach(comp => labelMap.set(comp.selector, comp));
+      labelComponents.forEach((comp) => labelMap.set(comp.selector, comp));
     }
-    
+
     const allLabelComponents = Array.from(labelMap.values());
     let inputItems: TmplAstElement[] = [];
     let labelItems: TmplAstElement[] = [];

--- a/packages/eslint-plugin-template/tests/rules/label-has-associated-control/cases.ts
+++ b/packages/eslint-plugin-template/tests/rules/label-has-associated-control/cases.ts
@@ -23,6 +23,18 @@ export const valid: readonly (string | ValidTestCase<Options>)[] = [
     `,
   {
     code: `
+      <label [myCustomFor]="customId">Label</label>
+      <my-custom-control [id]="customId"></my-custom-control>
+    `,
+    options: [
+      {
+        controlComponents: ['my-custom-control'],
+        labelComponents: [{ inputs: ['for', 'htmlFor', 'myCustomFor'], selector: 'label' }],
+      },
+    ],
+  },
+  {
+    code: `
       <app-label id="name"></app-label>
       <app-label id="{{name}}"></app-label>
       <app-label [id]="name"></app-label>

--- a/packages/eslint-plugin-template/tests/rules/label-has-associated-control/cases.ts
+++ b/packages/eslint-plugin-template/tests/rules/label-has-associated-control/cases.ts
@@ -29,7 +29,9 @@ export const valid: readonly (string | ValidTestCase<Options>)[] = [
     options: [
       {
         controlComponents: ['my-custom-control'],
-        labelComponents: [{ inputs: ['for', 'htmlFor', 'myCustomFor'], selector: 'label' }],
+        labelComponents: [
+          { inputs: ['for', 'htmlFor', 'myCustomFor'], selector: 'label' },
+        ],
       },
     ],
   },


### PR DESCRIPTION
Example PR to address #2359 