### PR TITLE
fix(eslint-plugin-template): remove backticks from inline template with interpolation

### DIFF
--- a/packages/eslint-plugin-template/src/processors.ts
+++ b/packages/eslint-plugin-template/src/processors.ts
@@ -144,7 +144,9 @@ export function preprocessComponentFile(
       }
 
       if (ts.isTemplateExpression(templatePropertyInitializer)) {
-        templateText = templatePropertyInitializer.getText();
+        // The text includes the opening and closing
+        // backtick, so trim the first and last characters.
+        templateText = templatePropertyInitializer.getText().slice(1, -1);
       }
 
       if (ts.isStringLiteral(templatePropertyInitializer)) {
@@ -321,6 +323,9 @@ export function postprocessComponentFile(
           message.endLine += rangeData.lineAndCharacter.start.line;
 
           if (message.fix) {
+            // The range defines the range of the value that initializes
+            // the `template` property, which includes the opening and
+            // closing quotes. Add one to move past the opening quote.
             const startOffset = rangeData.range[0] + 1;
             message.fix.range = [
               startOffset + message.fix.range[0],

--- a/packages/eslint-plugin-template/tests/processors.spec.ts
+++ b/packages/eslint-plugin-template/tests/processors.spec.ts
@@ -140,6 +140,27 @@ describe('extract-inline-html', () => {
           },
         ]);
       });
+
+      it(`should exclude the backticks from the template literal with interpolations`, () => {
+        const input = `
+          @Component({
+            template: \`hello \${name}\`,
+          })
+          export class ExampleComponent {}
+          `;
+        expect(
+          processors['extract-inline-html'].preprocess(
+            input,
+            'test.component.ts',
+          ),
+        ).toEqual([
+          input,
+          {
+            filename: `inline-template-test.component.ts-1.component.html`,
+            text: 'hello ${name}',
+          },
+        ]);
+      });
     });
 
     describe('components with inline templates', () => {


### PR DESCRIPTION
Fixes #2325 

If the inline template contains interpolations, then the template's content was retrieved using `templatePropertyInitializer.getText()`. That included the opening and closing backtick. Because the opening backtick was included in the template, the locations were one character further to the left than they should have been.

The fix was very simple - just remove the opening and closing backtick.