### PR TITLE
chore: emove unused peer dependency @angular/cli

### DIFF
--- a/packages/angular-eslint/package.json
+++ b/packages/angular-eslint/package.json
@@ -19,7 +19,6 @@
     "LICENSE"
   ],
   "peerDependencies": {
-    "@angular/cli": "catalog:other-runtime-dependencies",
     "eslint": "^9.0.0 || ^10.0.0",
     "typescript": "*",
     "typescript-eslint": "^8.0.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -394,9 +394,6 @@ importers:
       '@angular-eslint/template-parser':
         specifier: workspace:*
         version: link:../template-parser
-      '@angular/cli':
-        specifier: catalog:other-runtime-dependencies
-        version: 22.0.5(@types/node@26.1.1)
       '@typescript-eslint/types':
         specifier: ^8.0.0
         version: 8.62.1


### PR DESCRIPTION
In my usage of angular, I have no direct need of `@angular/cli`, which is an incredibly chunky package (just adding it adds around 90 transitive dependencies). `angular-eslint` is the only package which claims a dependency on it, as a peer. However, I can't find any actual usage of it within `angular-eslint`.

This PR removes it - all tests seem to pass, and it certainly works in the wild on my machine without providing it