### PR TITLE
fix(eslint-plugin-template): [prefer-template-literal] handle parentheses in autofix

### DIFF
--- a/packages/eslint-plugin-template/docs/rules/prefer-template-literal.md
+++ b/packages/eslint-plugin-template/docs/rules/prefer-template-literal.md
@@ -542,6 +542,60 @@ The rule does not have any configuration options.
 #### ❌ Invalid Code
 
 ```html
+{{ 'prefix-' + (condition ? 'true' : 'false') }}
+   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+```
+
+<br>
+
+---
+
+<br>
+
+#### Default Config
+
+```json
+{
+  "rules": {
+    "@angular-eslint/template/prefer-template-literal": [
+      "error"
+    ]
+  }
+}
+```
+
+<br>
+
+#### ❌ Invalid Code
+
+```html
+{{ 'prefix-' + ('value' | pipe) }}
+   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+```
+
+<br>
+
+---
+
+<br>
+
+#### Default Config
+
+```json
+{
+  "rules": {
+    "@angular-eslint/template/prefer-template-literal": [
+      "error"
+    ]
+  }
+}
+```
+
+<br>
+
+#### ❌ Invalid Code
+
+```html
 {{ "prefix-" + 42 }}
    ~~~~~~~~~~~~~~
 ```
@@ -731,6 +785,60 @@ The rule does not have any configuration options.
 #### ❌ Invalid Code
 
 ```html
+{{ 'prefix-' + (condition ? 'true' : 'false') }}
+   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+```
+
+<br>
+
+---
+
+<br>
+
+#### Default Config
+
+```json
+{
+  "rules": {
+    "@angular-eslint/template/prefer-template-literal": [
+      "error"
+    ]
+  }
+}
+```
+
+<br>
+
+#### ❌ Invalid Code
+
+```html
+{{ 'prefix-' + ('value' | pipe) }}
+   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+```
+
+<br>
+
+---
+
+<br>
+
+#### Default Config
+
+```json
+{
+  "rules": {
+    "@angular-eslint/template/prefer-template-literal": [
+      "error"
+    ]
+  }
+}
+```
+
+<br>
+
+#### ❌ Invalid Code
+
+```html
 {{ `prefix-${value}-suffix` + 42 }}
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 ```
@@ -895,6 +1003,60 @@ The rule does not have any configuration options.
 ```html
 {{ `prefix-${value}-suffix` + [42] }}
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+```
+
+<br>
+
+---
+
+<br>
+
+#### Default Config
+
+```json
+{
+  "rules": {
+    "@angular-eslint/template/prefer-template-literal": [
+      "error"
+    ]
+  }
+}
+```
+
+<br>
+
+#### ❌ Invalid Code
+
+```html
+{{ `prefix-${value}-suffix` + (condition ? 'true' : 'false') }}
+   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+```
+
+<br>
+
+---
+
+<br>
+
+#### Default Config
+
+```json
+{
+  "rules": {
+    "@angular-eslint/template/prefer-template-literal": [
+      "error"
+    ]
+  }
+}
+```
+
+<br>
+
+#### ❌ Invalid Code
+
+```html
+{{ `prefix-${value}-suffix` + ('value' | pipe) }}
+   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 ```
 
 <br>
@@ -1136,6 +1298,60 @@ The rule does not have any configuration options.
 #### ❌ Invalid Code
 
 ```html
+{{ (condition ? 'true' : 'false') + '-suffix' }}
+   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+```
+
+<br>
+
+---
+
+<br>
+
+#### Default Config
+
+```json
+{
+  "rules": {
+    "@angular-eslint/template/prefer-template-literal": [
+      "error"
+    ]
+  }
+}
+```
+
+<br>
+
+#### ❌ Invalid Code
+
+```html
+{{ ('value' | pipe) + '-suffix' }}
+   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+```
+
+<br>
+
+---
+
+<br>
+
+#### Default Config
+
+```json
+{
+  "rules": {
+    "@angular-eslint/template/prefer-template-literal": [
+      "error"
+    ]
+  }
+}
+```
+
+<br>
+
+#### ❌ Invalid Code
+
+```html
 {{ 42 + "-suffix" }}
    ~~~~~~~~~~~~~~
 ```
