### PR TITLE
feat(builder): add stats option

### DIFF
--- a/packages/builder/README.md
+++ b/packages/builder/README.md
@@ -5,3 +5,13 @@ Please see https://github.com/angular-eslint/angular-eslint for full usage instr
 The `@angular-eslint/builder` package is a custom Angular CLI builder that allows you to run ESLint on your Angular CLI projects.
 
 It wraps the ESLint programmatic node API (https://eslint.org/docs/latest/integrate/nodejs-api) to provide a seamless experience via `ng lint` that is closely equivalent to using the `eslint` CLI directly.
+
+## Performance statistics
+
+You can profile rule execution times by enabling ESLint's stats output:
+
+```bash
+ng lint --stats
+```
+
+This option requires a flat ESLint configuration (`eslint.config.js/ts/mjs`). Using `--stats` with legacy `.eslintrc.*` files will cause an error.

--- a/packages/builder/src/lint.impl.spec.ts
+++ b/packages/builder/src/lint.impl.spec.ts
@@ -83,6 +83,7 @@ function createValidRunBuilderOptions(
     silent: false,
     ignorePath: null,
     outputFile: null,
+    stats: false,
     noEslintrc: false,
     rulesdir: [],
     resolvePluginsRelativeTo: null,
@@ -171,6 +172,7 @@ describe('Linter Builder', () => {
         format: 'stylish',
         force: false,
         silent: false,
+        stats: false,
         maxWarnings: -1,
         outputFile: null,
         ignorePath: null,
@@ -195,6 +197,7 @@ describe('Linter Builder', () => {
         format: 'stylish',
         force: false,
         silent: false,
+        stats: false,
         useEslintrc: null,
         maxWarnings: -1,
         outputFile: null,
@@ -233,6 +236,7 @@ describe('Linter Builder', () => {
         format: 'stylish',
         force: false,
         silent: false,
+        stats: false,
         useEslintrc: null,
         maxWarnings: -1,
         outputFile: null,
@@ -271,6 +275,7 @@ describe('Linter Builder', () => {
         format: 'stylish',
         force: false,
         silent: false,
+        stats: false,
         useEslintrc: null,
         maxWarnings: -1,
         outputFile: null,
@@ -309,6 +314,7 @@ describe('Linter Builder', () => {
         format: 'stylish',
         force: false,
         silent: false,
+        stats: false,
         useEslintrc: null,
         maxWarnings: -1,
         outputFile: null,
@@ -758,6 +764,23 @@ describe('Linter Builder', () => {
     expect(fs.writeFileSync).toHaveBeenCalledWith(
       join(testWorkspaceRoot, 'a/b/c/outputFile1'),
       mockFormatter.format(mockReports),
+    );
+  });
+
+  it('should pass stats option to resolveAndInstantiateESLint', async () => {
+    await runBuilder(
+      createValidRunBuilderOptions({
+        eslintConfig: './eslint.config.js',
+        lintFilePatterns: ['includedFile1'],
+        stats: true,
+        format: 'json',
+      }),
+    );
+
+    expect(mockResolveAndInstantiateESLint).toHaveBeenCalledWith(
+      undefined,
+      expect.objectContaining({ stats: true }),
+      true,
     );
   });
 });

--- a/packages/builder/src/lint.impl.spec.ts
+++ b/packages/builder/src/lint.impl.spec.ts
@@ -768,19 +768,46 @@ describe('Linter Builder', () => {
   });
 
   it('should pass stats option to resolveAndInstantiateESLint', async () => {
+    jest.spyOn(fs, 'existsSync').mockImplementation((path: any) => {
+      if (basename(path) === 'eslint.config.js') {
+        return true;
+      }
+      return false;
+    });
+
     await runBuilder(
       createValidRunBuilderOptions({
-        eslintConfig: './eslint.config.js',
-        lintFilePatterns: ['includedFile1'],
         stats: true,
-        format: 'json',
       }),
     );
 
+    expect(mockResolveAndInstantiateESLint).toHaveBeenCalledTimes(1);
     expect(mockResolveAndInstantiateESLint).toHaveBeenCalledWith(
       undefined,
-      expect.objectContaining({ stats: true }),
-      true,
+      {
+        stats: true, // stats pass through correctly
+        lintFilePatterns: [],
+        eslintConfig: null,
+        exclude: ['excludedFile1'],
+        fix: true,
+        quiet: false,
+        cache: true,
+        cacheLocation: `cacheLocation1${sep}<???>`,
+        cacheStrategy: 'content',
+        format: 'stylish',
+        force: false,
+        silent: false,
+        useEslintrc: null,
+        maxWarnings: -1,
+        outputFile: null,
+        ignorePath: null,
+        noEslintrc: false,
+        noConfigLookup: null,
+        rulesdir: [],
+        resolvePluginsRelativeTo: null,
+        reportUnusedDisableDirectives: null,
+      },
+      true, // useFlatConfig
     );
   });
 });

--- a/packages/builder/src/schema.d.ts
+++ b/packages/builder/src/schema.d.ts
@@ -14,6 +14,7 @@ export interface Schema extends JsonObject {
   eslintConfig: string | null;
   ignorePath: string | null;
   outputFile: string | null;
+  stats: boolean;
   noEslintrc: boolean;
   rulesdir: string[];
   resolvePluginsRelativeTo: string | null;

--- a/packages/builder/src/schema.json
+++ b/packages/builder/src/schema.json
@@ -26,6 +26,11 @@
       "type": "string",
       "description": "File to write report to instead of the console."
     },
+    "stats": {
+      "type": "boolean",
+      "description": "Output performance statistics for ESLint rules",
+      "default": false
+    },
     "cacheStrategy": {
       "type": "string",
       "description": "Strategy to use for detecting changed files in the cache.",

--- a/packages/builder/src/utils/eslint-utils.spec.ts
+++ b/packages/builder/src/utils/eslint-utils.spec.ts
@@ -7,8 +7,8 @@ jest.mock('eslint/use-at-your-own-risk', () => ({
 }));
 
 import { ESLint } from 'eslint';
-import { resolveAndInstantiateESLint } from './eslint-utils';
 import { FlatESLint } from 'eslint/use-at-your-own-risk';
+import { resolveAndInstantiateESLint } from './eslint-utils';
 
 describe('eslint-utils', () => {
   beforeEach(() => {
@@ -30,7 +30,7 @@ describe('eslint-utils', () => {
       cacheLocation: '/root/cache',
       cacheStrategy: 'content',
       ignorePath: undefined,
-      useEslintrc: false,
+      useEslintrc: true,
       errorOnUnmatchedPattern: false,
       rulePaths: [],
     });

--- a/packages/builder/src/utils/eslint-utils.spec.ts
+++ b/packages/builder/src/utils/eslint-utils.spec.ts
@@ -2,8 +2,13 @@ jest.mock('eslint', () => ({
   ESLint: jest.fn(),
 }));
 
+jest.mock('eslint/use-at-your-own-risk', () => ({
+  FlatESLint: jest.fn(),
+}));
+
 import { ESLint } from 'eslint';
 import { resolveAndInstantiateESLint } from './eslint-utils';
+import { FlatESLint } from 'eslint/use-at-your-own-risk';
 
 describe('eslint-utils', () => {
   beforeEach(() => {
@@ -24,9 +29,8 @@ describe('eslint-utils', () => {
       cache: true,
       cacheLocation: '/root/cache',
       cacheStrategy: 'content',
-      stats: false,
       ignorePath: undefined,
-      useEslintrc: true,
+      useEslintrc: false,
       errorOnUnmatchedPattern: false,
       rulePaths: [],
     });
@@ -46,7 +50,6 @@ describe('eslint-utils', () => {
       cache: true,
       cacheLocation: '/root/cache',
       cacheStrategy: 'content',
-      stats: false,
       ignorePath: undefined,
       useEslintrc: true,
       errorOnUnmatchedPattern: false,
@@ -218,13 +221,20 @@ describe('eslint-utils', () => {
     it('should create the ESLint instance with "stats" set to true when using flat config', async () => {
       await resolveAndInstantiateESLint(
         './eslint.config.js',
-        { stats: true } as any,
+        {
+          stats: true,
+        } as any,
         true,
       );
-
-      expect(ESLint).toHaveBeenCalledWith(
-        expect.objectContaining({ stats: true }),
-      );
+      expect(FlatESLint).toHaveBeenCalledWith({
+        cache: false,
+        cacheLocation: undefined,
+        cacheStrategy: undefined,
+        errorOnUnmatchedPattern: false,
+        fix: false,
+        overrideConfigFile: './eslint.config.js',
+        stats: true,
+      });
     });
 
     it('should throw when "stats" is used with eslintrc config', async () => {

--- a/packages/builder/src/utils/eslint-utils.spec.ts
+++ b/packages/builder/src/utils/eslint-utils.spec.ts
@@ -29,7 +29,6 @@ describe('eslint-utils', () => {
       useEslintrc: true,
       errorOnUnmatchedPattern: false,
       rulePaths: [],
-      stats: false,
     });
   });
 

--- a/packages/builder/src/utils/eslint-utils.spec.ts
+++ b/packages/builder/src/utils/eslint-utils.spec.ts
@@ -24,10 +24,12 @@ describe('eslint-utils', () => {
       cache: true,
       cacheLocation: '/root/cache',
       cacheStrategy: 'content',
+      stats: false,
       ignorePath: undefined,
       useEslintrc: true,
       errorOnUnmatchedPattern: false,
       rulePaths: [],
+      stats: false,
     });
   });
 
@@ -45,6 +47,7 @@ describe('eslint-utils', () => {
       cache: true,
       cacheLocation: '/root/cache',
       cacheStrategy: 'content',
+      stats: false,
       ignorePath: undefined,
       useEslintrc: true,
       errorOnUnmatchedPattern: false,
@@ -209,6 +212,30 @@ describe('eslint-utils', () => {
       ).rejects.toThrowErrorMatchingInlineSnapshot(
         `"For Flat Config, ESLint removed \`ignorePath\` and so it is not supported as an option. See https://eslint.org/docs/latest/use/configure/configuration-files-new"`,
       );
+    });
+  });
+
+  describe('stats option', () => {
+    it('should create the ESLint instance with "stats" set to true when using flat config', async () => {
+      await resolveAndInstantiateESLint(
+        './eslint.config.js',
+        { stats: true } as any,
+        true,
+      );
+
+      expect(ESLint).toHaveBeenCalledWith(
+        expect.objectContaining({ stats: true }),
+      );
+    });
+
+    it('should throw when "stats" is used with eslintrc config', async () => {
+      await expect(
+        resolveAndInstantiateESLint(
+          './.eslintrc.json',
+          { stats: true } as any,
+          false,
+        ),
+      ).rejects.toThrow('The --stats option requires ESLint Flat Config');
     });
   });
 });

--- a/packages/builder/src/utils/eslint-utils.ts
+++ b/packages/builder/src/utils/eslint-utils.ts
@@ -33,6 +33,9 @@ export async function resolveAndInstantiateESLint(
   options: Schema,
   useFlatConfig = false,
 ) {
+  if (options.stats && !useFlatConfig) {
+    throw new Error('The --stats option requires ESLint Flat Config');
+  }
   if (
     useFlatConfig &&
     eslintConfigPath &&
@@ -63,6 +66,7 @@ export async function resolveAndInstantiateESLint(
   };
 
   if (useFlatConfig) {
+    eslintOptions.stats = !!options.stats;
     if (typeof options.useEslintrc !== 'undefined') {
       throw new Error(
         'For Flat Config, the `useEslintrc` option is not applicable. See https://eslint.org/docs/latest/use/configure/configuration-files-new',


### PR DESCRIPTION
## Summary
- expose `--stats` option in the lint builder schema
- support `stats` in builder implementation and util
- document the stats option
- test stats option and stats output

Fixes #1370