### PR TITLE
fix(eslint-plugin-template): [prefer-template-literal] handle chained concatenations correctly

### DIFF
--- a/packages/eslint-plugin-template/docs/rules/prefer-template-literal.md
+++ b/packages/eslint-plugin-template/docs/rules/prefer-template-literal.md
@@ -2122,6 +2122,168 @@ The rule does not have any configuration options.
 "></div>
 ```
 
+<br>
+
+---
+
+<br>
+
+#### Default Config
+
+```json
+{
+  "rules": {
+    "@angular-eslint/template/prefer-template-literal": [
+      "error"
+    ]
+  }
+}
+```
+
+<br>
+
+#### ❌ Invalid Code
+
+```html
+{{ 'a' + 'b' + 'c' }}
+   ~~~~~~~~~~~~~~~
+```
+
+<br>
+
+---
+
+<br>
+
+#### Default Config
+
+```json
+{
+  "rules": {
+    "@angular-eslint/template/prefer-template-literal": [
+      "error"
+    ]
+  }
+}
+```
+
+<br>
+
+#### ❌ Invalid Code
+
+```html
+{{ x.type + '' + y }}
+   ~~~~~~~~~~~~~~~
+```
+
+<br>
+
+---
+
+<br>
+
+#### Default Config
+
+```json
+{
+  "rules": {
+    "@angular-eslint/template/prefer-template-literal": [
+      "error"
+    ]
+  }
+}
+```
+
+<br>
+
+#### ❌ Invalid Code
+
+```html
+{{ x.type + '' + $any(x).label + '' + $any(x).to }}
+   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+```
+
+<br>
+
+---
+
+<br>
+
+#### Default Config
+
+```json
+{
+  "rules": {
+    "@angular-eslint/template/prefer-template-literal": [
+      "error"
+    ]
+  }
+}
+```
+
+<br>
+
+#### ❌ Invalid Code
+
+```html
+{{ 'a' + 'b' + 'c' + 'd' }}
+   ~~~~~~~~~~~~~~~~~~~~~
+```
+
+<br>
+
+---
+
+<br>
+
+#### Default Config
+
+```json
+{
+  "rules": {
+    "@angular-eslint/template/prefer-template-literal": [
+      "error"
+    ]
+  }
+}
+```
+
+<br>
+
+#### ❌ Invalid Code
+
+```html
+{{ 'prefix-' + value + '-middle-' + value2 + '-suffix' }}
+   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+```
+
+<br>
+
+---
+
+<br>
+
+#### Default Config
+
+```json
+{
+  "rules": {
+    "@angular-eslint/template/prefer-template-literal": [
+      "error"
+    ]
+  }
+}
+```
+
+<br>
+
+#### ❌ Invalid Code
+
+```html
+{{ getValue() + '-' + getOther() + '-end' }}
+   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+```
+
 </details>
 
 <br>

--- a/packages/eslint-plugin-template/tests/rules/prefer-template-literal/cases.ts
+++ b/packages/eslint-plugin-template/tests/rules/prefer-template-literal/cases.ts
@@ -1075,4 +1075,83 @@ export const invalid: readonly InvalidTestCase<MessageIds, Options>[] = [
         "></div>
       `,
   }),
+
+  // Issue #2500: Chained concatenations
+  convertAnnotatedSourceToFailureCase({
+    messageId,
+    description:
+      'should handle chained string concatenation (three strings - issue #2500)',
+    annotatedSource: `
+        {{ 'a' + 'b' + 'c' }}
+           ~~~~~~~~~~~~~~~
+      `,
+    annotatedOutput: `
+        {{ 'abc' }}
+           
+      `,
+  }),
+  convertAnnotatedSourceToFailureCase({
+    messageId,
+    description:
+      'should handle chained concatenation with expressions (issue #2500)',
+    annotatedSource: `
+        {{ x.type + '' + y }}
+           ~~~~~~~~~~~~~~~
+      `,
+    annotatedOutput: `
+        {{ \`\${x.type}\${y}\` }}
+           
+      `,
+  }),
+  convertAnnotatedSourceToFailureCase({
+    messageId,
+    description:
+      'should handle chained concatenation with $any and expressions (issue #2500)',
+    annotatedSource: `
+        {{ x.type + '' + $any(x).label + '' + $any(x).to }}
+           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      `,
+    annotatedOutput: `
+        {{ \`\${x.type}\${$any(x).label}\${$any(x).to}\` }}
+           
+      `,
+  }),
+  convertAnnotatedSourceToFailureCase({
+    messageId,
+    description: 'should handle four-way string concatenation (issue #2500)',
+    annotatedSource: `
+        {{ 'a' + 'b' + 'c' + 'd' }}
+           ~~~~~~~~~~~~~~~~~~~~~
+      `,
+    annotatedOutput: `
+        {{ 'abcd' }}
+           
+      `,
+  }),
+  convertAnnotatedSourceToFailureCase({
+    messageId,
+    description:
+      'should handle chained concatenation with mixed literals and expressions (issue #2500)',
+    annotatedSource: `
+        {{ 'prefix-' + value + '-middle-' + value2 + '-suffix' }}
+           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      `,
+    annotatedOutput: `
+        {{ \`prefix-\${value}-middle-\${value2}-suffix\` }}
+           
+      `,
+  }),
+  convertAnnotatedSourceToFailureCase({
+    messageId,
+    description:
+      'should handle chained concatenation with function calls (issue #2500)',
+    annotatedSource: `
+        {{ getValue() + '-' + getOther() + '-end' }}
+           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      `,
+    annotatedOutput: `
+        {{ \`\${getValue()}-\${getOther()}-end\` }}
+           
+      `,
+  }),
 ];


### PR DESCRIPTION
The fixer was not handling complex string concatenations correctly, particularly for multiline expressions and chained concatenations like `'a' + 'b' + 'c'` or `x.type + "" + $any(x).label + "" + $any(x).to`.

The issue was that the rule reported on each Binary + node individually, leading to conflicting fixes where only the innermost one was applied, leaving partial/incomplete fixes.

Changes:
- Skip inner Binary + nodes when part of a larger concatenation chain
- Flatten the entire chain and report only on the outermost node
- Generate a single fix that handles all parts of the concatenation
- Properly flatten template literals by their elements and expressions
- Preserve original quote style when all parts are string literals

Fixes #2500