### PR TITLE
fix(eslint-plugin): [no-uncalled-signals] do not report signal sets within logical expressions

### DIFF
--- a/packages/eslint-plugin/docs/rules/no-uncalled-signals.md
+++ b/packages/eslint-plugin/docs/rules/no-uncalled-signals.md
@@ -785,6 +785,38 @@ declare function effect(fn: () => void): void;
 interface Signal<T> {}
 ```
 
+<br>
+
+---
+
+<br>
+
+#### Default Config
+
+```json
+{
+  "rules": {
+    "@angular-eslint/no-uncalled-signals": [
+      "error"
+    ]
+  }
+}
+```
+
+<br>
+
+#### ✅ Valid Code
+
+```ts
+let a: Signal<string>;
+let b: boolean;
+let c = b && a.set('');
+
+interface Signal<T> {
+  set(value: T): void;
+}
+```
+
 </details>
 
 <br>

--- a/packages/eslint-plugin/src/rules/no-uncalled-signals.ts
+++ b/packages/eslint-plugin/src/rules/no-uncalled-signals.ts
@@ -40,10 +40,12 @@ export default createESLintRule<Options, MessageIds>({
           return;
         }
 
-        // Check if this identifier is the property in a MemberExpression that's being called
+        // Check if this identifier is the property or object in a MemberExpression that's being called.
+        // If the identifier is a signal and it's being called, then the signal's value is being read.
+        // If it's the object, then a method on the signal (most likely the `set` method) is being called.
         if (
           node.parent.type === AST_NODE_TYPES.MemberExpression &&
-          node.parent.property === node &&
+          (node.parent.object === node || node.parent.property === node) &&
           node.parent.parent?.type === AST_NODE_TYPES.CallExpression
         ) {
           return;

--- a/packages/eslint-plugin/tests/rules/no-uncalled-signals/cases.ts
+++ b/packages/eslint-plugin/tests/rules/no-uncalled-signals/cases.ts
@@ -127,6 +127,16 @@ export const valid: readonly (string | ValidTestCase<Options>)[] = [
     declare function effect(fn: () => void): void;
     interface Signal<T> {}
   `,
+  // https://github.com/angular-eslint/angular-eslint/issues/2574
+  `
+    let a: Signal<string>;
+    let b: boolean;
+    let c = b && a.set('');
+
+    interface Signal<T> {
+      set(value: T): void;
+    }
+  `,
 ];
 
 export const invalid: readonly InvalidTestCase<MessageIds, Options>[] = [


### PR DESCRIPTION
Fixes #2574 

When a signal was set within a `LogicalExpression`, the signal would incorrectly be reported as uncalled. Reads were detected, but `.set` calls were not.