### PR TITLE
fix(angular-eslint): support eslint defineConfig types in addition to typescript-eslint config

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "@angular/compiler": "catalog:",
     "@commitlint/cli": "catalog:",
     "@commitlint/config-conventional": "catalog:",
+    "@eslint/core": "catalog:",
     "@mdn/browser-compat-data": "catalog:",
     "@nx/devkit": "catalog:",
     "@nx/esbuild": "catalog:",

--- a/packages/angular-eslint/tests/type-compatibility.test.ts
+++ b/packages/angular-eslint/tests/type-compatibility.test.ts
@@ -1,0 +1,64 @@
+/**
+ * This test file exists purely to be type-checked in CI to ensure that angular-eslint plugins and parsers are compatible with both:
+ * 1. ESLint's defineConfig function (uses ESLint.Plugin and Linter.ParserModule types)
+ * 2. typescript-eslint's config function (uses TSESLint.FlatConfig.Plugin and TSESLint.FlatConfig.Parser types)
+ */
+
+import { defineConfig } from 'eslint/config';
+import { config } from 'typescript-eslint';
+
+import angular from '../src/index';
+
+/**
+ * Test 1: Verify compatibility with ESLint's defineConfig
+ */
+defineConfig([
+  {
+    files: ['**/*.ts'],
+    plugins: {
+      '@angular-eslint': angular.tsPlugin,
+    },
+    rules: {
+      '@angular-eslint/component-class-suffix': 'error',
+    },
+  },
+  {
+    files: ['**/*.html'],
+    plugins: {
+      '@angular-eslint/template': angular.templatePlugin,
+    },
+    languageOptions: {
+      parser: angular.templateParser,
+    },
+    rules: {
+      '@angular-eslint/template/banana-in-box': 'error',
+    },
+  },
+]);
+
+/**
+ * Test 2: Verify compatibility with typescript-eslint's config function
+ */
+config(
+  {
+    files: ['**/*.ts'],
+    plugins: {
+      '@angular-eslint': angular.tsPlugin,
+    },
+    rules: {
+      '@angular-eslint/component-class-suffix': 'error',
+    },
+  },
+  {
+    files: ['**/*.html'],
+    plugins: {
+      '@angular-eslint/template': angular.templatePlugin,
+    },
+    languageOptions: {
+      parser: angular.templateParser,
+    },
+    rules: {
+      '@angular-eslint/template/banana-in-box': 'error',
+    },
+  },
+);

--- a/packages/angular-eslint/tsconfig.json
+++ b/packages/angular-eslint/tsconfig.json
@@ -22,6 +22,9 @@
     },
     {
       "path": "./tsconfig.lib.json"
+    },
+    {
+      "path": "./tsconfig.type-compat.json"
     }
   ]
 }

--- a/packages/angular-eslint/tsconfig.type-compat.json
+++ b/packages/angular-eslint/tsconfig.type-compat.json
@@ -1,0 +1,15 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "../../dist/out-tsc/angular-eslint-type-compat",
+    "types": ["node"],
+    "sourceMap": true,
+    "skipLibCheck": false
+  },
+  "include": ["tests/type-compatibility.test.ts"],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    }
+  ]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,6 +18,9 @@ catalogs:
     '@commitlint/config-conventional':
       specifier: 20.0.0
       version: 20.0.0
+    '@eslint/core':
+      specifier: ^0.17.0
+      version: 0.17.0
     '@mdn/browser-compat-data':
       specifier: 7.1.18
       version: 7.1.18
@@ -216,6 +219,9 @@ importers:
       '@commitlint/config-conventional':
         specifier: 'catalog:'
         version: 20.0.0
+      '@eslint/core':
+        specifier: 'catalog:'
+        version: 0.17.0
       '@mdn/browser-compat-data':
         specifier: 'catalog:'
         version: 7.1.18

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -6,6 +6,7 @@ catalog:
   '@angular/compiler': 20.3.9
   '@commitlint/cli': 20.1.0
   '@commitlint/config-conventional': 20.0.0
+  '@eslint/core': ^0.17.0
   '@mdn/browser-compat-data': 7.1.18
   '@nx/devkit': 22.1.0-beta.3
   '@nx/esbuild': 22.1.0-beta.3


### PR DESCRIPTION
Added a file to reproduce the issue and ensure this dual support holds true in future refactors:

**Before**
<img width="1661" height="1182" alt="Image" src="https://github.com/user-attachments/assets/96286425-bed8-4f36-bf21-ad11395adef2" />

**After**
<img width="868" height="1291" alt="Image" src="https://github.com/user-attachments/assets/2e8a5525-ac13-4352-997c-3a8edbb56415" />

Fixes #2642