### PR TITLE
fix(schematics): sync application schema with upstream @schematics/angular

### DIFF
--- a/packages/schematics/src/application/schema.json
+++ b/packages/schematics/src/application/schema.json
@@ -21,13 +21,13 @@
       "x-prompt": "What name would you like to use for the application?"
     },
     "inlineStyle": {
-      "description": "Include the styles for the root component directly within the `app.component.ts` file. Only CSS styles can be included inline. By default, a separate stylesheet file (e.g., `app.component.css`) is created.",
+      "description": "Include the styles for the root component directly within the `app.ts` file. Only CSS styles can be included inline. By default, a separate stylesheet file (e.g., `app.css`) is created.",
       "type": "boolean",
       "alias": "s",
       "x-user-analytics": "ep.ng_inline_style"
     },
     "inlineTemplate": {
-      "description": "Include the HTML template for the root component directly within the `app.component.ts` file. By default, a separate template file (e.g., `app.component.html`) is created.",
+      "description": "Include the HTML template for the root component directly within the `app.ts` file. By default, a separate template file (e.g., `app.html`) is created.",
       "type": "boolean",
       "alias": "t",
       "x-user-analytics": "ep.ng_inline_template"


### PR DESCRIPTION
The application schema.json is regenerated from @schematics/angular during the schematics package build. Upstream now describes inline styles/templates using the 2025 file-naming style (app.ts/app.html/app.css), so every `pnpm install` was producing a working-tree diff and failing `check-clean-workspace-after-install`.
