### PR TITLE
feat(schematics): support --skip-install for ng-add

### DIFF
--- a/packages/schematics/README.md
+++ b/packages/schematics/README.md
@@ -3,3 +3,13 @@
 Please see https://github.com/angular-eslint/angular-eslint for full usage instructions and guidance.
 
 The `@angular-eslint/schematics` package is a set of custom Angular CLI Schematics which are used to add and update dependencies and configuration files which are relevant for running ESLint on an Angular workspace.
+
+## Options
+
+### `--skip-install`
+
+Skips installing npm packages when running `ng add @angular-eslint/schematics`. This can be useful when the schematic is executed as part of a larger workflow that handles dependency installation separately.
+
+```
+ng add @angular-eslint/schematics --skip-install
+```

--- a/packages/schematics/src/ng-add/index.ts
+++ b/packages/schematics/src/ng-add/index.ts
@@ -1,6 +1,7 @@
 import type { Rule, SchematicContext, Tree } from '@angular-devkit/schematics';
 import { chain, schematic } from '@angular-devkit/schematics';
 import { NodePackageInstallTask } from '@angular-devkit/schematics/tasks';
+import type { Schema } from './schema';
 import {
   createRootESLintConfig,
   createStringifiedRootESLintConfig,
@@ -21,6 +22,7 @@ const packageJSON = require('../../package.json');
 function addAngularESLintPackages(
   json: Record<string, any>,
   useFlatConfig: boolean,
+  options: Schema,
 ) {
   return (host: Tree, context: SchematicContext) => {
     if (!host.exists('package.json')) {
@@ -62,13 +64,21 @@ function addAngularESLintPackages(
     json.devDependencies = sortObjectByKeys(json.devDependencies);
     host.overwrite('package.json', JSON.stringify(json, null, 2));
 
-    context.addTask(new NodePackageInstallTask());
+    if (!options.skipInstall) {
+      context.addTask(new NodePackageInstallTask({ allowScripts: false }));
 
-    context.logger.info(`
+      context.logger.info(`
 All angular-eslint dependencies have been successfully installed 🎉
 
 Please see https://github.com/angular-eslint/angular-eslint for how to add ESLint configuration to your project.
 `);
+    } else {
+      context.logger.info(`
+All angular-eslint dependencies have been successfully added. Run your package manager install command to complete setup.
+
+Please see https://github.com/angular-eslint/angular-eslint for how to add ESLint configuration to your project.
+`);
+    }
 
     return host;
   };
@@ -212,7 +222,12 @@ Please see https://github.com/angular-eslint/angular-eslint for more information
   };
 }
 
-export default function (): Rule {
+/**
+ * Entry point for the ng-add schematic.
+ *
+ * @param options Configuration options passed to the schematic.
+ */
+export default function (options: Schema): Rule {
   return (host: Tree, context: SchematicContext) => {
     const workspacePackageJSON = (host.read('package.json') as Buffer).toString(
       'utf-8',
@@ -221,7 +236,7 @@ export default function (): Rule {
     const useFlatConfig = shouldUseFlatConfig(host, json);
 
     return chain([
-      addAngularESLintPackages(json, useFlatConfig),
+      addAngularESLintPackages(json, useFlatConfig, options),
       applyESLintConfigIfSingleProjectWithNoExistingTSLint(useFlatConfig),
     ])(host, context);
   };

--- a/packages/schematics/src/ng-add/schema.json
+++ b/packages/schematics/src/ng-add/schema.json
@@ -3,6 +3,13 @@
   "$id": "add-angular-eslint",
   "title": "Add angular-eslint to an existing workspace",
   "type": "object",
-  "properties": {},
+  "properties": {
+    "skipInstall": {
+      "type": "boolean",
+      "description": "Skip package installation after adding dependencies",
+      "default": false,
+      "alias": "skip-install"
+    }
+  },
   "required": []
 }

--- a/packages/schematics/src/ng-add/schema.ts
+++ b/packages/schematics/src/ng-add/schema.ts
@@ -1,0 +1,9 @@
+/**
+ * Options available to the ng-add schematic.
+ */
+export interface Schema {
+  /**
+   * Skip installing dependencies after modifying package.json.
+   */
+  skipInstall?: boolean;
+}


### PR DESCRIPTION
## Summary
- add skipInstall schema option for `ng-add`
- document new flag and usage example
- allow `--skip-install` to skip NodePackageInstallTask
- log install instructions when skipping dependencies

## Testing
- `pnpm jest packages/schematics --runInBand`
- `pnpm format-check`
- `pnpm nx sync:check`
- `NX_NO_CLOUD=true pnpm nx run-many -t check-rule-docs --parallel=1`
- `NX_NO_CLOUD=true pnpm nx run-many -t check-rule-lists --parallel=1`
- `NX_NO_CLOUD=true pnpm nx run-many -t check-rule-configs --parallel=1`
