### PR TITLE
chore: custom rules docs fixes

### DIFF
--- a/docs/WRITING_CUSTOM_RULES.md
+++ b/docs/WRITING_CUSTOM_RULES.md
@@ -59,8 +59,6 @@ For general information about writing ESLint custom rules, see the [official ESL
 
 Let's create a custom rule that enforces a naming convention for Angular services.
 
-### Step 1: Create the Rule File
-
 **`src/rules/service-class-suffix.ts`**
 
 ```typescript
@@ -141,7 +139,7 @@ export const rule = ESLintUtils.RuleCreator.withoutDocs<Options, MessageIds>({
 
 ## Creating an HTML Template Rule
 
-Let's create a simple rule that enforces a data attribute on div elements.
+Let's create a custom rule that enforces a data attribute on div elements.
 
 **`src/rules/require-data-foo.ts`**
 
@@ -281,7 +279,11 @@ import type {
 import { rule, RULE_NAME } from '../../src/rules/require-data-foo';
 import type { MessageIds, Options } from '../../src/rules/require-data-foo';
 
-const ruleTester = new RuleTester();
+const ruleTester = new RuleTester({
+  languageOptions: {
+    parser: require('@angular-eslint/template-parser'),
+  },
+});
 const messageId: MessageIds = 'requireDataFoo';
 
 const valid: readonly (string | ValidTestCase<Options>)[] = [
@@ -313,8 +315,8 @@ const invalid: readonly InvalidTestCase<MessageIds, Options>[] = [
         messageId,
         line: 2,
         column: 7,
-        endLine: 2,
-        endColumn: 12,
+        endLine: 4,
+        endColumn: 13,
       },
     ],
   },
@@ -329,8 +331,8 @@ const invalid: readonly InvalidTestCase<MessageIds, Options>[] = [
         messageId,
         line: 2,
         column: 7,
-        endLine: 2,
-        endColumn: 29,
+        endLine: 4,
+        endColumn: 13,
       },
     ],
   },


### PR DESCRIPTION
First of all I want to say thank you for maintaining this very useful project.

While working on adding custom angular template rules for a project, I noticed some small errors in `docs/WRITING_CUSTOM_RULES.md`:

- In the section "Creating a TypeScript Rule" there is a heading "Step 1: Create the Rule File", however no further steps follow.\
Additionally, in the section "Creating an HTML Template Rule" such a heading is absent.\
Therefore I've removed the heading.
- In the section "Creating a TypeScript Rule" the intro mentions to "create a custom rule" vs in the section "Creating an HTML Template Rule" the intro mentions to "create a simple rule".\
I've aligned the wording in the second section.
- In the section "HTML Template Rule Tests" the provided code has two errors:
  - The `RuleTester` is missing the required `languageOptions.parser` configuration.\
    I've added the missing configuration, based on the spec files inside this repository.
  - The `endLine` and `endColumn` values for the defined `invalid` rules are incorrect.\
    I've updated the defined values.

Please review the changes and let me know if any further tweaks are needed :)