### PR TITLE
fix(eslint-plugin-template): [valid-aria] validate each token of a token list

### DIFF
--- a/packages/eslint-plugin-template/docs/rules/valid-aria.md
+++ b/packages/eslint-plugin-template/docs/rules/valid-aria.md
@@ -110,6 +110,37 @@ The rule does not have any configuration options.
        ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 ```
 
+<br>
+
+---
+
+<br>
+
+#### Default Config
+
+```json
+{
+  "rules": {
+    "@angular-eslint/template/valid-aria": [
+      "error"
+    ]
+  }
+}
+```
+
+<br>
+
+#### ❌ Invalid Code
+
+```html
+<div aria-relevant="additions notAToken">Text</div>
+     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+<div aria-dropeffect="copy notAToken">Text</div>
+     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+<div aria-relevant="   ">Text</div>
+     ~~~~~~~~~~~~~~~~~~~
+```
+
 </details>
 
 <br>
@@ -375,6 +406,110 @@ The rule does not have any configuration options.
 
 ```html
 <div aria-relevant="additions">additions</div>
+```
+
+<br>
+
+---
+
+<br>
+
+#### Default Config
+
+```json
+{
+  "rules": {
+    "@angular-eslint/template/valid-aria": [
+      "error"
+    ]
+  }
+}
+```
+
+<br>
+
+#### ✅ Valid Code
+
+```html
+<div aria-relevant="additions removals">additions removals</div>
+```
+
+<br>
+
+---
+
+<br>
+
+#### Default Config
+
+```json
+{
+  "rules": {
+    "@angular-eslint/template/valid-aria": [
+      "error"
+    ]
+  }
+}
+```
+
+<br>
+
+#### ✅ Valid Code
+
+```html
+<div aria-relevant="additions text">the ARIA default value</div>
+```
+
+<br>
+
+---
+
+<br>
+
+#### Default Config
+
+```json
+{
+  "rules": {
+    "@angular-eslint/template/valid-aria": [
+      "error"
+    ]
+  }
+}
+```
+
+<br>
+
+#### ✅ Valid Code
+
+```html
+<div aria-relevant="  additions   text  ">surrounding and repeated whitespace</div>
+```
+
+<br>
+
+---
+
+<br>
+
+#### Default Config
+
+```json
+{
+  "rules": {
+    "@angular-eslint/template/valid-aria": [
+      "error"
+    ]
+  }
+}
+```
+
+<br>
+
+#### ✅ Valid Code
+
+```html
+<div aria-dropeffect="copy move">copy move</div>
 ```
 
 <br>

--- a/packages/eslint-plugin-template/src/rules/valid-aria.ts
+++ b/packages/eslint-plugin-template/src/rules/valid-aria.ts
@@ -177,12 +177,17 @@ function isValidAriaPropertyValue(
       return isNumeric(attributeValue);
     case 'string':
       return isString(attributeValue);
-    case 'token':
-    case 'tokenlist': {
+    case 'token': {
       const parsedAttributeValue = isBooleanLike(attributeValue)
         ? JSON.parse(attributeValue as unknown as string)
         : attributeValue;
       return Boolean(values?.includes(parsedAttributeValue));
+    }
+    case 'tokenlist': {
+      // A token list is whitespace-separated, so each token is looked up on its own.
+      if (!isString(attributeValue)) return false;
+      const tokens = attributeValue.trim().split(/\s+/);
+      return tokens.every((token) => Boolean(values?.includes(token)));
     }
   }
 }

--- a/packages/eslint-plugin-template/tests/rules/valid-aria/cases.ts
+++ b/packages/eslint-plugin-template/tests/rules/valid-aria/cases.ts
@@ -20,6 +20,10 @@ export const valid: readonly (string | ValidTestCase<Options>)[] = [
   '<input [attr.aria-rowcount]="2">',
   '<table aria-rowcount="-1"></table>',
   '<div aria-relevant="additions">additions</div>',
+  '<div aria-relevant="additions removals">additions removals</div>',
+  '<div aria-relevant="additions text">the ARIA default value</div>',
+  '<div aria-relevant="  additions   text  ">surrounding and repeated whitespace</div>',
+  '<div aria-dropeffect="copy move">copy move</div>',
   '<div aria-checked="false">checked</div>',
   '<div role="slider" [attr.aria-valuemin]="1"></div>',
   '<div role="slider" aria-valuemin="1"></div>',
@@ -193,6 +197,35 @@ export const invalid: readonly InvalidTestCase<MessageIds, Options>[] = [
         char: '@',
         messageId: accessibilityValidAriaValue,
         data: { attribute: 'aria-placeholder' },
+      },
+    ],
+  }),
+  convertAnnotatedSourceToFailureCase({
+    description:
+      'should fail if a token list contains an unknown token, or holds no token at all',
+    annotatedSource: `
+        <div aria-relevant="additions notAToken">Text</div>
+             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+        <div aria-dropeffect="copy notAToken">Text</div>
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+        <div aria-relevant="   ">Text</div>
+             ###################
+      `,
+    messages: [
+      {
+        char: '~',
+        messageId: accessibilityValidAriaValue,
+        data: { attribute: 'aria-relevant' },
+      },
+      {
+        char: '^',
+        messageId: accessibilityValidAriaValue,
+        data: { attribute: 'aria-dropeffect' },
+      },
+      {
+        char: '#',
+        messageId: accessibilityValidAriaValue,
+        data: { attribute: 'aria-relevant' },
       },
     ],
   }),


### PR DESCRIPTION
Closes #3124.

`isValidAriaPropertyValue` handled `token` and `tokenlist` in the same `switch` branch and tested the whole attribute value against `values`. A token list is by definition a whitespace-separated list of tokens, so every legal multi-token value was rejected — including `aria-relevant="additions text"`, which is the ARIA-specified default value for that attribute.

`aria-relevant` and `aria-dropeffect` are the only `tokenlist` entries in `aria-query@5.3.2`, so both were affected.

Full credit to @dungnguyen-dev, who diagnosed this precisely in the issue, down to the offending branch.

### Change

`tokenlist` gets its own branch and each whitespace-separated token is validated on its own. `token` keeps its existing behaviour, including the boolean-like `JSON.parse` path.

I left out the `tokens.length > 0 &&` guard from the suggestion in the issue: `String.prototype.split` never returns an empty array, so `''.trim().split(/\s+/)` yields `['']` and the check is unreachable. Empty and whitespace-only values therefore keep reporting, exactly as before — there is a test pinning that.

### Tests

Added to `valid`:

- `aria-relevant="additions removals"`
- `aria-relevant="additions text"` (the ARIA default)
- `aria-relevant="  additions   text  "` (surrounding and repeated whitespace)
- `aria-dropeffect="copy move"`

Added an `invalid` case so the fix cannot silently become too permissive: a list holding an unknown token (`additions notAToken`, `copy notAToken`) still reports, and so does a value with no token at all.

All four new valid cases fail on `main` and pass with this change. `nx test eslint-plugin-template` is green (1261 tests), as are `lint`, `typecheck` and `format-check`. Rule docs were regenerated with `nx update-rule-docs eslint-plugin-template`.
