### PR TITLE
[wip] feat(eslint-plugin): [no-mutable-signal-values] add rule

### DIFF
--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -23,10 +23,12 @@
     "ts-api-utils": "catalog:other-runtime-dependencies"
   },
   "devDependencies": {
-    "@angular-eslint/test-utils": "workspace:*"
+    "@angular-eslint/test-utils": "workspace:*",
+    "@angular/core": "catalog:"
   },
   "peerDependencies": {
     "@typescript-eslint/utils": "^7.11.0 || ^8.0.0",
+    "@typescript-eslint/type-utils": "^7.11.0 || ^8.0.0",
     "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
     "typescript": "*"
   },

--- a/packages/eslint-plugin/src/rules/no-mutable-signal-values.ts
+++ b/packages/eslint-plugin/src/rules/no-mutable-signal-values.ts
@@ -1,0 +1,363 @@
+import {
+  getParserServices,
+  nullThrows,
+  NullThrowsReasons,
+} from '@typescript-eslint/utils/eslint-utils';
+import { createESLintRule } from '../utils/create-eslint-rule';
+import {
+  getNameOfDeclaration,
+  IndexKind,
+  isPrivateIdentifier,
+  Node,
+  Symbol,
+  SymbolFlags,
+  Type,
+} from 'typescript';
+import { isSignal } from '../utils/signals';
+import {
+  isConditionalType,
+  isIntersectionType,
+  isObjectType,
+  isPropertyReadonlyInType,
+  isSymbolFlagSet,
+  isTypeReference,
+  isUnionType,
+} from 'ts-api-utils';
+import { TSESTree } from '@typescript-eslint/utils';
+import {
+  getTypeOfPropertyOfType,
+  isTypeReadonly,
+  typeMatchesSomeSpecifier,
+} from '@typescript-eslint/type-utils';
+
+export type Options = [{ immutableTypes?: string[] }];
+export type MessageIds = 'noMutableSignalValues';
+export const RULE_NAME = 'no-mutable-signal-values';
+
+export default createESLintRule<Options, MessageIds>({
+  name: RULE_NAME,
+  meta: {
+    type: 'suggestion',
+    docs: {
+      description:
+        'Ensures that the type of a value stored in a signal is immutable',
+    },
+    schema: [
+      {
+        type: 'object',
+        properties: {
+          immutableTypes: {
+            type: 'array',
+            items: { type: 'string' },
+          },
+        },
+      },
+    ],
+    messages: {
+      noMutableSignalValues: 'Signals should only store immutable values',
+    },
+  },
+  defaultOptions: [{}],
+  create(context, [{ immutableTypes = [] }]) {
+    const services = getParserServices(context);
+    const program = services.program;
+    const checker = program.getTypeChecker();
+    const knownImmutability = new Map<Type, boolean | undefined>();
+
+    function* getSignalValueTypes(type: Type): Iterable<Type> {
+      const symbol = type.getSymbol();
+
+      if (isSignal(type, symbol)) {
+        const signalTypeArguments = isTypeReference(type)
+          ? type.typeArguments
+          : type.aliasTypeArguments;
+
+        if (signalTypeArguments && signalTypeArguments.length > 0) {
+          yield signalTypeArguments[0];
+        } else if (type.isUnionOrIntersection()) {
+          for (const part of type.types) {
+            yield* getSignalValueTypes(part);
+          }
+        }
+      }
+    }
+
+    function isImmutable(type: Type, visited?: Set<Type>): boolean | undefined {
+      // This function and the functions that it calls are based heavily off
+      // the logic in the `isTypeReadonly` function from `@typescript-eslint/type-utils`,
+      // but with some modifications to handle readonly sets, maps and arrays, and signals.
+      //
+      // https://github.com/typescript-eslint/typescript-eslint/blob/366976c4b461c48c81f1e96aec52ad2bf2e2c6b0/packages/type-utils/src/isTypeReadonly.ts
+
+      // If we have calculated the immutability of this
+      // type before, return the cached result.
+      if (knownImmutability.has(type)) {
+        return knownImmutability.get(type);
+      }
+
+      if (visited) {
+        // If we are in the process of calculating this type, then return
+        // undefined because we don't know the final result at this point.
+        if (visited.has(type)) {
+          return undefined;
+        }
+      } else {
+        visited = new Set();
+      }
+
+      const symbol = type.getSymbol();
+      if (symbol) {
+        if (
+          symbol.name === 'ReadonlyMap' ||
+          symbol.name === 'ReadonlySet' ||
+          symbol.name === 'ReadonlyArray'
+        ) {
+          // These types are readonly if their type arguments are readonly.
+          const result =
+            isTypeReference(type) &&
+            checker
+              .getTypeArguments(type)
+              .every((x) => isImmutable(x, visited));
+          knownImmutability.set(type, result);
+          return result;
+        }
+      }
+
+      // If the type is a signal, then we will consider it immutable
+      // because the signal cannot be replaced even though its value
+      // can be changed. This allows signals to contain arrays of other
+      // signals or objects that have properties that store signals.
+      // We won't check the value type of this signal because that will
+      // be checked separately when we check the signal itself.
+      if (isSignal(type, symbol)) {
+        knownImmutability.set(type, true);
+        return true;
+      }
+
+      if (immutableTypes.length > 0) {
+        // If the type has an alias symbol, check it against
+        // the types that we have been told are immutable.
+        if (type.aliasSymbol) {
+          if (immutableTypes.includes(type.aliasSymbol.getName())) {
+            knownImmutability.set(type, true);
+            return true;
+          }
+        }
+
+        if (typeMatchesSomeSpecifier(type, immutableTypes, program)) {
+          knownImmutability.set(type, true);
+          return true;
+        }
+      }
+
+      if (isUnionType(type)) {
+        // All types in a union must be immutable.
+        const result = type.types.every(
+          (t) => visited.has(t) || isImmutable(t, visited) === true,
+        );
+        knownImmutability.set(type, result);
+        return result;
+      }
+
+      if (isIntersectionType(type)) {
+        // Special case for handling arrays/tuples
+        // (as readonly arrays/tuples always have mutable methods).
+        if (
+          type.types.some(
+            (t) => checker.isArrayType(t) || checker.isTupleType(t),
+          )
+        ) {
+          const allReadonlyParts = type.types.every(
+            (t) => visited.has(t) || isImmutable(t, visited) === true,
+          );
+          knownImmutability.set(type, allReadonlyParts);
+          return allReadonlyParts;
+        }
+
+        // Normal case.
+        const result = isImmutableObject(type, visited);
+        if (result !== undefined) {
+          knownImmutability.set(type, result);
+          return result;
+        }
+      }
+
+      if (isConditionalType(type)) {
+        const result = [type.root.node.trueType, type.root.node.falseType]
+          .map(checker.getTypeFromTypeNode)
+          .every((t) => visited.has(t) || isImmutable(t, visited) === true);
+
+        knownImmutability.set(type, result);
+        return result;
+      }
+
+      // All non-object, non-intersection types are readonly.
+      // This should only be primitive types.
+      if (!isObjectType(type)) {
+        knownImmutability.set(type, true);
+        return true;
+      }
+
+      // Pure function types are readonly.
+      if (
+        type.getCallSignatures().length > 0 &&
+        type.getProperties().length === 0
+      ) {
+        knownImmutability.set(type, true);
+        return true;
+      }
+
+      knownImmutability.set(type, false);
+      return false;
+    }
+
+    function isImmutableObject(
+      type: Type,
+      visited: Set<Type>,
+    ): boolean | undefined {
+      function checkIndexSignature(kind: IndexKind): boolean | undefined {
+        const indexInfo = checker.getIndexInfoOfType(type, kind);
+        if (indexInfo) {
+          if (!indexInfo.isReadonly) {
+            return false;
+          }
+
+          if (indexInfo.type === type || visited.has(indexInfo.type)) {
+            return true;
+          }
+
+          return isImmutable(indexInfo.type, visited);
+        }
+
+        return undefined;
+      }
+
+      const properties = type.getProperties();
+      if (properties.length > 0) {
+        // ensure the properties are marked as readonly
+        for (const property of properties) {
+          if (
+            property.valueDeclaration != null &&
+            hasSymbol(property.valueDeclaration) &&
+            isSymbolFlagSet(
+              property.valueDeclaration.symbol,
+              SymbolFlags.Method,
+            )
+          ) {
+            continue;
+          }
+
+          const declarations = property.getDeclarations();
+          const lastDeclaration = declarations?.at(-1);
+          if (
+            lastDeclaration != null &&
+            hasSymbol(lastDeclaration) &&
+            isSymbolFlagSet(lastDeclaration.symbol, SymbolFlags.Method)
+          ) {
+            continue;
+          }
+
+          if (
+            isPropertyReadonlyInType(type, property.getEscapedName(), checker)
+          ) {
+            continue;
+          }
+
+          const name = getNameOfDeclaration(property.valueDeclaration);
+          if (name && isPrivateIdentifier(name)) {
+            continue;
+          }
+
+          return false;
+        }
+
+        // all properties were readonly
+        // now ensure that all of the values are readonly also.
+
+        // do this after checking property readonly-ness as a perf optimization,
+        // as we might be able to bail out early due to a mutable property before
+        // doing this deep, potentially expensive check.
+        for (const property of properties) {
+          const propertyType = nullThrows(
+            getTypeOfPropertyOfType(checker, type, property),
+            NullThrowsReasons.MissingToken(
+              `property "${property.name}"`,
+              'type',
+            ),
+          );
+
+          // handle recursive types.
+          // we only need this simple check, because a mutable recursive type will break via the above prop readonly check
+          if (visited.has(propertyType)) {
+            continue;
+          }
+
+          if (isImmutable(propertyType, visited) === false) {
+            return false;
+          }
+        }
+      }
+
+      const isStringIndexSigReadonly = checkIndexSignature(IndexKind.String);
+      if (isStringIndexSigReadonly === false) {
+        return false;
+      }
+
+      const isNumberIndexSigReadonly = checkIndexSignature(IndexKind.Number);
+      if (isNumberIndexSigReadonly === false) {
+        return false;
+      }
+
+      return true;
+    }
+
+    function hasSymbol(node: Node): node is { symbol: Symbol } & Node {
+      return Object.hasOwn(node, 'symbol');
+    }
+
+    return {
+      Identifier(node) {
+        switch (node.parent.type) {
+          case TSESTree.AST_NODE_TYPES.ImportSpecifier:
+          case TSESTree.AST_NODE_TYPES.TSTypeReference:
+            return;
+        }
+
+        const type = services.getTypeAtLocation(node);
+        for (const valueType of getSignalValueTypes(type)) {
+          if (
+            !isTypeReadonly(program, valueType, {
+              allow: immutableTypes,
+              treatMethodsAsReadonly: true,
+            })
+          ) {
+            // if (!isImmutable(valueType)) {
+            // If the identifier has a type annotation, then report the
+            // problem on that. If it doesn't, then see if we can find where
+            // the associated type annotation is. If we can't find a type
+            // annotation, then we'll just report the problem on the identifier.
+            let typeNode = node.typeAnnotation?.typeAnnotation;
+            if (!typeNode) {
+              switch (node.parent.type) {
+                case TSESTree.AST_NODE_TYPES.TSPropertySignature:
+                  typeNode = node.parent.typeAnnotation?.typeAnnotation;
+                  break;
+                case TSESTree.AST_NODE_TYPES.PropertyDefinition:
+                  typeNode = node.parent.typeAnnotation?.typeAnnotation;
+                  break;
+              }
+            }
+            context.report({
+              node: typeNode ?? node,
+              messageId: 'noMutableSignalValues',
+            });
+          }
+        }
+      },
+    };
+  },
+});
+
+export const RULE_DOCS_EXTENSION = {
+  rationale: `Signal values should only be updated using the \`.set(value)\` or \`.update(callback)\` methods. Storing a mutable value in a signal allows it to be updated directly, which breaks the signal's change detection.`,
+};

