### PR TITLE
docs: correct prettier configuration example

### DIFF
--- a/docs/CONFIGURING_FLAT_CONFIG.md
+++ b/docs/CONFIGURING_FLAT_CONFIG.md
@@ -192,7 +192,8 @@ module.exports = tseslint.config([
     // we already applied the rootConfig above which has them)
     files: ['**/*.ts'],
     extends: [prettierRecommended], // here we inherit from the recommended setup from eslint-plugin-prettier for TS
-    rules: {
+    rules: {},
+  },
   {
     // Any project level overrides or additional rules for HTML files can go here
     // (we don't need to extend from any angular-eslint configs because


### PR DESCRIPTION
## Summary
- fix code sample in `CONFIGURING_FLAT_CONFIG.md`

## Testing
- `pnpm format-check`
- `pnpm nx sync:check`
- `NX_NO_CLOUD=true pnpm nx run-many -t check-rule-docs`
- `NX_NO_CLOUD=true pnpm nx run-many -t check-rule-lists`
- `NX_NO_CLOUD=true pnpm nx run-many -t check-rule-configs`
