### PR TITLE
chore: add schematics package bugs metadata

### DIFF
--- a/packages/schematics/package.json
+++ b/packages/schematics/package.json
@@ -10,6 +10,9 @@
     "url": "https://github.com/angular-eslint/angular-eslint.git",
     "directory": "packages/schematics"
   },
+  "bugs": {
+    "url": "https://github.com/angular-eslint/angular-eslint/issues"
+  },
   "files": [
     "dist",
     "!**/*.tsbuildinfo",


### PR DESCRIPTION
## Summary
- add `bugs.url` metadata for the published `@angular-eslint/schematics` package

## Validation
- `node -e "const p=require('./packages/schematics/package.json'); if(p.name!=='@angular-eslint/schematics'||p.bugs.url!=='https://github.com/angular-eslint/angular-eslint/issues') process.exit(1); console.log(p.name, p.version, p.bugs.url)"`
- `git diff --check`