### PR TITLE
feat(eslint-plugin-template): [no-inline-styles] allow [style] bindings via allowBindToStyle

### DIFF
--- a/packages/eslint-plugin-template/docs/rules/no-inline-styles.md
+++ b/packages/eslint-plugin-template/docs/rules/no-inline-styles.md
@@ -23,7 +23,7 @@ Disallows the use of inline styles in HTML templates
 
 ## Rationale
 
-Inline styles in templates (style attribute, ngStyle directive, [style] object/map bindings, or [style.property] bindings) make it difficult to maintain consistent styling across an application and can violate Content Security Policy (CSP) restrictions. Styles should be defined in component stylesheets or CSS classes where they can be managed centrally, reused, cached by browsers, and easily modified. Inline styles also mix presentation concerns with template structure, making templates harder to read. Using CSS classes with [class] or [ngClass] bindings provides the same dynamic styling capabilities while keeping styles organized and maintainable. This rule can be configured to allow ngStyle, [style] object/map bindings, or style property bindings if needed for specific use cases.
+Inline styles in templates (style attribute, ngStyle directive, [style] bindings, or [style.property] bindings) make it difficult to maintain consistent styling across an application and can violate Content Security Policy (CSP) restrictions. Styles should be defined in component stylesheets or CSS classes where they can be managed centrally, reused, cached by browsers, and easily modified. Inline styles also mix presentation concerns with template structure, making templates harder to read. Using CSS classes with [class] or [ngClass] bindings provides the same dynamic styling capabilities while keeping styles organized and maintainable. This rule can be configured to allow ngStyle, [style] bindings, or style property bindings if needed for specific use cases.
 
 <br>
 
@@ -44,7 +44,7 @@ interface Options {
   /**
    * Default: `false`
    */
-  allowStyleObjectBinding?: boolean;
+  allowStyleBinding?: boolean;
 }
 
 ```
@@ -354,7 +354,7 @@ interface Options {
     "@angular-eslint/template/no-inline-styles": [
       "error",
       {
-        "allowStyleObjectBinding": true
+        "allowStyleBinding": true
       }
     ]
   }
@@ -870,7 +870,7 @@ interface Options {
     "@angular-eslint/template/no-inline-styles": [
       "error",
       {
-        "allowStyleObjectBinding": true
+        "allowStyleBinding": true
       }
     ]
   }
@@ -899,7 +899,7 @@ interface Options {
     "@angular-eslint/template/no-inline-styles": [
       "error",
       {
-        "allowStyleObjectBinding": true
+        "allowStyleBinding": true
       }
     ]
   }
@@ -912,6 +912,35 @@ interface Options {
 
 ```html
 <input [style]="styleObject">
+```
+
+<br>
+
+---
+
+<br>
+
+#### Custom Config
+
+```json
+{
+  "rules": {
+    "@angular-eslint/template/no-inline-styles": [
+      "error",
+      {
+        "allowStyleBinding": true
+      }
+    ]
+  }
+}
+```
+
+<br>
+
+#### ✅ Valid Code
+
+```html
+<input [style]="'border: 1px solid black;'">
 ```
 
 <br>
@@ -960,7 +989,7 @@ interface Options {
       {
         "allowNgStyle": true,
         "allowBindToStyle": true,
-        "allowStyleObjectBinding": true
+        "allowStyleBinding": true
       }
     ]
   }

--- a/packages/eslint-plugin-template/docs/rules/no-inline-styles.md
+++ b/packages/eslint-plugin-template/docs/rules/no-inline-styles.md
@@ -23,7 +23,7 @@ Disallows the use of inline styles in HTML templates
 
 ## Rationale
 
-Inline styles in templates (style attribute, ngStyle directive, or [style.property] bindings) make it difficult to maintain consistent styling across an application and can violate Content Security Policy (CSP) restrictions. Styles should be defined in component stylesheets or CSS classes where they can be managed centrally, reused, cached by browsers, and easily modified. Inline styles also mix presentation concerns with template structure, making templates harder to read. Using CSS classes with [class] or [ngClass] bindings provides the same dynamic styling capabilities while keeping styles organized and maintainable. This rule can be configured to allow ngStyle or style bindings if needed for specific use cases.
+Inline styles in templates (style attribute, ngStyle directive, [style] object/map bindings, or [style.property] bindings) make it difficult to maintain consistent styling across an application and can violate Content Security Policy (CSP) restrictions. Styles should be defined in component stylesheets or CSS classes where they can be managed centrally, reused, cached by browsers, and easily modified. Inline styles also mix presentation concerns with template structure, making templates harder to read. Using CSS classes with [class] or [ngClass] bindings provides the same dynamic styling capabilities while keeping styles organized and maintainable. This rule can be configured to allow ngStyle, [style] object/map bindings, or style property bindings if needed for specific use cases.
 
 <br>
 
@@ -41,6 +41,10 @@ interface Options {
    * Default: `false`
    */
   allowBindToStyle?: boolean;
+  /**
+   * Default: `false`
+   */
+  allowStyleObjectBinding?: boolean;
 }
 
 ```
