### PR TITLE
fix(builder): correct option name in flat config error

### DIFF
--- a/packages/builder/src/utils/eslint-utils.ts
+++ b/packages/builder/src/utils/eslint-utils.ts
@@ -80,7 +80,7 @@ export async function resolveAndInstantiateESLint(
     }
     if (options.reportUnusedDisableDirectives) {
       throw new Error(
-        'For Flat Config, ESLint removed `reportedUnusedDisableDirectives` and so it is not supported as an option. See https://eslint.org/docs/latest/use/configure/configuration-files-new',
+        'For Flat Config, ESLint removed `reportUnusedDisableDirectives` and so it is not supported as an option. See https://eslint.org/docs/latest/use/configure/configuration-files-new',
       );
     }
 


### PR DESCRIPTION
## Summary
- fix the option name typo in builder's flat config error message

## Testing
- `NX_NO_CLOUD=true pnpm nx lint builder --skip-nx-cache`
- `NX_NO_CLOUD=true pnpm nx test builder --skip-nx-cache`
