### PR TITLE
docs(eslint-plugin): add rationale for no-experimental and no-developer-preview

### DIFF
--- a/packages/eslint-plugin/docs/rules/no-developer-preview.md
+++ b/packages/eslint-plugin/docs/rules/no-developer-preview.md
@@ -21,6 +21,12 @@ Disallow using code which is marked as developer preview
 
 <br>
 
+## Rationale
+
+Angular's [developer preview APIs](https://angular.dev/reference/releases#developer-preview) are fully functional and polished, but not yet covered by Angular's [breaking change policy](https://angular.dev/reference/releases#breaking-change-policy-and-update-paths). These APIs may change even in patch releases, making them risky for production applications.
+
+<br>
+
 ## Rule Options
 
 The rule does not have any configuration options.

--- a/packages/eslint-plugin/docs/rules/no-experimental.md
+++ b/packages/eslint-plugin/docs/rules/no-experimental.md
@@ -21,6 +21,12 @@ Disallow using code which is marked as experimental
 
 <br>
 
+## Rationale
+
+Angular's [experimental APIs](https://angular.dev/reference/releases#experimental) are subject to significant changes or removal without notice and are not covered by Angular's [breaking change policy](https://angular.dev/reference/releases#breaking-change-policy-and-update-paths). These APIs may change even in patch releases, making them risky for production applications.
+
+<br>
+
 ## Rule Options
 
 The rule does not have any configuration options.

--- a/packages/eslint-plugin/src/rules/no-developer-preview.ts
+++ b/packages/eslint-plugin/src/rules/no-developer-preview.ts
@@ -50,3 +50,7 @@ export default createESLintRule<Options, MessageIds>({
     };
   },
 });
+
+export const RULE_DOCS_EXTENSION = {
+  rationale: `Angular's [developer preview APIs](https://angular.dev/reference/releases#developer-preview) are fully functional and polished, but not yet covered by Angular's [breaking change policy](https://angular.dev/reference/releases#breaking-change-policy-and-update-paths). These APIs may change even in patch releases, making them risky for production applications.`,
+};

--- a/packages/eslint-plugin/src/rules/no-experimental.ts
+++ b/packages/eslint-plugin/src/rules/no-experimental.ts
@@ -50,3 +50,7 @@ export default createESLintRule<Options, MessageIds>({
     };
   },
 });
+
+export const RULE_DOCS_EXTENSION = {
+  rationale: `Angular's [experimental APIs](https://angular.dev/reference/releases#experimental) are subject to significant changes or removal without notice and are not covered by Angular's [breaking change policy](https://angular.dev/reference/releases#breaking-change-policy-and-update-paths). These APIs may change even in patch releases, making them risky for production applications.`,
+};


### PR DESCRIPTION
Add reasoning for the new `no-experimental` and `no-developer-preview` rules, see #1447