### PR TITLE
fix(eslint-plugin-template): [prefer-contextual-for-variables] fix overlapping fixes for semicolon-separated let declarations

### DIFF
--- a/packages/eslint-plugin-template/docs/rules/prefer-contextual-for-variables.md
+++ b/packages/eslint-plugin-template/docs/rules/prefer-contextual-for-variables.md
@@ -2765,6 +2765,36 @@ interface Options {
 #### ❌ Invalid Code
 
 ```html
+@for (example of examples; track example; let index = $index; let last = $last) {
+                                              ~~~~~~~~~~~~~~      ~~~~~~~~~~~~
+  {{ index }}
+  {{ last }}
+}
+```
+
+<br>
+
+---
+
+<br>
+
+#### Default Config
+
+```json
+{
+  "rules": {
+    "@angular-eslint/template/prefer-contextual-for-variables": [
+      "error"
+    ]
+  }
+}
+```
+
+<br>
+
+#### ❌ Invalid Code
+
+```html
 @for (a of outer; track a.id) {
   @if ($index === 0) {
        ~~~~~~~~~~~~


### PR DESCRIPTION
When `@for` loops use multiple separate `let` declarations with semicolons (e.g., `let index = $index; let last = $last`), the autofix would produce invalid output because it tried to keep the `let` keyword when removing the first variable in a comma-separated list, but failed to detect that semicolon-separated declarations each have their own `let` keyword.

This fix adds a `hasOwnLetKeyword` function that checks whether a variable is the only one in its `let` block (no comma after it), and if so, removes the entire `; let variable = $value` instead of just the variable.

Fixes #2676