--- a/packages/eslint-plugin/src/rules/no-uncalled-signals.ts
+++ b/packages/eslint-plugin/src/rules/no-uncalled-signals.ts
@@ -5,7 +5,7 @@ import {
   TSESTree,
 } from '@typescript-eslint/utils';
 import { createESLintRule } from '../utils/create-eslint-rule';
-import { KNOWN_SIGNAL_TYPES } from '../utils/signals';
+import { isSignal } from '../utils/signals';
 
 export type Options = [];
 export type MessageIds = 'noUncalledSignals' | 'suggestCallSignal';
@@ -52,18 +52,8 @@ export default createESLintRule<Options, MessageIds>({
     function checkForUncalledSignal(node: TSESTree.Node): void {
       const type = services.getTypeAtLocation(node);
       const symbol = type.getSymbol();
-      let isSignal = symbol && KNOWN_SIGNAL_TYPES.has(symbol.name);
 
-      // If the type is not a known signal type, but it has an alias
-      // symbol, then check if that alias symbol is a known signal type.
-      // The `Signal` type will fall under this category, because it is
-      // defined as a type alias. Other signal types like `InputSignal`
-      // won't match here, because they are defined as interfaces.
-      if (!isSignal && type.aliasSymbol) {
-        isSignal = KNOWN_SIGNAL_TYPES.has(type.aliasSymbol.name);
-      }
-
-      if (isSignal) {
+      if (isSignal(type, symbol)) {
         context.report({
           node,
           messageId: 'noUncalledSignals',

--- a/packages/eslint-plugin/src/utils/signals.ts
+++ b/packages/eslint-plugin/src/utils/signals.ts
@@ -1,3 +1,5 @@
+import { Type, Symbol } from 'typescript';
+
 export const KNOWN_SIGNAL_TYPES: ReadonlySet<string> = new Set([
   'InputSignal',
   'ModelSignal',
@@ -5,3 +7,20 @@ export const KNOWN_SIGNAL_TYPES: ReadonlySet<string> = new Set([
   'WritableSignal',
   'InputSignalWithTransform',
 ]);
+
+export function isSignal(type: Type, symbol: Symbol | undefined): boolean {
+  if (symbol && KNOWN_SIGNAL_TYPES.has(symbol.name)) {
+    return true;
+  }
+
+  // If the type has an alias symbol, then check if that
+  // alias symbol is a known signal type. The `Signal` type
+  // will fall under this category, because it is defined
+  // as a type alias. Other signal types like `InputSignal`
+  // won't match here, because they are defined as interfaces.
+  if (type.aliasSymbol) {
+    return KNOWN_SIGNAL_TYPES.has(type.aliasSymbol.name);
+  }
+
+  return false;
+}

--- a/packages/eslint-plugin/tests/rules/no-mutable-signal-values/cases.ts
+++ b/packages/eslint-plugin/tests/rules/no-mutable-signal-values/cases.ts
@@ -1,0 +1,315 @@
+import { convertAnnotatedSourceToFailureCase } from '@angular-eslint/test-utils';
+import type {
+  InvalidTestCase,
+  ValidTestCase,
+} from '@typescript-eslint/rule-tester';
+import type {
+  MessageIds,
+  Options,
+} from '../../../src/rules/no-mutable-signal-values';
+import { addSignalImports } from '../../test-utils/signal-helpers';
+
+const messageId: MessageIds = 'noMutableSignalValues';
+
+export const valid: readonly (string | ValidTestCase<Options>)[] = [
+  // Primitive types.
+  'let a: Signal<number>;',
+  'let a: Signal<string>;',
+  'let a: Signal<boolean>;',
+  'let a: Signal<bigint>;',
+  'let a: Signal<null>;',
+  'let a: Signal<undefined>;',
+  'let a: Signal<1>;',
+  'let a: Signal<"a">;',
+  'let a: Signal<true>;',
+  'let a: Signal<1n>;',
+  `
+    enum Foo { A, B };
+    let a: Signal<Foo>;
+  `,
+  `
+    const enum Foo { A, B };
+    let a: Signal<Foo>;
+  `,
+
+  // Readonly Arrays.
+  'let a: Signal<readonly number[]>;',
+  'let a: Signal<ReadonlyArray<number>>;',
+  'let a: Signal<readonly (number | string)[]>;',
+  'let a: Signal<readonly [r: number, g: number, b: number]>;',
+
+  // ReadonlySet and ReadonlyMap.
+  'let a: Signal<ReadonlySet<number>>;',
+  'let a: Signal<ReadonlyMap<number, number>>;',
+  `
+    type ReadonlySetOfNumber = ReadonlySet<number>;
+    let a: Signal<ReadonlySetOfNumber>;
+  `,
+  `
+    type ReadonlyMapOfNumberToNumber = ReadonlyMap<number, number>;
+    let a: Signal<ReadonlyMapOfNumberToNumber>;
+  `,
+
+  // Configured immutable types.
+  {
+    code: `
+      class Foo {}
+      let a: Signal<Foo>;
+    `,
+    options: [{ immutableTypes: ['Foo', 'Bar'] }],
+  } satisfies ValidTestCase<Options>,
+  {
+    code: `
+      interface Foo {}
+      let a: Signal<Foo>;
+    `,
+    options: [{ immutableTypes: ['Foo', 'Bar'] }],
+  } satisfies ValidTestCase<Options>,
+
+  // Immutable object literals.
+  'let a: Signal<{ readonly b: number }>;',
+  'let a: Signal<{ readonly b: number; readonly c: string }>;',
+  'let a: Signal<{ readonly b: number; readonly c: { readonly d: string }}>;',
+  'let a: Signal<Readonly<{ b: number; c: { readonly d: string }}>>;',
+
+  // Immutable interfaces.
+  `
+    interface Foo { readonly a: number }
+    let a: Signal<Foo>;
+  `,
+  `
+    interface Foo { readonly a: number; readonly b: Bar; }
+    interface Bar { readonly c: number; }
+    let a: Signal<Foo>;
+  `,
+
+  // Unions.
+  'let a: Signal<number | null>;',
+  'let a: Signal<number | undefined>;',
+  'let a: Signal<number | string>;',
+  'let a: Signal<number | readonly number[]>;',
+  'let a: Signal<number | { readonly b: number; readonly c: number }>;',
+  `
+    type Foo = 'a' | 'b';
+    let a: Signal<Foo>;
+  `,
+
+  // Nested signals.
+  'let a: Signal<Signal<number>>;',
+  'let a: Signal<readonly Signal<number>[]>;',
+  `
+    interface Foo { readonly a: Signal<number>; }
+    let a: Signal<Foo>;
+  `,
+
+  // Other signal types.
+  'let a: InputSignal<number>;',
+  'let a: ModelSignal<number>;',
+  'let a: WritableSignal<number>;',
+  'let a: InputSignalWithTransform<number, string>;',
+
+  // Inferred signal types.
+  'let a = signal(1);',
+  'let a = input(1);',
+
+  // Signal properties.
+  'class Foo { readonly a: Signal<number>; }',
+  'interface Foo { readonly a: Signal<number>; }',
+  'type Foo = { readonly a: Signal<number>; }',
+].map((test) =>
+  typeof test === 'string'
+    ? { name: test, code: addSignalImports(test) }
+    : { ...test, name: test.code, code: addSignalImports(test.code) },
+);
+
+export const invalid: readonly InvalidTestCase<MessageIds, Options>[] = [
+  convertAnnotatedSourceToFailureCase<MessageIds, Options>({
+    description: 'should fail if signal value is mutable array',
+    annotatedSource: `
+      let a: Signal<number[]>;
+             ~~~~~~~~~~~~~~~~
+      `,
+    messageId,
+  }),
+  convertAnnotatedSourceToFailureCase<MessageIds, Options>({
+    description:
+      'should fail if signal value is immutable array with mutable values',
+    annotatedSource: `
+      let a: Signal<readonly { a: number }[]>;
+             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      `,
+    messageId,
+  }),
+  convertAnnotatedSourceToFailureCase<MessageIds, Options>({
+    description: 'should fail if signal value is Set',
+    annotatedSource: `
+      let a: Signal<Set<number>>;
+             ~~~~~~~~~~~~~~~~~~~
+      `,
+    messageId,
+  }),
+  convertAnnotatedSourceToFailureCase<MessageIds, Options>({
+    description:
+      'should fail if signal value is ReadonlySet with mutable values',
+    annotatedSource: `
+      let a: Signal<ReadonlySet<{ a: number }>>;
+             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      `,
+    messageId,
+  }),
+  convertAnnotatedSourceToFailureCase<MessageIds, Options>({
+    description: 'should fail if signal value is Map',
+    annotatedSource: `
+      let a: Signal<Map<number, string>>;
+             ~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      `,
+    messageId,
+  }),
+  convertAnnotatedSourceToFailureCase<MessageIds, Options>({
+    description: 'should fail if signal value is ReadonlyMap with mutable keys',
+    annotatedSource: `
+      let a: Signal<ReadonlyMap<{ a: number }, number>>;
+             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      `,
+    messageId,
+  }),
+  convertAnnotatedSourceToFailureCase<MessageIds, Options>({
+    description:
+      'should fail if signal value is ReadonlyMap with mutable values',
+    annotatedSource: `
+      let a: Signal<ReadonlyMap<number, { a: number }>>;
+             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      `,
+    messageId,
+  }),
+  convertAnnotatedSourceToFailureCase<MessageIds, Options>({
+    description: 'should fail if signal value is mutable object literal',
+    annotatedSource: `
+      let a: Signal<{ a: number }>;
+             ~~~~~~~~~~~~~~~~~~~~~
+      `,
+    messageId,
+  }),
+  convertAnnotatedSourceToFailureCase<MessageIds, Options>({
+    description:
+      'should fail if signal value is object literal that is immutable at the top level but mutable at deeper level',
+    annotatedSource: `
+      let a: Signal<{ readonly a: { readonly b: { c: number }}}>;
+             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      `,
+    messageId,
+  }),
+  convertAnnotatedSourceToFailureCase<MessageIds, Options>({
+    description: 'should fail if signal value is mutable class',
+    annotatedSource: `
+      class Foo { a: number };
+      let a: Signal<Foo>;
+             ~~~~~~~~~~~
+      `,
+    messageId,
+  }),
+  convertAnnotatedSourceToFailureCase<MessageIds, Options>({
+    description: 'should fail if signal value is mutable interface',
+    annotatedSource: `
+      interface Foo { a: number };
+      let a: Signal<Foo>;
+             ~~~~~~~~~~~
+      `,
+    messageId,
+  }),
+  convertAnnotatedSourceToFailureCase<MessageIds, Options>({
+    description: 'should fail if signal value is mutable type',
+    annotatedSource: `
+      type Foo = { a: number };
+      let a: Signal<Foo>;
+             ~~~~~~~~~~~
+      `,
+    messageId,
+  }),
+  convertAnnotatedSourceToFailureCase<MessageIds, Options>({
+    description: 'should fail if signal value is union with mutable type',
+    annotatedSource: `
+      let a: Signal<number | { a: number }>;
+             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      `,
+    messageId,
+  }),
+  convertAnnotatedSourceToFailureCase<MessageIds, Options>({
+    description:
+      'should fail if signal value is class with mutable parameter properties',
+    annotatedSource: `
+      class Foo {
+        constructor(public a: number) {}
+      }
+      let a: Signal<Foo>;
+             ~~~~~~~~~~~
+      `,
+    messageId,
+  }),
+  convertAnnotatedSourceToFailureCase<MessageIds, Options>({
+    description: 'should fail if signal value is class with methods',
+    annotatedSource: `
+      class Foo {
+        public foo() {}
+      }
+      let a: Signal<Foo>;
+             ~~~~~~~~~~~
+      `,
+    messageId,
+  }),
+  convertAnnotatedSourceToFailureCase<MessageIds, Options>({
+    description:
+      'should fail if signal value is class that is not declared as immutable',
+    annotatedSource: `
+      class Foo { a: number; }
+      class Bar { b: number; }
+      let a: Signal<Foo>;
+             ~~~~~~~~~~~
+      `,
+    options: [{ immutableTypes: ['Bar'] }],
+    messageId,
+  }),
+  convertAnnotatedSourceToFailureCase<MessageIds, Options>({
+    description: 'should fail if signal value is interface with methods',
+    annotatedSource: `
+      interface Foo { a(): void; }
+      let a: Signal<Foo>;
+             ~~~~~~~~~~~
+      `,
+    messageId,
+  }),
+  convertAnnotatedSourceToFailureCase<MessageIds, Options>({
+    description: 'should fail if inferred signal type has immutable value',
+    annotatedSource: `
+      let a = signal({ a: 1 });
+          ~
+      `,
+    messageId,
+  }),
+  convertAnnotatedSourceToFailureCase<MessageIds, Options>({
+    description: 'should check class properties',
+    annotatedSource: `
+      class Foo {
+        protected readonly a: Signal<number[]>;
+                              ~~~~~~~~~~~~~~~~
+      }
+      `,
+    messageId,
+  }),
+  convertAnnotatedSourceToFailureCase<MessageIds, Options>({
+    description: 'should check interface properties',
+    annotatedSource: `
+      interface Foo {
+        readonly a: Signal<number[]>;
+                    ~~~~~~~~~~~~~~~~
+      }
+      `,
+    messageId,
+  }),
+].map((test) => ({
+  ...test,
+  code: addSignalImports(test.code),
+  errors: test.errors.map((error) => ({
+    ...error,
+  })),
+}));

--- a/packages/eslint-plugin/tests/rules/no-mutable-signal-values/project/file.ts
+++ b/packages/eslint-plugin/tests/rules/no-mutable-signal-values/project/file.ts
@@ -1,0 +1,1 @@
+// Used for type-checked tests.

--- a/packages/eslint-plugin/tests/rules/no-mutable-signal-values/project/tsconfig.json
+++ b/packages/eslint-plugin/tests/rules/no-mutable-signal-values/project/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "compilerOptions": {
+    "strict": true
+  },
+  "include": ["file.ts"]
+}

--- a/packages/eslint-plugin/tests/rules/no-mutable-signal-values/spec.ts
+++ b/packages/eslint-plugin/tests/rules/no-mutable-signal-values/spec.ts
@@ -1,0 +1,18 @@
+import { RuleTester } from '@angular-eslint/test-utils';
+import path from 'node:path';
+import rule, { RULE_NAME } from '../../../src/rules/no-mutable-signal-values';
+import { invalid, valid } from './cases';
+
+const ruleTester = new RuleTester({
+  languageOptions: {
+    parserOptions: {
+      projectService: true,
+      tsconfigRootDir: path.join(__dirname, 'project'),
+    },
+  },
+});
+
+ruleTester.run(RULE_NAME, rule, {
+  valid,
+  invalid,
+});

--- a/packages/eslint-plugin/tests/rules/no-uncalled-signals/cases.ts
+++ b/packages/eslint-plugin/tests/rules/no-uncalled-signals/cases.ts
@@ -3,6 +3,7 @@ import type {
   InvalidTestCase,
   ValidTestCase,
 } from '@typescript-eslint/rule-tester';
+import { addSignalImports } from '../../test-utils/signal-helpers';
 import { MessageIds, Options } from '../../../src/rules/no-uncalled-signals';
 
 const messageId: MessageIds = 'noUncalledSignals';
@@ -187,7 +188,7 @@ export const valid: readonly (string | ValidTestCase<Options>)[] = [
       true && ((x) => b.c.set(x))(true);
     }
   `,
-].map(appendTypes);
+].map(addSignalImports);
 
 export const invalid: readonly InvalidTestCase<MessageIds, Options>[] = [
   convertAnnotatedSourceToFailureCase<MessageIds, Options>({
@@ -613,29 +614,13 @@ export const invalid: readonly InvalidTestCase<MessageIds, Options>[] = [
   ),
 ].map((test) => ({
   ...test,
-  code: appendTypes(test.code),
+  code: addSignalImports(test.code),
   errors: test.errors.map((error) => ({
     ...error,
     suggestions: error.suggestions?.map((suggestion) => ({
       ...suggestion,
-      output: appendTypes(suggestion.output),
+      output: addSignalImports(suggestion.output),
     })),
   })),
+  options: [],
 }));
-
-function appendTypes(code: string): string {
-  // Exclude the types from the generated docs because they
-  // are standard Angular types and only need to be defined
-  // so that the type symbols in the tests are correct.
-  /* istanbul ignore next */
-  if (process.env.GENERATING_RULE_DOCS === '1') {
-    return code;
-  }
-
-  // Put the given code on the same line as the import so that the tests don't have
-  // to adjust the line numbers to account for the code that we insert at the start.
-  return (
-    'import { effect, InputSignal, InputSignalWithTransform, ModelSignal, signal, Signal, WritableSignal } from "@angular/core";' +
-    code
-  );
-}

--- a/packages/eslint-plugin/tests/test-utils/signal-helpers.ts
+++ b/packages/eslint-plugin/tests/test-utils/signal-helpers.ts
@@ -1,0 +1,20 @@
+export function addSignalImports(code: string) {
+  // Exclude the types from the generated docs because they
+  // are standard Angular types and only need to be defined
+  // so that the type symbols in the tests are correct.
+  /* v8 ignore if -- @preserve */
+  if (process.env.GENERATING_RULE_DOCS === '1') {
+    return code;
+  }
+
+  // The code we have been given should have already been parsed and the line
+  // numbers of any expected errors extracted. That means that when we insert
+  // the import statement, we cannot cause the line numbers or column numbers
+  // of any of the code to change. The code should start with a new line, so we
+  // can put the import statement at the very start without a trailing new line
+  // and that won't affect the line or column numbers of any of the given code.
+  return (
+    'import { effect, InputSignal, InputSignalWithTransform, ModelSignal, signal, Signal, WritableSignal } from "@angular/core";' +
+    code
+  );
+}

--- a/packages/eslint-plugin/tsconfig.spec.json
+++ b/packages/eslint-plugin/tsconfig.spec.json
@@ -13,7 +13,8 @@
     "**/*.spec.js",
     "**/*.spec.jsx",
     "**/*.d.ts",
-    "tests/rules/**/*.ts"
+    "tests/rules/**/*.ts",
+    "tests/test-utils/**/*.ts"
   ],
   "references": [
     {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,6 +12,9 @@ catalogs:
     '@angular/compiler':
       specifier: 21.2.2
       version: 21.2.2
+    '@angular/core':
+      specifier: 21.2.2
+      version: 21.2.2
     '@commitlint/cli':
       specifier: 20.4.3
       version: 20.4.3
@@ -437,6 +440,9 @@ importers:
       '@angular-eslint/utils':
         specifier: workspace:*
         version: link:../utils
+      '@typescript-eslint/type-utils':
+        specifier: ^7.11.0 || ^8.0.0
+        version: 8.56.1(eslint@10.0.3(jiti@2.6.1))(typescript@5.9.3)
       '@typescript-eslint/utils':
         specifier: ^7.11.0 || ^8.0.0
         version: 8.56.1(eslint@10.0.3(jiti@2.6.1))(typescript@5.9.3)
@@ -453,6 +459,9 @@ importers:
       '@angular-eslint/test-utils':
         specifier: workspace:*
         version: link:../test-utils
+      '@angular/core':
+        specifier: 'catalog:'
+        version: 21.2.2(@angular/compiler@21.2.2)(rxjs@7.8.2)
 
   packages/eslint-plugin-template:
     dependencies:
@@ -677,6 +686,19 @@ packages:
   '@angular/compiler@21.2.2':
     resolution: {integrity: sha512-k7P0EH8I/Iwf2uRalSqhfokFbItTwdH7CmBJ7RKTRIH4FcrQcnqHetNKUMCOYXZtnlHIAnTpG+C+T4+6GTpYFg==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  '@angular/core@21.2.2':
+    resolution: {integrity: sha512-ljiyiFjR6dgK27CNlOcMrjsDPYKFf2Rl89WLwGEGMOj0cJg/PSLQqpW/fbSkSB3SDgwG/WhXQ4Wrw525OKMupg==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+    peerDependencies:
+      '@angular/compiler': 21.2.2
+      rxjs: ^6.5.3 || ^7.4.0
+      zone.js: ~0.15.0 || ~0.16.0
+    peerDependenciesMeta:
+      '@angular/compiler':
+        optional: true
+      zone.js:
+        optional: true
 
   '@apidevtools/json-schema-ref-parser@11.9.3':
     resolution: {integrity: sha512-60vepv88RwcJtSHrD6MjIL6Ta3SOYbgfnkHb+ppAVK+o9mXprRtulx7VlRl3lN3bbvysAfCS7WMVfhUYemB0IQ==}
@@ -6994,6 +7016,13 @@ snapshots:
   '@angular/compiler@21.2.2':
     dependencies:
       tslib: 2.8.1
+
+  '@angular/core@21.2.2(@angular/compiler@21.2.2)(rxjs@7.8.2)':
+    dependencies:
+      rxjs: 7.8.2
+      tslib: 2.8.1
+    optionalDependencies:
+      '@angular/compiler': 21.2.2
 
   '@apidevtools/json-schema-ref-parser@11.9.3':
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,6 +3,7 @@ packages:
 catalog:
   '@angular/cli': '21.2.1'
   '@angular/compiler': '21.2.2'
+  '@angular/core': '21.2.2'
   '@commitlint/cli': '20.4.3'
   '@commitlint/config-conventional': '20.4.3'
   '@eslint/core': '1.1.1'


### PR DESCRIPTION
This is an alternative approach #2890. It still requires work, but I thought I'd get some feedback on this approach before I go any further.

Rather than checking that the value of a signal is not mutated (it can be difficult to keep track of where signal values are assigned), this approach checks that the _type_ of value stored in a signal is immutable.

Determining if a type is immutable is quite complex. Thankfully, `typescript-eslint` has a helper function called [`isTypeReadonly`](https://github.com/typescript-eslint/typescript-eslint/blob/366976c4b461c48c81f1e96aec52ad2bf2e2c6b0/packages/type-utils/src/isTypeReadonly.ts). _Unfortunately_, it doesn't quite handle all types that I think it should (see https://github.com/typescript-eslint/typescript-eslint/issues/8013 as an example).

So the option is to accept those limitations and end up with false positives or false negatives, or rewrite that function. I've partially implemented that function as `isImmutable`, but the rule is currently using the `isTypeReadonly`.