@@ -1352,6 +1568,60 @@ The rule does not have any configuration options.
 #### ❌ Invalid Code
 
 ```html
+{{ (condition ? 'true' : 'false') + "-suffix" }}
+   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+```
+
+<br>
+
+---
+
+<br>
+
+#### Default Config
+
+```json
+{
+  "rules": {
+    "@angular-eslint/template/prefer-template-literal": [
+      "error"
+    ]
+  }
+}
+```
+
+<br>
+
+#### ❌ Invalid Code
+
+```html
+{{ ('value' | pipe) + "-suffix" }}
+   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+```
+
+<br>
+
+---
+
+<br>
+
+#### Default Config
+
+```json
+{
+  "rules": {
+    "@angular-eslint/template/prefer-template-literal": [
+      "error"
+    ]
+  }
+}
+```
+
+<br>
+
+#### ❌ Invalid Code
+
+```html
 {{ 42 + `prefix-${value}-suffix` }}
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 ```
@@ -1516,6 +1786,60 @@ The rule does not have any configuration options.
 ```html
 {{ [42] + `prefix-${value}-suffix` }}
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+```
+
+<br>
+
+---
+
+<br>
+
+#### Default Config
+
+```json
+{
+  "rules": {
+    "@angular-eslint/template/prefer-template-literal": [
+      "error"
+    ]
+  }
+}
+```
+
+<br>
+
+#### ❌ Invalid Code
+
+```html
+{{ (condition ? 'true' : 'false') + `prefix-${value}-suffix` }}
+   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+```
+
+<br>
+
+---
+
+<br>
+
+#### Default Config
+
+```json
+{
+  "rules": {
+    "@angular-eslint/template/prefer-template-literal": [
+      "error"
+    ]
+  }
+}
+```
+
+<br>
+
+#### ❌ Invalid Code
+
+```html
+{{ ('value' | pipe) + `prefix-${value}-suffix` }}
+   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 ```
 
 </details>

