### PR TITLE
fix(eslint-plugin): [no-uncalled-signals] handle direct signal calls in member expressions

### DIFF
--- a/packages/eslint-plugin/docs/rules/no-uncalled-signals.md
+++ b/packages/eslint-plugin/docs/rules/no-uncalled-signals.md
@@ -702,6 +702,89 @@ declare function createSignal(): Signal<boolean>;
 interface Signal<T> {}
 ```
 
+<br>
+
+---
+
+<br>
+
+#### Default Config
+
+```json
+{
+  "rules": {
+    "@angular-eslint/no-uncalled-signals": [
+      "error"
+    ]
+  }
+}
+```
+
+<br>
+
+#### ✅ Valid Code
+
+```ts
+export class AppComponent {
+  readonly test = signal<boolean>(false);
+
+  constructor() {
+    effect(() => {
+      if (this.test()) {
+        console.log('Hey');
+      } else {
+        console.log('Hoo');
+      }
+    });
+  }
+}
+declare function signal<T>(value: T): Signal<T>;
+declare function effect(fn: () => void): void;
+interface Signal<T> {}
+```
+
+<br>
+
+---
+
+<br>
+
+#### Default Config
+
+```json
+{
+  "rules": {
+    "@angular-eslint/no-uncalled-signals": [
+      "error"
+    ]
+  }
+}
+```
+
+<br>
+
+#### ✅ Valid Code
+
+```ts
+export class AppComponent {
+  readonly test = signal<boolean>(false);
+
+  constructor() {
+    const t = this.test;
+    effect(() => {
+      if (t()) {
+        console.log('Hey');
+      } else {
+        console.log('Hoo');
+      }
+    });
+  }
+}
+declare function signal<T>(value: T): Signal<T>;
+declare function effect(fn: () => void): void;
+interface Signal<T> {}
+```
+
 </details>
 
 <br>

--- a/packages/eslint-plugin/src/rules/no-uncalled-signals.ts
+++ b/packages/eslint-plugin/src/rules/no-uncalled-signals.ts
@@ -40,6 +40,15 @@ export default createESLintRule<Options, MessageIds>({
           return;
         }
 
+        // Check if this identifier is the property in a MemberExpression that's being called
+        if (
+          node.parent.type === AST_NODE_TYPES.MemberExpression &&
+          node.parent.property === node &&
+          node.parent.parent?.type === AST_NODE_TYPES.CallExpression
+        ) {
+          return;
+        }
+
         const type = services.getTypeAtLocation(node);
         const identifierType = type.getSymbol()?.name;
 

--- a/packages/eslint-plugin/tests/rules/no-uncalled-signals/cases.ts
+++ b/packages/eslint-plugin/tests/rules/no-uncalled-signals/cases.ts
@@ -89,6 +89,44 @@ export const valid: readonly (string | ValidTestCase<Options>)[] = [
     declare function createSignal(): Signal<boolean>;
     interface Signal<T> {}
   `,
+  // Test cases for the reported bug - direct signal calls on member expressions
+  `
+    export class AppComponent {
+      readonly test = signal<boolean>(false);
+
+      constructor() {
+        effect(() => {
+          if (this.test()) {
+            console.log('Hey');
+          } else {
+            console.log('Hoo');
+          }
+        });
+      }
+    }
+    declare function signal<T>(value: T): Signal<T>;
+    declare function effect(fn: () => void): void;
+    interface Signal<T> {}
+  `,
+  `
+    export class AppComponent {
+      readonly test = signal<boolean>(false);
+
+      constructor() {
+        const t = this.test;
+        effect(() => {
+          if (t()) {
+            console.log('Hey');
+          } else {
+            console.log('Hoo');
+          }
+        });
+      }
+    }
+    declare function signal<T>(value: T): Signal<T>;
+    declare function effect(fn: () => void): void;
+    interface Signal<T> {}
+  `,
 ];
 
 export const invalid: readonly InvalidTestCase<MessageIds, Options>[] = [


### PR DESCRIPTION
Fixes issue where `this.test()` was incorrectly flagged as an uncalled signal.
The rule now properly detects when an identifier is the property of a
MemberExpression that is being called.

Fixes #2490

Generated with [Claude Code](https://claude.ai/code)