### PR TITLE
fix(eslint-plugin): [no-uncalled-signals] add check `InputSignalWithTransform`

### DIFF
--- a/packages/eslint-plugin/docs/rules/no-uncalled-signals.md
+++ b/packages/eslint-plugin/docs/rules/no-uncalled-signals.md
@@ -486,6 +486,34 @@ if (a) { }
 #### ❌ Invalid Code
 
 ```ts
+let a: InputSignalWithTransform<boolean, boolean | string>;
+if (a) { }
+    ~
+```
+
+<br>
+
+---
+
+<br>
+
+#### Default Config
+
+```json
+{
+  "rules": {
+    "@angular-eslint/no-uncalled-signals": [
+      "error"
+    ]
+  }
+}
+```
+
+<br>
+
+#### ❌ Invalid Code
+
+```ts
 let a: ModelSignal<boolean>;
 if (a) { }
     ~

--- a/packages/eslint-plugin/src/utils/signals.ts
+++ b/packages/eslint-plugin/src/utils/signals.ts
@@ -3,4 +3,5 @@ export const KNOWN_SIGNAL_TYPES: ReadonlySet<string> = new Set([
   'ModelSignal',
   'Signal',
   'WritableSignal',
+  'InputSignalWithTransform',
 ]);

--- a/packages/eslint-plugin/tests/rules/no-uncalled-signals/cases.ts
+++ b/packages/eslint-plugin/tests/rules/no-uncalled-signals/cases.ts
@@ -442,6 +442,25 @@ export const invalid: readonly InvalidTestCase<MessageIds, Options>[] = [
       },
     ],
   }),
+  convertAnnotatedSourceToFailureCase<MessageIds, Options>({
+    description: 'InputSignalWithTransform',
+    annotatedSource: `
+        let a: InputSignalWithTransform<boolean, boolean | string>;
+        if (a) { }
+            ~
+      `,
+    messageId,
+    suggestions: [
+      {
+        messageId: 'suggestCallSignal',
+        output: `
+        let a: InputSignalWithTransform<boolean, boolean | string>;
+        if (a()) { }
+            
+      `,
+      },
+    ],
+  }),
 
   convertAnnotatedSourceToFailureCase<MessageIds, Options>({
     description: 'ModelSignal',
@@ -513,6 +532,7 @@ function appendTypes(code: string): string {
       'interface Signal<T> { (): T; }',
       'interface InputSignal<T> extends Signal<T> {}',
       'interface ModelSignal<T> extends Signal<T> {}',
+      'interface InputSignalWithTransform<T, TTransform> extends Signal<T> {}',
       'interface WritableSignal<T> extends Signal<T> { set(value: T): void; }',
       'declare function effect(fn: () => void): void;',
     ]


### PR DESCRIPTION
`no-uncalled-signals` doesn't report missing signal calls when `input` use `transform`.

### Works

```typescript
  required = input(true);
  
  test(): void {
    // no-uncalled-signals: Error reported
    if (this.required) {
    ...
    }
  }
```

### Doesn't work

```typescript
  required = input(true, { transform: booleanAttribute });
  
  test(): void {
    // no-uncalled-signals: No error reported
    if (this.required) {
    ...
    }
  }
```