### PR TITLE
no-implicit-take-until-destroyed introduced false-negatives

### DIFF
--- a/packages/eslint-plugin/tests/rules/no-implicit-take-until-destroyed/cases.ts
+++ b/packages/eslint-plugin/tests/rules/no-implicit-take-until-destroyed/cases.ts
@@ -324,4 +324,26 @@ export const invalid: readonly InvalidTestCase<MessageIds, Options>[] = [
     `,
     messageId,
   }),
+  convertAnnotatedSourceToFailureCase({
+    description:
+      'should fail in method called both from constructor and from not constructor',
+    annotatedSource: `
+      @Component()
+      class Test {
+        constructor() {
+          this.loadData();
+        }
+
+        ngOnInit() {
+          this.loadData();
+        }
+
+        loadData() {
+          this.data$.pipe(takeUntilDestroyed()).subscribe();
+                          ~~~~~~~~~~~~~~~~~~~~
+        }
+      }
+    `,
+    messageId,
+  }),
 ];


### PR DESCRIPTION
@pierluigilenoci, @JamesHenry, the very recently merged PR #3011 fixed the false-positive from no-implicit-take-until-destroyed, that [I originally reported](https://github.com/angular-eslint/angular-eslint/pull/3011). Unfortunately it also introduces false-negatives when a `takeUntilDestroyed()` is part of a method that is called _both_ by the constructor and another (public) method.

This PR adds a failing test cases that prove the introduction of false-negatives.

I would argue that false-negative is worse than false-positive, because false-positives might be workaround-ed, but not false-negatives, since we are not even aware of them. IMHO the PR #3011 should either be entirely reverted, or thoroughly completed.