### PR TITLE
fix: add missing metadata fields to package.json

### DIFF
--- a/packages/schematics/package.json
+++ b/packages/schematics/package.json
@@ -1,6 +1,9 @@
 {
   "name": "@angular-eslint/schematics",
   "version": "22.0.0",
+  "bugs": {
+    "url": "https://github.com/angular-eslint/angular-eslint/issues"
+  },
   "description": "Angular Schematics for angular-eslint",
   "license": "MIT",
   "main": "dist/index.js",


### PR DESCRIPTION
Adds missing `bugs` metadata to `packages/schematics/package.json`.

Fixes npm tooling unable to resolve package metadata.