### PR TITLE
fix(eslint-plugin): append fixes in prefer-on-push-change-detection, use-injectable-provided-in

### DIFF
--- a/packages/eslint-plugin/docs/rules/prefer-on-push-component-change-detection.md
+++ b/packages/eslint-plugin/docs/rules/prefer-on-push-component-change-detection.md
@@ -151,6 +151,35 @@ class Test {}
 #### ❌ Invalid Code
 
 ```ts
+import { Component } from '@angular/core';
+@Component({ selector: 'app-test', })
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+class Test {}
+```
+
+<br>
+
+---
+
+<br>
+
+#### Default Config
+
+```json
+{
+  "rules": {
+    "@angular-eslint/prefer-on-push-component-change-detection": [
+      "error"
+    ]
+  }
+}
+```
+
+<br>
+
+#### ❌ Invalid Code
+
+```ts
 @Component({ changeDetection: undefined })
                               ~~~~~~~~~
 class Test {}

--- a/packages/eslint-plugin/tests/rules/prefer-on-push-component-change-detection/cases.ts
+++ b/packages/eslint-plugin/tests/rules/prefer-on-push-component-change-detection/cases.ts
@@ -122,7 +122,29 @@ export const invalid: readonly InvalidTestCase<MessageIds, Options>[] = [
         output: `
       import { Component, ChangeDetectionStrategy } from '@angular/core';
       const changeDetection = 'template';
-      @Component({ changeDetection: ChangeDetectionStrategy.OnPush,[changeDetection]: '' })
+      @Component({ [changeDetection]: '', changeDetection: ChangeDetectionStrategy.OnPush })
+      
+      class Test {}
+    `,
+      },
+    ],
+  }),
+  convertAnnotatedSourceToFailureCase({
+    description:
+      'should fail if `@Component` has no `changeDetection` (trailing comma)',
+    annotatedSource: `
+      import { Component } from '@angular/core';
+      @Component({ selector: 'app-test', })
+      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      class Test {}
+    `,
+    messageId,
+    suggestions: [
+      {
+        messageId: suggestAddChangeDetectionOnPush,
+        output: `
+      import { Component, ChangeDetectionStrategy } from '@angular/core';
+      @Component({ selector: 'app-test', changeDetection: ChangeDetectionStrategy.OnPush, })
       
       class Test {}
     `,

--- a/packages/eslint-plugin/tests/rules/use-injectable-provided-in/cases.ts
+++ b/packages/eslint-plugin/tests/rules/use-injectable-provided-in/cases.ts
@@ -116,7 +116,7 @@ export const invalid: readonly InvalidTestCase<MessageIds, Options>[] = [
       messageId: suggestInjector,
       output: `
       const providedIn = 'anotherProperty';
-      @Injectable({ providedIn: '${injector}',[providedIn]: [] })
+      @Injectable({ [providedIn]: [], providedIn: '${injector}' })
       
       class Test {}
     `,

--- a/packages/utils/src/eslint-plugin/rule-fixes.ts
+++ b/packages/utils/src/eslint-plugin/rule-fixes.ts
@@ -168,8 +168,8 @@ export function getDecoratorPropertyAddFix(
     return fixer.insertTextAfterRange([initialRange + 1, endRange - 1], text);
   }
 
-  // `@Component({...})` => `@Component({changeDetection: ChangeDetectionStrategy.OnPush, ...})`
-  return fixer.insertTextBefore(properties[0], `${text},`);
+  // `@Component({...})` => `@Component({..., changeDetection: ChangeDetectionStrategy.OnPush})`
+  return fixer.insertTextAfter(getLast(properties), `, ${text}`);
 }
 
 export function getImplementsRemoveFix(


### PR DESCRIPTION
Fixes #2968.

Also affects `use-injectable-provided-in`, where it will append `providedIn` to the end of properties in `@Injectable`.
This is not great, but most injectables don't have other properties.