### PR TITLE
docs(eslint-plugin): add rationale for button-has-type rule

### DIFF
--- a/packages/eslint-plugin-template/docs/rules/button-has-type.md
+++ b/packages/eslint-plugin-template/docs/rules/button-has-type.md
@@ -21,6 +21,12 @@ Ensures that a button has a valid type specified
 
 <br>
 
+## Rationale
+
+Buttons default to `type="submit"` when no type is specified. If placed inside a form, the button triggers a form submission on click. Enforcing the type attribute clarifies the code's intent and prevents unintended form submissions.
+
+<br>
+
 ## Rule Options
 
 The rule accepts an options object with the following properties:

--- a/packages/eslint-plugin-template/src/rules/button-has-type.ts
+++ b/packages/eslint-plugin-template/src/rules/button-has-type.ts
@@ -92,6 +92,11 @@ export default createESLintRule<Options, MessageIds>({
   },
 });
 
+export const RULE_DOCS_EXTENSION = {
+  rationale:
+    'Buttons default to `type="submit"` when no type is specified. If placed inside a form, the button triggers a form submission on click. Enforcing the type attribute clarifies the code\'s intent and prevents unintended form submissions.',
+};
+
 function isTypeAttributePresentInElement({
   inputs,
   attributes,


### PR DESCRIPTION
Add reasoning for the `button-has-type` rule, see #1447 