@@ -304,6 +308,66 @@ interface Options {
 ```html
 <input [style]="'border: 1px solid black;'">
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+```
+
+<br>
+
+---
+
+<br>
+
+#### Custom Config
+
+```json
+{
+  "rules": {
+    "@angular-eslint/template/no-inline-styles": [
+      "error",
+      {
+        "allowBindToStyle": true
+      }
+    ]
+  }
+}
+```
+
+<br>
+
+#### ❌ Invalid Code
+
+```html
+<input [style]="{ 'background-color': '#fff' }">
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+```
+
+<br>
+
+---
+
+<br>
+
+#### Custom Config
+
+```json
+{
+  "rules": {
+    "@angular-eslint/template/no-inline-styles": [
+      "error",
+      {
+        "allowStyleObjectBinding": true
+      }
+    ]
+  }
+}
+```
+
+<br>
+
+#### ❌ Invalid Code
+
+```html
+<input [attr.style]="'padding: 10px;'">
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 ```
 
 <br>
@@ -806,6 +870,64 @@ interface Options {
     "@angular-eslint/template/no-inline-styles": [
       "error",
       {
+        "allowStyleObjectBinding": true
+      }
+    ]
+  }
+}
+```
+
+<br>
+
+#### ✅ Valid Code
+
+```html
+<input [style]="{ 'background-color': '#fff' }">
+```
+
+<br>
+
+---
+
+<br>
+
+#### Custom Config
+
+```json
+{
+  "rules": {
+    "@angular-eslint/template/no-inline-styles": [
+      "error",
+      {
+        "allowStyleObjectBinding": true
+      }
+    ]
+  }
+}
+```
+
+<br>
+
+#### ✅ Valid Code
+
+```html
+<input [style]="styleObject">
+```
+
+<br>
+
+---
+
+<br>
+
+#### Custom Config
+
+```json
+{
+  "rules": {
+    "@angular-eslint/template/no-inline-styles": [
+      "error",
+      {
         "allowNgStyle": true,
         "allowBindToStyle": true
       }
@@ -820,6 +942,37 @@ interface Options {
 
 ```html
 <input [ngStyle]="{ 'background-color': 'red' }" [style.background-color]="'#fff'">
+```
+
+<br>
+
+---
+
+<br>
+
+#### Custom Config
+
+```json
+{
+  "rules": {
+    "@angular-eslint/template/no-inline-styles": [
+      "error",
+      {
+        "allowNgStyle": true,
+        "allowBindToStyle": true,
+        "allowStyleObjectBinding": true
+      }
+    ]
+  }
+}
+```
+
+<br>
+
+#### ✅ Valid Code
+
+```html
+<input [ngStyle]="{ 'background-color': 'red' }" [style]="styleObject" [style.background-color]="'#fff'">
 ```
 
 </details>

--- a/packages/eslint-plugin-template/docs/rules/no-inline-styles.md
+++ b/packages/eslint-plugin-template/docs/rules/no-inline-styles.md
@@ -23,7 +23,7 @@ Disallows the use of inline styles in HTML templates
 
 ## Rationale
 
-Inline styles in templates (style attribute, ngStyle directive, or [style.property] bindings) make it difficult to maintain consistent styling across an application and can violate Content Security Policy (CSP) restrictions. Styles should be defined in component stylesheets or CSS classes where they can be managed centrally, reused, cached by browsers, and easily modified. Inline styles also mix presentation concerns with template structure, making templates harder to read. Using CSS classes with [class] or [ngClass] bindings provides the same dynamic styling capabilities while keeping styles organized and maintainable. This rule can be configured to allow ngStyle or style bindings if needed for specific use cases.
+Inline styles in templates (style attribute, ngStyle directive, [style] bindings, or [style.property] bindings) make it difficult to maintain consistent styling across an application and can violate Content Security Policy (CSP) restrictions. Styles should be defined in component stylesheets or CSS classes where they can be managed centrally, reused, cached by browsers, and easily modified. Inline styles also mix presentation concerns with template structure, making templates harder to read. Using CSS classes with [class] or [ngClass] bindings provides the same dynamic styling capabilities while keeping styles organized and maintainable. This rule can be configured to allow ngStyle or style bindings if needed for specific use cases.
 
 <br>
 
@@ -304,6 +304,36 @@ interface Options {
 ```html
 <input [style]="'border: 1px solid black;'">
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+```
+
+<br>
+
+---
+
+<br>
+
+#### Custom Config
+
+```json
+{
+  "rules": {
+    "@angular-eslint/template/no-inline-styles": [
+      "error",
+      {
+        "allowBindToStyle": true
+      }
+    ]
+  }
+}
+```
+
+<br>
+
+#### ❌ Invalid Code
+
+```html
+<input [attr.style]="'padding: 10px;'">
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 ```
 
 <br>
@@ -740,6 +770,32 @@ interface Options {
 
 <br>
 
+#### Default Config
+
+```json
+{
+  "rules": {
+    "@angular-eslint/template/no-inline-styles": [
+      "error"
+    ]
+  }
+}
+```
+
+<br>
+
+#### ✅ Valid Code
+
+```html
+<div [attr.stylesheet]="x">
+```
+
+<br>
+
+---
+
+<br>
+
 #### Custom Config
 
 ```json
@@ -806,6 +862,151 @@ interface Options {
     "@angular-eslint/template/no-inline-styles": [
       "error",
       {
+        "allowBindToStyle": true
+      }
+    ]
+  }
+}
+```
+
+<br>
+
+#### ✅ Valid Code
+
+```html
+<input [style]="{ 'background-color': '#fff' }">
+```
+
+<br>
+
+---
+
+<br>
+
+#### Custom Config
+
+```json
+{
+  "rules": {
+    "@angular-eslint/template/no-inline-styles": [
+      "error",
+      {
+        "allowBindToStyle": true
+      }
+    ]
+  }
+}
+```
+
+<br>
+
+#### ✅ Valid Code
+
+```html
+<input [style]="styleObject">
+```
+
+<br>
+
+---
+
+<br>
+
+#### Custom Config
+
+```json
+{
+  "rules": {
+    "@angular-eslint/template/no-inline-styles": [
+      "error",
+      {
+        "allowBindToStyle": true
+      }
+    ]
+  }
+}
+```
+
+<br>
+
+#### ✅ Valid Code
+
+```html
+<input [style.width.px]="w">
+```
+
+<br>
+
+---
+
+<br>
+
+#### Custom Config
+
+```json
+{
+  "rules": {
+    "@angular-eslint/template/no-inline-styles": [
+      "error",
+      {
+        "allowBindToStyle": true
+      }
+    ]
+  }
+}
+```
+
+<br>
+
+#### ✅ Valid Code
+
+```html
+<input style="{{ x }}">
+```
+
+<br>
+
+---
+
+<br>
+
+#### Custom Config
+
+```json
+{
+  "rules": {
+    "@angular-eslint/template/no-inline-styles": [
+      "error",
+      {
+        "allowBindToStyle": true
+      }
+    ]
+  }
+}
+```
+
+<br>
+
+#### ✅ Valid Code
+
+```html
+<input bind-style="x">
+```
+
+<br>
+
+---
+
+<br>
+
+#### Custom Config
+
+```json
+{
+  "rules": {
+    "@angular-eslint/template/no-inline-styles": [
+      "error",
+      {
         "allowNgStyle": true,
         "allowBindToStyle": true
       }
@@ -820,6 +1021,36 @@ interface Options {
 
 ```html
 <input [ngStyle]="{ 'background-color': 'red' }" [style.background-color]="'#fff'">
+```
+
+<br>
+
+---
+
+<br>
+
+#### Custom Config
+
+```json
+{
+  "rules": {
+    "@angular-eslint/template/no-inline-styles": [
+      "error",
+      {
+        "allowNgStyle": true,
+        "allowBindToStyle": true
+      }
+    ]
+  }
+}
+```
+
+<br>
+
+#### ✅ Valid Code
+
+```html
+<input [ngStyle]="{ 'background-color': 'red' }" [style]="styleObject" [style.background-color]="'#fff'">
 ```
 
 </details>

--- a/packages/eslint-plugin-template/src/rules/no-inline-styles.ts
+++ b/packages/eslint-plugin-template/src/rules/no-inline-styles.ts
@@ -9,11 +9,13 @@ export type Options = [
   {
     readonly allowNgStyle?: boolean;
     readonly allowBindToStyle?: boolean;
+    readonly allowStyleObjectBinding?: boolean;
   },
 ];
 const DEFAULT_OPTIONS: Options[number] = {
   allowNgStyle: false,
   allowBindToStyle: false,
+  allowStyleObjectBinding: false,
 };
 export type MessageIds = 'noInlineStyles';
 export const RULE_NAME = 'no-inline-styles';
@@ -37,6 +39,10 @@ export default createESLintRule<Options, MessageIds>({
             type: 'boolean',
             default: DEFAULT_OPTIONS.allowBindToStyle,
           },
+          allowStyleObjectBinding: {
+            type: 'boolean',
+            default: DEFAULT_OPTIONS.allowStyleObjectBinding,
+          },
         },
         additionalProperties: false,
       },
@@ -47,28 +53,25 @@ export default createESLintRule<Options, MessageIds>({
     },
   },
   defaultOptions: [DEFAULT_OPTIONS],
-  create(context, [{ allowNgStyle, allowBindToStyle }]) {
+  create(
+    context,
+    [{ allowNgStyle, allowBindToStyle, allowStyleObjectBinding }],
+  ) {
     const parserServices = getTemplateParserServices(context);
 
     return {
       Element(node: TmplAstElement) {
-        let isInvalid = false;
-
-        if (!allowNgStyle && !allowBindToStyle) {
-          isInvalid =
-            isNodeHasStyleAttribute(node) ||
-            isNodeHasNgStyleAttribute(node) ||
-            isNodeHasBindingToStyleAttribute(node);
-        } else {
-          const ngStyle = allowNgStyle
-            ? false
-            : isNodeHasNgStyleAttribute(node);
-          const bindToStyle = allowBindToStyle
-            ? false
-            : isNodeHasBindingToStyleAttribute(node);
-
-          isInvalid = isNodeHasStyleAttribute(node) || ngStyle || bindToStyle;
-        }
+        const hasDisallowedNgStyle =
+          !allowNgStyle && isNodeHasNgStyleAttribute(node);
+        const hasDisallowedBindToStyle =
+          !allowBindToStyle && isNodeHasBindingToStyleAttribute(node);
+        const hasDisallowedStyleObjectBinding =
+          !allowStyleObjectBinding && isNodeHasStyleObjectBinding(node);
+        const isInvalid =
+          isNodeHasStyleAttribute(node) ||
+          hasDisallowedNgStyle ||
+          hasDisallowedBindToStyle ||
+          hasDisallowedStyleObjectBinding;
 
         if (isInvalid) {
           const loc = parserServices.convertElementSourceSpanToLoc(
@@ -95,7 +98,7 @@ export default createESLintRule<Options, MessageIds>({
 function isNodeHasStyleAttribute(node: TmplAstElement): boolean {
   return (
     node.attributes.some(({ name }) => isStyle(name)) ||
-    node.inputs.some(({ name }) => isStyle(name))
+    node.inputs.some(({ keySpan }) => isAttributeStyleBinding(keySpan))
   );
 }
 /**
@@ -113,6 +116,15 @@ function isNodeHasBindingToStyleAttribute(node: TmplAstElement): boolean {
 }
 
 /**
+ *  Check that an element (for example `<img>`) has a `[style]` object/map binding.
+ */
+function isNodeHasStyleObjectBinding(node: TmplAstElement): boolean {
+  return node.inputs.some(
+    ({ name, keySpan }) => isStyle(name) && !isAttributeStyleBinding(keySpan),
+  );
+}
+
+/**
  *  Check element is style
  */
 function isStyle(name: string): name is 'style' {
@@ -127,7 +139,11 @@ function isStyleBound(keySpan: ParseSourceSpan): boolean {
   return keySpan?.details ? keySpan.details.includes('style.') : false;
 }
 
+function isAttributeStyleBinding(keySpan: ParseSourceSpan): boolean {
+  return keySpan?.details ? keySpan.details.includes('attr.style') : false;
+}
+
 export const RULE_DOCS_EXTENSION = {
   rationale:
-    'Inline styles in templates (style attribute, ngStyle directive, or [style.property] bindings) make it difficult to maintain consistent styling across an application and can violate Content Security Policy (CSP) restrictions. Styles should be defined in component stylesheets or CSS classes where they can be managed centrally, reused, cached by browsers, and easily modified. Inline styles also mix presentation concerns with template structure, making templates harder to read. Using CSS classes with [class] or [ngClass] bindings provides the same dynamic styling capabilities while keeping styles organized and maintainable. This rule can be configured to allow ngStyle or style bindings if needed for specific use cases.',
+    'Inline styles in templates (style attribute, ngStyle directive, [style] object/map bindings, or [style.property] bindings) make it difficult to maintain consistent styling across an application and can violate Content Security Policy (CSP) restrictions. Styles should be defined in component stylesheets or CSS classes where they can be managed centrally, reused, cached by browsers, and easily modified. Inline styles also mix presentation concerns with template structure, making templates harder to read. Using CSS classes with [class] or [ngClass] bindings provides the same dynamic styling capabilities while keeping styles organized and maintainable. This rule can be configured to allow ngStyle, [style] object/map bindings, or style property bindings if needed for specific use cases.',
 };

--- a/packages/eslint-plugin-template/src/rules/no-inline-styles.ts
+++ b/packages/eslint-plugin-template/src/rules/no-inline-styles.ts
@@ -9,13 +9,13 @@ export type Options = [
   {
     readonly allowNgStyle?: boolean;
     readonly allowBindToStyle?: boolean;
-    readonly allowStyleObjectBinding?: boolean;
+    readonly allowStyleBinding?: boolean;
   },
 ];
 const DEFAULT_OPTIONS: Options[number] = {
   allowNgStyle: false,
   allowBindToStyle: false,
-  allowStyleObjectBinding: false,
+  allowStyleBinding: false,
 };
 export type MessageIds = 'noInlineStyles';
 export const RULE_NAME = 'no-inline-styles';
@@ -39,9 +39,9 @@ export default createESLintRule<Options, MessageIds>({
             type: 'boolean',
             default: DEFAULT_OPTIONS.allowBindToStyle,
           },
-          allowStyleObjectBinding: {
+          allowStyleBinding: {
             type: 'boolean',
-            default: DEFAULT_OPTIONS.allowStyleObjectBinding,
+            default: DEFAULT_OPTIONS.allowStyleBinding,
           },
         },
         additionalProperties: false,
@@ -55,7 +55,7 @@ export default createESLintRule<Options, MessageIds>({
   defaultOptions: [DEFAULT_OPTIONS],
   create(
     context,
-    [{ allowNgStyle, allowBindToStyle, allowStyleObjectBinding }],
+    [{ allowNgStyle, allowBindToStyle, allowStyleBinding }],
   ) {
     const parserServices = getTemplateParserServices(context);
 
@@ -65,13 +65,13 @@ export default createESLintRule<Options, MessageIds>({
           !allowNgStyle && isNodeHasNgStyleAttribute(node);
         const hasDisallowedBindToStyle =
           !allowBindToStyle && isNodeHasBindingToStyleAttribute(node);
-        const hasDisallowedStyleObjectBinding =
-          !allowStyleObjectBinding && isNodeHasStyleObjectBinding(node);
+        const hasDisallowedStyleBinding =
+          !allowStyleBinding && isNodeHasStyleBinding(node);
         const isInvalid =
           isNodeHasStyleAttribute(node) ||
           hasDisallowedNgStyle ||
           hasDisallowedBindToStyle ||
-          hasDisallowedStyleObjectBinding;
+          hasDisallowedStyleBinding;
 
         if (isInvalid) {
           const loc = parserServices.convertElementSourceSpanToLoc(
@@ -116,9 +116,9 @@ function isNodeHasBindingToStyleAttribute(node: TmplAstElement): boolean {
 }
 
 /**
- *  Check that an element (for example `<img>`) has a `[style]` object/map binding.
+ *  Check that an element (for example `<img>`) has a `[style]` binding.
  */
-function isNodeHasStyleObjectBinding(node: TmplAstElement): boolean {
+function isNodeHasStyleBinding(node: TmplAstElement): boolean {
   return node.inputs.some(
     ({ name, keySpan }) => isStyle(name) && !isAttributeStyleBinding(keySpan),
   );
@@ -145,5 +145,5 @@ function isAttributeStyleBinding(keySpan: ParseSourceSpan): boolean {
 
 export const RULE_DOCS_EXTENSION = {
   rationale:
-    'Inline styles in templates (style attribute, ngStyle directive, [style] object/map bindings, or [style.property] bindings) make it difficult to maintain consistent styling across an application and can violate Content Security Policy (CSP) restrictions. Styles should be defined in component stylesheets or CSS classes where they can be managed centrally, reused, cached by browsers, and easily modified. Inline styles also mix presentation concerns with template structure, making templates harder to read. Using CSS classes with [class] or [ngClass] bindings provides the same dynamic styling capabilities while keeping styles organized and maintainable. This rule can be configured to allow ngStyle, [style] object/map bindings, or style property bindings if needed for specific use cases.',
+    'Inline styles in templates (style attribute, ngStyle directive, [style] bindings, or [style.property] bindings) make it difficult to maintain consistent styling across an application and can violate Content Security Policy (CSP) restrictions. Styles should be defined in component stylesheets or CSS classes where they can be managed centrally, reused, cached by browsers, and easily modified. Inline styles also mix presentation concerns with template structure, making templates harder to read. Using CSS classes with [class] or [ngClass] bindings provides the same dynamic styling capabilities while keeping styles organized and maintainable. This rule can be configured to allow ngStyle, [style] bindings, or style property bindings if needed for specific use cases.',
 };

--- a/packages/eslint-plugin-template/src/rules/no-inline-styles.ts
+++ b/packages/eslint-plugin-template/src/rules/no-inline-styles.ts
@@ -1,6 +1,6 @@
-import type {
-  ParseSourceSpan,
-  TmplAstElement,
+import {
+  BindingType,
+  type TmplAstElement,
 } from '@angular-eslint/bundled-angular-compiler';
 import { getTemplateParserServices } from '@angular-eslint/utils';
 import { createESLintRule } from '../utils/create-eslint-rule';
@@ -17,6 +17,10 @@ const DEFAULT_OPTIONS: Options[number] = {
 };
 export type MessageIds = 'noInlineStyles';
 export const RULE_NAME = 'no-inline-styles';
+
+type InputWithOriginalType = TmplAstElement['inputs'][number] & {
+  readonly __originalType?: BindingType;
+};
 
 export default createESLintRule<Options, MessageIds>({
   name: RULE_NAME,
@@ -52,23 +56,30 @@ export default createESLintRule<Options, MessageIds>({
 
     return {
       Element(node: TmplAstElement) {
-        let isInvalid = false;
+        const hasDisallowedInput = node.inputs.some((input) => {
+          const { __originalType: originalType, type } =
+            input as InputWithOriginalType;
 
-        if (!allowNgStyle && !allowBindToStyle) {
-          isInvalid =
-            isNodeHasStyleAttribute(node) ||
-            isNodeHasNgStyleAttribute(node) ||
-            isNodeHasBindingToStyleAttribute(node);
-        } else {
-          const ngStyle = allowNgStyle
-            ? false
-            : isNodeHasNgStyleAttribute(node);
-          const bindToStyle = allowBindToStyle
-            ? false
-            : isNodeHasBindingToStyleAttribute(node);
-
-          isInvalid = isNodeHasStyleAttribute(node) || ngStyle || bindToStyle;
-        }
+          switch (originalType ?? type) {
+            case BindingType.Attribute:
+              return input.name === 'style';
+            case BindingType.Style:
+              return !allowBindToStyle;
+            case BindingType.Property:
+              if (input.name === 'style') {
+                return !allowBindToStyle;
+              }
+              if (input.name === 'ngStyle') {
+                return !allowNgStyle;
+              }
+              return false;
+            default:
+              return false;
+          }
+        });
+        const isInvalid =
+          node.attributes.some(({ name }) => name === 'style') ||
+          hasDisallowedInput;
 
         if (isInvalid) {
           const loc = parserServices.convertElementSourceSpanToLoc(
@@ -89,45 +100,7 @@ export default createESLintRule<Options, MessageIds>({
   },
 });
 
-/**
- *  Check that an element (for example `<img>`) has a `style` attribute or `attr.style` binding.
- */
-function isNodeHasStyleAttribute(node: TmplAstElement): boolean {
-  return (
-    node.attributes.some(({ name }) => isStyle(name)) ||
-    node.inputs.some(({ name }) => isStyle(name))
-  );
-}
-/**
- *  Check that an element (for example `<img>`) has a `ngStyle` attribute binding.
- */
-function isNodeHasNgStyleAttribute(node: TmplAstElement): boolean {
-  return node.inputs.some(({ name }) => isNgStyle(name));
-}
-
-/**
- *  Check that an element (for example `<img>`) has a `[style.background-color]` attribute binding.
- */
-function isNodeHasBindingToStyleAttribute(node: TmplAstElement): boolean {
-  return node.inputs.some(({ keySpan }) => isStyleBound(keySpan));
-}
-
-/**
- *  Check element is style
- */
-function isStyle(name: string): name is 'style' {
-  return name === 'style';
-}
-
-function isNgStyle(name: string): name is 'ngStyle' {
-  return name === 'ngStyle';
-}
-
-function isStyleBound(keySpan: ParseSourceSpan): boolean {
-  return keySpan?.details ? keySpan.details.includes('style.') : false;
-}
-
 export const RULE_DOCS_EXTENSION = {
   rationale:
-    'Inline styles in templates (style attribute, ngStyle directive, or [style.property] bindings) make it difficult to maintain consistent styling across an application and can violate Content Security Policy (CSP) restrictions. Styles should be defined in component stylesheets or CSS classes where they can be managed centrally, reused, cached by browsers, and easily modified. Inline styles also mix presentation concerns with template structure, making templates harder to read. Using CSS classes with [class] or [ngClass] bindings provides the same dynamic styling capabilities while keeping styles organized and maintainable. This rule can be configured to allow ngStyle or style bindings if needed for specific use cases.',
+    'Inline styles in templates (style attribute, ngStyle directive, [style] bindings, or [style.property] bindings) make it difficult to maintain consistent styling across an application and can violate Content Security Policy (CSP) restrictions. Styles should be defined in component stylesheets or CSS classes where they can be managed centrally, reused, cached by browsers, and easily modified. Inline styles also mix presentation concerns with template structure, making templates harder to read. Using CSS classes with [class] or [ngClass] bindings provides the same dynamic styling capabilities while keeping styles organized and maintainable. This rule can be configured to allow ngStyle or style bindings if needed for specific use cases.',
 };

--- a/packages/eslint-plugin-template/tests/rules/no-inline-styles/cases.ts
+++ b/packages/eslint-plugin-template/tests/rules/no-inline-styles/cases.ts
@@ -32,8 +32,26 @@ export const valid: readonly (string | ValidTestCase<Options>)[] = [
     options: [{ allowBindToStyle: true }],
   },
   {
+    code: `<input [style]="{ 'background-color': '#fff' }">`,
+    options: [{ allowStyleObjectBinding: true }],
+  },
+  {
+    code: `<input [style]="styleObject">`,
+    options: [{ allowStyleObjectBinding: true }],
+  },
+  {
     code: `<input [ngStyle]="{ 'background-color': 'red' }" [style.background-color]="'#fff'">`,
     options: [{ allowNgStyle: true, allowBindToStyle: true }],
+  },
+  {
+    code: `<input [ngStyle]="{ 'background-color': 'red' }" [style]="styleObject" [style.background-color]="'#fff'">`,
+    options: [
+      {
+        allowNgStyle: true,
+        allowBindToStyle: true,
+        allowStyleObjectBinding: true,
+      },
+    ],
   },
 ];
 
@@ -118,7 +136,8 @@ export const invalid: readonly InvalidTestCase<MessageIds, Options>[] = [
   }),
   convertAnnotatedSourceToFailureCase({
     messageId,
-    description: 'should fail when input element with ngStyle attribute exist',
+    description:
+      'should fail when input element with style object binding attribute exist',
     annotatedSource: `
         <input [style]="'border: 1px solid black;'">
         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -128,7 +147,30 @@ export const invalid: readonly InvalidTestCase<MessageIds, Options>[] = [
   }),
   convertAnnotatedSourceToFailureCase({
     messageId,
-    description: 'should fail when input element with ngStyle attribute exist',
+    description:
+      'should fail when input element with style object binding attribute exist and allowBindToStyle set to true',
+    annotatedSource: `
+        <input [style]="{ 'background-color': '#fff' }">
+        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      `,
+    data: { element: 'input' },
+    options: [{ allowBindToStyle: true }],
+  }),
+  convertAnnotatedSourceToFailureCase({
+    messageId,
+    description:
+      'should fail when input element with attr.style binding exist and allowStyleObjectBinding set to true',
+    annotatedSource: `
+        <input [attr.style]="'padding: 10px;'">
+        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      `,
+    data: { element: 'input' },
+    options: [{ allowStyleObjectBinding: true }],
+  }),
+  convertAnnotatedSourceToFailureCase({
+    messageId,
+    description:
+      'should fail when input element with style object binding attribute exist',
     annotatedSource: `
         <input [ngStyle]="{ 'padding': '10px' }" [style]="'border: 1px solid black;'">
         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/packages/eslint-plugin-template/tests/rules/no-inline-styles/cases.ts
+++ b/packages/eslint-plugin-template/tests/rules/no-inline-styles/cases.ts
@@ -33,11 +33,15 @@ export const valid: readonly (string | ValidTestCase<Options>)[] = [
   },
   {
     code: `<input [style]="{ 'background-color': '#fff' }">`,
-    options: [{ allowStyleObjectBinding: true }],
+    options: [{ allowStyleBinding: true }],
   },
   {
     code: `<input [style]="styleObject">`,
-    options: [{ allowStyleObjectBinding: true }],
+    options: [{ allowStyleBinding: true }],
+  },
+  {
+    code: `<input [style]="'border: 1px solid black;'">`,
+    options: [{ allowStyleBinding: true }],
   },
   {
     code: `<input [ngStyle]="{ 'background-color': 'red' }" [style.background-color]="'#fff'">`,
@@ -49,7 +53,7 @@ export const valid: readonly (string | ValidTestCase<Options>)[] = [
       {
         allowNgStyle: true,
         allowBindToStyle: true,
-        allowStyleObjectBinding: true,
+        allowStyleBinding: true,
       },
     ],
   },
@@ -137,7 +141,7 @@ export const invalid: readonly InvalidTestCase<MessageIds, Options>[] = [
   convertAnnotatedSourceToFailureCase({
     messageId,
     description:
-      'should fail when input element with style object binding attribute exist',
+      'should fail when input element with style binding attribute exist',
     annotatedSource: `
         <input [style]="'border: 1px solid black;'">
         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -148,7 +152,7 @@ export const invalid: readonly InvalidTestCase<MessageIds, Options>[] = [
   convertAnnotatedSourceToFailureCase({
     messageId,
     description:
-      'should fail when input element with style object binding attribute exist and allowBindToStyle set to true',
+      'should fail when input element with style binding attribute exist and allowBindToStyle set to true',
     annotatedSource: `
         <input [style]="{ 'background-color': '#fff' }">
         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -159,18 +163,18 @@ export const invalid: readonly InvalidTestCase<MessageIds, Options>[] = [
   convertAnnotatedSourceToFailureCase({
     messageId,
     description:
-      'should fail when input element with attr.style binding exist and allowStyleObjectBinding set to true',
+      'should fail when input element with attr.style binding exist and allowStyleBinding set to true',
     annotatedSource: `
         <input [attr.style]="'padding: 10px;'">
         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
       `,
     data: { element: 'input' },
-    options: [{ allowStyleObjectBinding: true }],
+    options: [{ allowStyleBinding: true }],
   }),
   convertAnnotatedSourceToFailureCase({
     messageId,
     description:
-      'should fail when input element with style object binding attribute exist',
+      'should fail when input element with style binding attribute exist',
     annotatedSource: `
         <input [ngStyle]="{ 'padding': '10px' }" [style]="'border: 1px solid black;'">
         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/packages/eslint-plugin-template/tests/rules/no-inline-styles/cases.ts
+++ b/packages/eslint-plugin-template/tests/rules/no-inline-styles/cases.ts
@@ -23,6 +23,7 @@ export const valid: readonly (string | ValidTestCase<Options>)[] = [
   '<input type="image" alt="This is descriptive!">',
   '<input type="image" aria-label="foo">',
   '<input type="image" aria-labelledby="id1">',
+  '<div [attr.stylesheet]="x">',
   {
     code: `<input [ngStyle]="{ 'background-color': '#fff' }">`,
     options: [{ allowNgStyle: true }],
@@ -32,8 +33,37 @@ export const valid: readonly (string | ValidTestCase<Options>)[] = [
     options: [{ allowBindToStyle: true }],
   },
   {
+    code: `<input [style]="{ 'background-color': '#fff' }">`,
+    options: [{ allowBindToStyle: true }],
+  },
+  {
+    code: `<input [style]="styleObject">`,
+    options: [{ allowBindToStyle: true }],
+  },
+  {
+    code: `<input [style.width.px]="w">`,
+    options: [{ allowBindToStyle: true }],
+  },
+  {
+    code: `<input style="{{ x }}">`,
+    options: [{ allowBindToStyle: true }],
+  },
+  {
+    code: `<input bind-style="x">`,
+    options: [{ allowBindToStyle: true }],
+  },
+  {
     code: `<input [ngStyle]="{ 'background-color': 'red' }" [style.background-color]="'#fff'">`,
     options: [{ allowNgStyle: true, allowBindToStyle: true }],
+  },
+  {
+    code: `<input [ngStyle]="{ 'background-color': 'red' }" [style]="styleObject" [style.background-color]="'#fff'">`,
+    options: [
+      {
+        allowNgStyle: true,
+        allowBindToStyle: true,
+      },
+    ],
   },
 ];
 
@@ -80,7 +110,7 @@ export const invalid: readonly InvalidTestCase<MessageIds, Options>[] = [
   }),
   convertAnnotatedSourceToFailureCase({
     messageId,
-    description: 'should fail when input element with style attribute exist',
+    description: 'should fail when input element with attr.style binding exist',
     annotatedSource: `
         <input [attr.style]="'padding: 10px;'">
         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -89,7 +119,8 @@ export const invalid: readonly InvalidTestCase<MessageIds, Options>[] = [
   }),
   convertAnnotatedSourceToFailureCase({
     messageId,
-    description: 'should fail when input element with binding to style exist',
+    description:
+      'should fail when input element with style property binding exist',
     annotatedSource: `
         <input [style.background-color]="'#fff'">
         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -99,7 +130,7 @@ export const invalid: readonly InvalidTestCase<MessageIds, Options>[] = [
   convertAnnotatedSourceToFailureCase({
     messageId,
     description:
-      'should fail when input element with binding to style exist and allowNgStyle set to true',
+      'should fail when input element with style bindings exist and allowNgStyle set to true',
     annotatedSource: `
         <input [style]="'border: 1px solid black;'" [ngStyle]="{ 'padding': '10px' }" [style.background-color]="'#fff'">
         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -109,7 +140,7 @@ export const invalid: readonly InvalidTestCase<MessageIds, Options>[] = [
   }),
   convertAnnotatedSourceToFailureCase({
     messageId,
-    description: 'should fail when input element with ngStyle attribute exist',
+    description: 'should fail when input element with ngStyle binding exist',
     annotatedSource: `
         <input [ngStyle]="'background-color: #fff'">
         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -118,7 +149,8 @@ export const invalid: readonly InvalidTestCase<MessageIds, Options>[] = [
   }),
   convertAnnotatedSourceToFailureCase({
     messageId,
-    description: 'should fail when input element with ngStyle attribute exist',
+    description:
+      'should fail when input element with style binding exists with only allowNgStyle set to true',
     annotatedSource: `
         <input [style]="'border: 1px solid black;'">
         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -128,7 +160,19 @@ export const invalid: readonly InvalidTestCase<MessageIds, Options>[] = [
   }),
   convertAnnotatedSourceToFailureCase({
     messageId,
-    description: 'should fail when input element with ngStyle attribute exist',
+    description:
+      'should fail when input element with attr.style binding exists even with allowBindToStyle set to true',
+    annotatedSource: `
+        <input [attr.style]="'padding: 10px;'">
+        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      `,
+    data: { element: 'input' },
+    options: [{ allowBindToStyle: true }],
+  }),
+  convertAnnotatedSourceToFailureCase({
+    messageId,
+    description:
+      'should fail when input element has ngStyle and style bindings without allowBindToStyle',
     annotatedSource: `
         <input [ngStyle]="{ 'padding': '10px' }" [style]="'border: 1px solid black;'">
         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
## Summary
- extend `allowBindToStyle` so it covers `[style]`, `bind-style`, interpolated `style`, and `[style.prop]` bindings
- keep static `style` attributes and `[attr.style]` invalid in all configurations
- classify style inputs using Angular binding types instead of matching `keySpan.details`
- add regression coverage for `[attr.stylesheet]` and the requested style binding cases

Fixes #3016

## Checks
- `node ..\..\node_modules\vitest\vitest.mjs run tests\rules\no-inline-styles\spec.ts --config vitest.config.mts`
- `node node_modules\typescript\bin\tsc --build packages\eslint-plugin-template\tsconfig.spec.json --pretty false`
- `node node_modules\prettier\bin\prettier.cjs --check packages\eslint-plugin-template\src\rules\no-inline-styles.ts packages\eslint-plugin-template\tests\rules\no-inline-styles\cases.ts packages\eslint-plugin-template\docs\rules\no-inline-styles.md`
