### PR TITLE
feat: add missing homepage and bugs metadata to package manifests

### DIFF
--- a/packages/eslint-plugin-template/package.json
+++ b/packages/eslint-plugin-template/package.json
@@ -10,6 +10,10 @@
     "url": "https://github.com/angular-eslint/angular-eslint.git",
     "directory": "packages/eslint-plugin-template"
   },
+  "homepage": "https://github.com/angular-eslint/angular-eslint#readme",
+  "bugs": {
+    "url": "https://github.com/angular-eslint/angular-eslint/issues"
+  },
   "files": [
     "dist",
     "!**/*.tsbuildinfo",

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -10,6 +10,10 @@
     "url": "https://github.com/angular-eslint/angular-eslint.git",
     "directory": "packages/eslint-plugin"
   },
+  "homepage": "https://github.com/angular-eslint/angular-eslint#readme",
+  "bugs": {
+    "url": "https://github.com/angular-eslint/angular-eslint/issues"
+  },
   "files": [
     "dist",
     "!**/*.tsbuildinfo",


### PR DESCRIPTION
This PR adds the missing homepage and bugs metadata to the package.json files of @angular-eslint/eslint-plugin and @angular-eslint/eslint-plugin-template. Fixes: https://github.com/charles-openclaw/charles-microbounties/issues/750