### PR TITLE
fix: set `template-parser` dependency as dependency instead of dev dependency in `eslint-plugin-template`

### DIFF
--- a/packages/eslint-plugin-template/package.json
+++ b/packages/eslint-plugin-template/package.json
@@ -19,12 +19,12 @@
   ],
   "dependencies": {
     "@angular-eslint/bundled-angular-compiler": "workspace:*",
+    "@angular-eslint/template-parser": "workspace:*",
     "@angular-eslint/utils": "workspace:*",
     "aria-query": "5.3.2",
     "axobject-query": "4.1.0"
   },
   "devDependencies": {
-    "@angular-eslint/template-parser": "workspace:*",
     "@angular-eslint/test-utils": "workspace:*",
     "@types/aria-query": "5.0.4"
   },


### PR DESCRIPTION
Based on issue #2347

When installing `eslint-plugin-template` separately, it currently requires manually installing `@angular-eslint/template-parser`. However, according to the `README`:

> [@angular-eslint/eslint-plugin-template](https://github.com/angular-eslint/angular-eslint/blob/main/packages/eslint-plugin-template/README.md) - An ESLint-specific plugin which, when used in conjunction with @angular-eslint/template-parser, allows for Angular template-specific linting rules to run.

Given this dependency relationship, it might make sense to list `template-parser` under `dependencies` instead of `devDependencies`.