### PR TITLE
fix(schematics): ensure @eslint/js and @angular-eslint/builder are always available in non-npm repos

### DIFF
--- a/packages/schematics/src/ng-add/index.ts
+++ b/packages/schematics/src/ng-add/index.ts
@@ -13,7 +13,7 @@ import {
   updateSchematicCollections,
 } from '../utils';
 
-export const FIXED_ESLINT_V8_VERSION = '8.57.0';
+export const FIXED_ESLINT_V8_VERSION = '8.57.1';
 export const FIXED_TYPESCRIPT_ESLINT_V7_VERSION = '7.11.0';
 
 const packageJSON = require('../../package.json');
@@ -61,6 +61,8 @@ function addAngularESLintPackages(
           // Prevent TS IDE errors in the eslint config file for non-npm installations by explicitly including @eslint/js (even though linting seems to still work without it)
           json.devDependencies['@eslint/js'] =
             `^${packageJSON.devDependencies['eslint']}`;
+          // Ensure @angular-eslint/builder is always resolvable in non-npm installations (https://github.com/angular-eslint/angular-eslint/issues/2241)
+          json.devDependencies['@angular-eslint/builder'] = packageJSON.version;
         }
       }
     } else {

--- a/packages/schematics/src/ng-add/index.ts
+++ b/packages/schematics/src/ng-add/index.ts
@@ -55,6 +55,13 @@ function addAngularESLintPackages(
           typescriptESLintVersion;
         json.devDependencies['@typescript-eslint/utils'] =
           typescriptESLintVersion;
+      } else {
+        const isNpm = host.exists('package-lock.json');
+        if (!isNpm) {
+          // Prevent TS IDE errors in the eslint config file for non-npm installations by explicitly including @eslint/js (even though linting seems to still work without it)
+          json.devDependencies['@eslint/js'] =
+            `^${packageJSON.devDependencies['eslint']}`;
+        }
       }
     } else {
       applyDevDependenciesForESLintRC(json);

--- a/packages/schematics/tests/ng-add/index.test.ts
+++ b/packages/schematics/tests/ng-add/index.test.ts
@@ -35,6 +35,7 @@ describe('ng-add', () => {
           },
         }),
       );
+      workspaceTree.create('package-lock.json', JSON.stringify({}));
     });
 
     describe('standard workspace layout - single existing project', () => {
@@ -489,6 +490,7 @@ describe('ng-add', () => {
     beforeEach(() => {
       workspaceTree = new UnitTestTree(Tree.empty());
       workspaceTree.create('package.json', JSON.stringify({}));
+      workspaceTree.create('package-lock.json', JSON.stringify({}));
     });
 
     describe('standard workspace layout - single existing project', () => {


### PR DESCRIPTION
Closes #2241 