### PR TITLE
fix: add npm support metadata for eslint plugins

### DIFF
--- a/packages/eslint-plugin-template/package.json
+++ b/packages/eslint-plugin-template/package.json
@@ -10,6 +10,10 @@
     "url": "https://github.com/angular-eslint/angular-eslint.git",
     "directory": "packages/eslint-plugin-template"
   },
+  "homepage": "https://github.com/angular-eslint/angular-eslint#readme",
+  "bugs": {
+    "url": "https://github.com/angular-eslint/angular-eslint/issues"
+  },
   "files": [
     "dist",
     "!**/*.tsbuildinfo",

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -10,6 +10,10 @@
     "url": "https://github.com/angular-eslint/angular-eslint.git",
     "directory": "packages/eslint-plugin"
   },
+  "homepage": "https://github.com/angular-eslint/angular-eslint#readme",
+  "bugs": {
+    "url": "https://github.com/angular-eslint/angular-eslint/issues"
+  },
   "files": [
     "dist",
     "!**/*.tsbuildinfo",


### PR DESCRIPTION
## Summary

- Add homepage metadata to @angular-eslint/eslint-plugin and @angular-eslint/eslint-plugin-template.
- Add bugs.url metadata pointing to the project issue tracker for both packages.
- Leave runtime code, dependencies, exports, and package entrypoints unchanged.

## Why

The current published npm metadata for @angular-eslint/eslint-plugin@22.0.0 and @angular-eslint/eslint-plugin-template@22.0.0 exposes repository metadata, while homepage and bugs are absent. Adding these standard npm fields helps package consumers and metadata tools route users to the project documentation and issue tracker.

## Validation

```sh
npm view @angular-eslint/eslint-plugin@22.0.0 name version homepage repository bugs deprecated dist.tarball --json
npm view @angular-eslint/eslint-plugin-template@22.0.0 name version homepage repository bugs deprecated dist.tarball --json
node metadata smoke for both package manifests
node package.json parse check for both package manifests
npm pack --dry-run --ignore-scripts ./packages/eslint-plugin
npm pack --dry-run --ignore-scripts ./packages/eslint-plugin-template
git diff --check
```
