### PR TITLE
fix(eslint-plugin-template): [eqeqeq]  could not destructure null

### DIFF
--- a/packages/eslint-plugin-template/src/rules/eqeqeq.ts
+++ b/packages/eslint-plugin-template/src/rules/eqeqeq.ts
@@ -113,12 +113,13 @@ const getFix = ({
   sourceCode: Readonly<TSESLint.SourceCode>;
   fixer: TSESLint.RuleFixer;
 }): TSESLint.RuleFix | null => {
-  const { source, ast } = getNearestNodeFrom(
-    node,
-    isASTWithSource,
-  ) as ASTWithSource & { ast: unknown };
+  const result = getNearestNodeFrom(node, isASTWithSource) as ASTWithSource & {
+    ast: unknown;
+  };
 
-  if (!source) return null;
+  if (!result?.source) return null;
+
+  const { source, ast } = result;
 
   let startOffset = 0;
   while (!isInterpolation(ast) && isLeadingTriviaChar(source[startOffset])) {


### PR DESCRIPTION
`getNearestNodeFrom` can return `null` and thus I currently get the following error for nodes like:

```html
<div [class.foo]="items?.length == 1"></div>
```
```
Error when running ESLint: Cannot destructure property 'source' of '(0 , get_nearest_node_from_1.getNearestNodeFrom)(...)' as it is null.
Occurred while linting some.html:30
Rule: "@angular-eslint/template/eqeqeq"
```