### PR TITLE
fix(eslint-plugin-template): handle new control flow

### DIFF
--- a/packages/eslint-plugin-template/docs/rules/cyclomatic-complexity.md
+++ b/packages/eslint-plugin-template/docs/rules/cyclomatic-complexity.md
@@ -132,6 +132,42 @@ interface Options {
 </div>
 ```
 
+<br>
+
+---
+
+<br>
+
+#### Custom Config
+
+```json
+{
+  "rules": {
+    "@angular-eslint/template/cyclomatic-complexity": [
+      "error",
+      {
+        "maxComplexity": 3
+      }
+    ]
+  }
+}
+```
+
+<br>
+
+#### ❌ Invalid Code
+
+```html
+@if (cond) {
+  @for (item of items; track item.id) {
+    @switch (item) {
+      @case ('a') {}
+      @default {}
+    }
+  }
+}
+```
+
 </details>
 
 <br>
@@ -239,6 +275,103 @@ interface Options {
     </div>
   </div>
 </div>
+```
+
+<br>
+
+---
+
+<br>
+
+#### Custom Config
+
+```json
+{
+  "rules": {
+    "@angular-eslint/template/cyclomatic-complexity": [
+      "error",
+      {
+        "maxComplexity": 1
+      }
+    ]
+  }
+}
+```
+
+<br>
+
+#### ✅ Valid Code
+
+```html
+@if (condition) {
+  <div>Content</div>
+} @else {
+  <div>Other</div>
+}
+```
+
+<br>
+
+---
+
+<br>
+
+#### Custom Config
+
+```json
+{
+  "rules": {
+    "@angular-eslint/template/cyclomatic-complexity": [
+      "error",
+      {
+        "maxComplexity": 1
+      }
+    ]
+  }
+}
+```
+
+<br>
+
+#### ✅ Valid Code
+
+```html
+@for (item of items; track item.id) {
+  {{ item }}
+}
+```
+
+<br>
+
+---
+
+<br>
+
+#### Custom Config
+
+```json
+{
+  "rules": {
+    "@angular-eslint/template/cyclomatic-complexity": [
+      "error",
+      {
+        "maxComplexity": 3
+      }
+    ]
+  }
+}
+```
+
+<br>
+
+#### ✅ Valid Code
+
+```html
+@switch (value) {
+  @case ('a') { <span>A</span> }
+  @case ('b') { <span>B</span> }
+  @default { <span>Default</span> }
+}
 ```
 
 </details>

--- a/packages/eslint-plugin-template/tests/rules/cyclomatic-complexity/cases.ts
+++ b/packages/eslint-plugin-template/tests/rules/cyclomatic-complexity/cases.ts
@@ -44,6 +44,34 @@ export const valid: readonly (string | ValidTestCase<Options>)[] = [
       `,
     options: [{ maxComplexity: 5 }],
   },
+  {
+    code: `
+        @if (condition) {
+          <div>Content</div>
+        } @else {
+          <div>Other</div>
+        }
+      `,
+    options: [{ maxComplexity: 1 }],
+  },
+  {
+    code: `
+        @for (item of items; track item.id) {
+          {{ item }}
+        }
+      `,
+    options: [{ maxComplexity: 1 }],
+  },
+  {
+    code: `
+        @switch (value) {
+          @case ('a') { <span>A</span> }
+          @case ('b') { <span>B</span> }
+          @default { <span>Default</span> }
+        }
+      `,
+    options: [{ maxComplexity: 3 }],
+  },
 ];
 
 export const invalid: readonly InvalidTestCase<MessageIds, Options>[] = [
@@ -124,4 +152,23 @@ export const invalid: readonly InvalidTestCase<MessageIds, Options>[] = [
     ],
     options: [{ maxComplexity: 6 }],
   }),
+  {
+    code: `
+        @if (cond) {
+          @for (item of items; track item.id) {
+            @switch (item) {
+              @case ('a') {}
+              @default {}
+            }
+          }
+        }
+      `,
+    options: [{ maxComplexity: 3 }],
+    errors: [
+      {
+        messageId,
+        data: { maxComplexity: 3, totalComplexity: 4 },
+      },
+    ],
+  },
 ];


### PR DESCRIPTION
## Summary
- support Angular control flow blocks in cyclomatic complexity
- update tests for new control flow syntax

## Testing
- `pnpm format-check`
- `pnpm nx test eslint-plugin-template --runInBand --silent`
- `pnpm nx lint eslint-plugin-template`
- `pnpm nx run-many -t check-rule-docs` *(fails: Nx flaky task)*
- `pnpm nx run-many -t check-rule-lists` *(fails: uncommitted changes)*
- `pnpm nx run-many -t check-rule-configs` *(fails: uncommitted changes)*