--- a/packages/eslint-plugin-template/tests/rules/prefer-template-literal/cases.ts
+++ b/packages/eslint-plugin-template/tests/rules/prefer-template-literal/cases.ts
@@ -266,6 +266,32 @@ export const invalid: readonly InvalidTestCase<MessageIds, Options>[] = [
            
       `,
   }),
+  convertAnnotatedSourceToFailureCase({
+    messageId,
+    description:
+      'should fail concatenation (left: simple quote, right: ternary in parentheses)',
+    annotatedSource: `
+        {{ 'prefix-' + (condition ? 'true' : 'false') }}
+           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      `,
+    annotatedOutput: `
+        {{ \`prefix-\${condition ? 'true' : 'false'}\` }}
+           
+      `,
+  }),
+  convertAnnotatedSourceToFailureCase({
+    messageId,
+    description:
+      'should fail concatenation (left: simple quote, right: pipe in parentheses)',
+    annotatedSource: `
+        {{ 'prefix-' + ('value' | pipe) }}
+           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      `,
+    annotatedOutput: `
+        {{ \`prefix-\${'value' | pipe}\` }}
+           
+      `,
+  }),
 
   // Left : double quote
   convertAnnotatedSourceToFailureCase({
@@ -356,6 +382,32 @@ export const invalid: readonly InvalidTestCase<MessageIds, Options>[] = [
            
       `,
   }),
+  convertAnnotatedSourceToFailureCase({
+    messageId,
+    description:
+      'should fail concatenation (left: double quote, right: ternary in parentheses)',
+    annotatedSource: `
+        {{ 'prefix-' + (condition ? 'true' : 'false') }}
+           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      `,
+    annotatedOutput: `
+        {{ \`prefix-\${condition ? 'true' : 'false'}\` }}
+           
+      `,
+  }),
+  convertAnnotatedSourceToFailureCase({
+    messageId,
+    description:
+      'should fail concatenation (left: double quote, right: pipe in parentheses)',
+    annotatedSource: `
+        {{ 'prefix-' + ('value' | pipe) }}
+           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      `,
+    annotatedOutput: `
+        {{ \`prefix-\${'value' | pipe}\` }}
+           
+      `,
+  }),
 
   // Left : template
   convertAnnotatedSourceToFailureCase({
@@ -440,6 +492,32 @@ export const invalid: readonly InvalidTestCase<MessageIds, Options>[] = [
       `,
     annotatedOutput: `
         {{ \`prefix-\${value}-suffix\${[42]}\` }}
+           
+      `,
+  }),
+  convertAnnotatedSourceToFailureCase({
+    messageId,
+    description:
+      'should fail concatenation (left: template, right: ternary in parentheses)',
+    annotatedSource: `
+        {{ \`prefix-\${value}-suffix\` + (condition ? 'true' : 'false') }}
+           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      `,
+    annotatedOutput: `
+        {{ \`prefix-\${value}-suffix\${condition ? 'true' : 'false'}\` }}
+           
+      `,
+  }),
+  convertAnnotatedSourceToFailureCase({
+    messageId,
+    description:
+      'should fail concatenation (left: template, right: pipe in parentheses)',
+    annotatedSource: `
+        {{ \`prefix-\${value}-suffix\` + ('value' | pipe) }}
+           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      `,
+    annotatedOutput: `
+        {{ \`prefix-\${value}-suffix\${'value' | pipe}\` }}
            
       `,
   }),
@@ -546,6 +624,32 @@ export const invalid: readonly InvalidTestCase<MessageIds, Options>[] = [
            
       `,
   }),
+  convertAnnotatedSourceToFailureCase({
+    messageId,
+    description:
+      'should fail concatenation (left: ternary in parentheses, right: simple quote)',
+    annotatedSource: `
+        {{ (condition ? 'true' : 'false') + '-suffix' }}
+           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      `,
+    annotatedOutput: `
+        {{ \`\${condition ? 'true' : 'false'}-suffix\` }}
+           
+      `,
+  }),
+  convertAnnotatedSourceToFailureCase({
+    messageId,
+    description:
+      'should fail concatenation (left: pipe in parentheses, right: simple quote)',
+    annotatedSource: `
+        {{ ('value' | pipe) + '-suffix' }}
+           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      `,
+    annotatedOutput: `
+        {{ \`\${'value' | pipe}-suffix\` }}
+           
+      `,
+  }),
 
   // Right : double quote
   convertAnnotatedSourceToFailureCase({
@@ -649,6 +753,32 @@ export const invalid: readonly InvalidTestCase<MessageIds, Options>[] = [
            
       `,
   }),
+  convertAnnotatedSourceToFailureCase({
+    messageId,
+    description:
+      'should fail concatenation (left: ternary in parentheses, right: double quote)',
+    annotatedSource: `
+        {{ (condition ? 'true' : 'false') + "-suffix" }}
+           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      `,
+    annotatedOutput: `
+        {{ \`\${condition ? 'true' : 'false'}-suffix\` }}
+           
+      `,
+  }),
+  convertAnnotatedSourceToFailureCase({
+    messageId,
+    description:
+      'should fail concatenation (left: pipe in parentheses, right: double quote)',
+    annotatedSource: `
+        {{ ('value' | pipe) + "-suffix" }}
+           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      `,
+    annotatedOutput: `
+        {{ \`\${'value' | pipe}-suffix\` }}
+           
+      `,
+  }),
 
   // Right : template
   convertAnnotatedSourceToFailureCase({
@@ -733,6 +863,32 @@ export const invalid: readonly InvalidTestCase<MessageIds, Options>[] = [
       `,
     annotatedOutput: `
         {{ \`\${[42]}prefix-\${value}-suffix\` }}
+           
+      `,
+  }),
+  convertAnnotatedSourceToFailureCase({
+    messageId,
+    description:
+      'should fail concatenation (left: ternary in parentheses, right: template)',
+    annotatedSource: `
+        {{ (condition ? 'true' : 'false') + \`prefix-\${value}-suffix\` }}
+           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      `,
+    annotatedOutput: `
+        {{ \`\${condition ? 'true' : 'false'}prefix-\${value}-suffix\` }}
+           
+      `,
+  }),
+  convertAnnotatedSourceToFailureCase({
+    messageId,
+    description:
+      'should fail concatenation (left: pipe in parentheses, right: template)',
+    annotatedSource: `
+        {{ ('value' | pipe) + \`prefix-\${value}-suffix\` }}
+           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      `,
+    annotatedOutput: `
+        {{ \`\${'value' | pipe}prefix-\${value}-suffix\` }}
            
       `,
   }),


### PR DESCRIPTION
## Examples of autofix error cases ##

In some cases (when autofix result is a template), a parenthesis is removed but not both.

`'prefix-' + (condition ? 'true' : 'false')` => `` `prefix-${condition ? 'true' : 'false'}`)``

`('value' | pipe) + "-suffix"` => ``(`${'value' | pipe}-suffix` ``

## Fix ##

If node is surronded by parentheses remove them, with template literal they become useless