### PR TITLE
fix(eslint-plugin): [relative-url-prefix] handle template literals

### DIFF
--- a/packages/eslint-plugin/docs/rules/relative-url-prefix.md
+++ b/packages/eslint-plugin/docs/rules/relative-url-prefix.md
@@ -309,6 +309,38 @@ class Test {}
 class Test {}
 ```
 
+<br>
+
+---
+
+<br>
+
+#### Default Config
+
+```json
+{
+  "rules": {
+    "@angular-eslint/relative-url-prefix": [
+      "error"
+    ]
+  }
+}
+```
+
+<br>
+
+#### ✅ Valid Code
+
+```ts
+@Component({
+  templateUrl: `../foobar.html`,
+  styleUrls: [
+    `.././foobar.css`,
+  ]
+})
+class Test {}
+```
+
 </details>
 
 <br>

--- a/packages/eslint-plugin/src/rules/relative-url-prefix.ts
+++ b/packages/eslint-plugin/src/rules/relative-url-prefix.ts
@@ -59,6 +59,9 @@ function isUrlInvalid(
   if (!node) {
     return false;
   }
+  if (ASTUtils.isTemplateLiteral(node)) {
+    return !RELATIVE_URL_PREFIX_MATCHER.test(node.quasis[0].value.raw);
+  }
   return (
     !ASTUtils.isStringLiteral(node) ||
     !RELATIVE_URL_PREFIX_MATCHER.test(node.value)

--- a/packages/eslint-plugin/tests/rules/relative-url-prefix/cases.ts
+++ b/packages/eslint-plugin/tests/rules/relative-url-prefix/cases.ts
@@ -60,6 +60,16 @@ export const valid: readonly (string | ValidTestCase<Options>)[] = [
     })
     class Test {}
     `,
+  // Should support backticks https://github.com/angular-eslint/angular-eslint/issues/2575
+  `
+    @Component({
+      templateUrl: \`../foobar.html\`,
+      styleUrls: [
+        \`.././foobar.css\`,
+      ]
+    })
+    class Test {}
+    `,
 ];
 
 export const invalid: readonly InvalidTestCase<MessageIds, Options>[] = [


### PR DESCRIPTION
Fixes #2575