### PR TITLE
fix(eslint-plugin-template): [no-interpolation-in-attributes] use keySpan as attr. range and sourceSpan as replacement range

### DIFF
--- a/packages/eslint-plugin-template/docs/rules/no-interpolation-in-attributes.md
+++ b/packages/eslint-plugin-template/docs/rules/no-interpolation-in-attributes.md
@@ -112,6 +112,33 @@ interface Options {
 
 <br>
 
+#### Default Config
+
+```json
+{
+  "rules": {
+    "@angular-eslint/template/no-interpolation-in-attributes": [
+      "error"
+    ]
+  }
+}
+```
+
+<br>
+
+#### ❌ Invalid Code
+
+```html
+<input type="text" attr.data-myExample="{{ foo }}">
+                                        ~~~~~~~~~
+```
+
+<br>
+
+---
+
+<br>
+
 #### Custom Config
 
 ```json

--- a/packages/eslint-plugin-template/src/rules/no-interpolation-in-attributes.ts
+++ b/packages/eslint-plugin-template/src/rules/no-interpolation-in-attributes.ts
@@ -73,7 +73,11 @@ export default createESLintRule<Options, MessageIds>({
           messageId: 'noInterpolationInAttributes',
           fix: isFullInterpolation
             ? (fixer) => {
-                const attributeName = boundAttribute.name.trim();
+                const attrStart = boundAttribute.keySpan.start.offset;
+                const attrEnd = boundAttribute.keySpan.end.offset;
+                const attributeName = sourceCode.text
+                  .slice(attrStart, attrEnd)
+                  .trim();
 
                 const exprStart = boundAttribute.valueSpan.start.offset + 2; // +2 to remove '{{'
                 const exprEnd = boundAttribute.valueSpan.end.offset - 2; // -2 to remove '}}'
@@ -81,12 +85,12 @@ export default createESLintRule<Options, MessageIds>({
                   .slice(exprStart, exprEnd)
                   .trim();
 
+                const rangeStart = boundAttribute.sourceSpan.start.offset;
+                const rangeEnd = boundAttribute.sourceSpan.end.offset;
+                const replacement = `[${attributeName}]="${expression}"`;
                 return fixer.replaceTextRange(
-                  [
-                    boundAttribute.keySpan.start.offset,
-                    boundAttribute.valueSpan.end.offset,
-                  ],
-                  `[${attributeName}]="${expression}`, // Replace with property binding. Leave out the last quote since its automatically added.
+                  [rangeStart, rangeEnd],
+                  replacement,
                 );
               }
             : null,

--- a/packages/eslint-plugin-template/tests/rules/no-interpolation-in-attributes/cases.ts
+++ b/packages/eslint-plugin-template/tests/rules/no-interpolation-in-attributes/cases.ts
@@ -47,6 +47,19 @@ export const invalid: readonly InvalidTestCase<MessageIds, Options>[] = [
   }),
   convertAnnotatedSourceToFailureCase({
     description:
+      'it should fail and autofix the full attribute if interpolation is used as attribute value',
+    annotatedSource: `
+        <input type="text" attr.data-myExample="{{ foo }}">
+                                                ~~~~~~~~~
+      `,
+    messageId,
+    annotatedOutput: `
+        <input type="text" [attr.data-myExample]="foo">
+                                                
+      `,
+  }),
+  convertAnnotatedSourceToFailureCase({
+    description:
       'it should fail and not autofix when interpolation is used as part of attribute value and this is explicitly configured as disallowed',
     annotatedSource: `
         <input type="text" name="{{ foo }}bar">


### PR DESCRIPTION
Fix for released version 19.8: https://github.com/angular-eslint/angular-eslint/pull/2501

This PR fixes an issue in the no-interpolation-in-attributes rule where attributes using attr. (e.g. `attr.data-*`) were incorrectly autofixed by removing the attr. prefix. The fixer now correctly preserves the full attribute name, ensuring proper binding syntax like `[attr.data-example]="..."`.

If this fix is valid, I'd appreciate it if it could still be included in a v19 release, if possible.