### PR TITLE
fix(eslint-plugin): [sort-keys-in-type-decorator] preserve unconfigured properties during autofix

### DIFF
--- a/packages/eslint-plugin/docs/rules/sort-keys-in-type-decorator.md
+++ b/packages/eslint-plugin/docs/rules/sort-keys-in-type-decorator.md
@@ -479,6 +479,51 @@ class Test {}
 class Test {}
 ```
 
+<br>
+
+---
+
+<br>
+
+#### Custom Config
+
+```json
+{
+  "rules": {
+    "@angular-eslint/sort-keys-in-type-decorator": [
+      "error",
+      {
+        "Component": [
+          "selector",
+          "imports",
+          "standalone",
+          "templateUrl",
+          "styleUrl",
+          "encapsulation",
+          "changeDetection"
+        ]
+      }
+    ]
+  }
+}
+```
+
+<br>
+
+#### ❌ Invalid Code
+
+```ts
+@Component({
+  styleUrl: './app.component.css',
+  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  selector: 'app-root',
+  templateUrl: './app.component.html',
+  providers: [MyService, myProvider]
+})
+class Test {
+}
+```
+
 </details>
 
 <br>

--- a/packages/eslint-plugin/src/rules/sort-keys-in-type-decorator.ts
+++ b/packages/eslint-plugin/src/rules/sort-keys-in-type-decorator.ts
@@ -233,8 +233,8 @@ function reportAndFix(
       const configuredProps = expectedOrder.filter((name) =>
         propNames.includes(name),
       );
-      const unconfiguredProps = propNames.filter((name) =>
-        !expectedOrder.includes(name),
+      const unconfiguredProps = propNames.filter(
+        (name) => !expectedOrder.includes(name),
       );
       const filteredOrder = [...configuredProps, ...unconfiguredProps];
 

--- a/packages/eslint-plugin/src/rules/sort-keys-in-type-decorator.ts
+++ b/packages/eslint-plugin/src/rules/sort-keys-in-type-decorator.ts
@@ -230,9 +230,13 @@ function reportAndFix(
       const propNames = properties.map(
         (p) => (p.key as TSESTree.Identifier).name,
       );
-      const filteredOrder = expectedOrder.filter((name) =>
+      const configuredProps = expectedOrder.filter((name) =>
         propNames.includes(name),
       );
+      const unconfiguredProps = propNames.filter((name) =>
+        !expectedOrder.includes(name),
+      );
+      const filteredOrder = [...configuredProps, ...unconfiguredProps];
 
       const propInfoMap = CommentUtils.extractPropertyComments(
         sourceCode,

--- a/packages/eslint-plugin/tests/rules/sort-keys-in-type-decorator/cases.ts
+++ b/packages/eslint-plugin/tests/rules/sort-keys-in-type-decorator/cases.ts
@@ -603,4 +603,33 @@ export const invalid: readonly InvalidTestCase<MessageIds, Options>[] = [
       class Test {}
     `,
   }),
+  convertAnnotatedSourceToFailureCase({
+    description: 'should preserve unconfigured properties like providers when sorting',
+    annotatedSource: `
+      @Component({
+        selector: 'my-app',
+        templateUrl: './app.component.html',
+        changeDetection: ChangeDetectionStrategy.OnPush,
+        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+        imports: [NgClass],
+        providers: [MyService, myProvider]
+      })
+      class Test {}
+    `,
+    messageId: 'incorrectOrder',
+    data: {
+      decorator: 'Component',
+      expectedOrder: 'selector, imports, templateUrl, changeDetection',
+    },
+    annotatedOutput: `
+      @Component({
+        selector: 'my-app',
+        imports: [NgClass],
+        templateUrl: './app.component.html',
+        changeDetection: ChangeDetectionStrategy.OnPush,
+        providers: [MyService, myProvider]
+      })
+      class Test {}
+    `,
+  }),
 ];

--- a/packages/eslint-plugin/tests/rules/sort-keys-in-type-decorator/cases.ts
+++ b/packages/eslint-plugin/tests/rules/sort-keys-in-type-decorator/cases.ts
@@ -604,32 +604,47 @@ export const invalid: readonly InvalidTestCase<MessageIds, Options>[] = [
     `,
   }),
   convertAnnotatedSourceToFailureCase({
-    description: 'should preserve unconfigured properties like providers when sorting',
+    description:
+      'should preserve unconfigured properties like providers when sorting',
     annotatedSource: `
       @Component({
-        selector: 'my-app',
+        styleUrl: './app.component.css',
+        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+        selector: 'app-root',
         templateUrl: './app.component.html',
-        changeDetection: ChangeDetectionStrategy.OnPush,
-        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-        imports: [NgClass],
         providers: [MyService, myProvider]
       })
-      class Test {}
+      class Test {
+      }
     `,
     messageId: 'incorrectOrder',
     data: {
       decorator: 'Component',
-      expectedOrder: 'selector, imports, templateUrl, changeDetection',
+      expectedOrder: 'selector, templateUrl, styleUrl',
     },
+    options: [
+      {
+        Component: [
+          'selector',
+          'imports',
+          'standalone',
+          'templateUrl',
+          'styleUrl',
+          'encapsulation',
+          'changeDetection',
+          // providers is intentionally not configured here to cover: https://github.com/angular-eslint/angular-eslint/issues/2455
+        ],
+      },
+    ],
     annotatedOutput: `
       @Component({
-        selector: 'my-app',
-        imports: [NgClass],
+        selector: 'app-root',
         templateUrl: './app.component.html',
-        changeDetection: ChangeDetectionStrategy.OnPush,
+        styleUrl: './app.component.css',
         providers: [MyService, myProvider]
       })
-      class Test {}
+      class Test {
+      }
     `,
   }),
 ];


### PR DESCRIPTION
Fixes #2455

The autofix was removing properties that weren't in the expected order configuration. This fix ensures all properties are preserved, with configured properties sorted according to the expected order and unconfigured properties appended at the end.

Generated with [Claude Code](https://claude.ai/code)