### PR TITLE
feat(eslint-plugin): [use-injectable-provided-in] add allowProvidedInNull option

### DIFF
--- a/packages/eslint-plugin/docs/rules/use-injectable-provided-in.md
+++ b/packages/eslint-plugin/docs/rules/use-injectable-provided-in.md
@@ -25,7 +25,7 @@ Using the `providedIn` property makes `Injectables` tree-shakable
 
 ## Rationale
 
-Using 'providedIn' in the @Injectable() decorator (like '@Injectable({ providedIn: "root" })') enables tree-shaking, which means Angular can remove the service from your production bundle if it's never actually used. Without 'providedIn', services must be registered in a module's providers array, and Angular must include them in the bundle even if they're unused. This can significantly increase bundle size. Additionally, 'providedIn' makes services easier to use (no need to add them to module providers) and makes circular dependencies less likely. The 'providedIn' syntax is the modern, recommended way to provide services. Setting 'providedIn' to 'null' is an intentional choice to scope the service to a specific injector and is therefore allowed by this rule.
+Using 'providedIn' in the @Injectable() decorator (like '@Injectable({ providedIn: "root" })') enables tree-shaking, which means Angular can remove the service from your production bundle if it's never actually used. Without 'providedIn', services must be registered in a module's providers array, and Angular must include them in the bundle even if they're unused. This can significantly increase bundle size. Additionally, 'providedIn' makes services easier to use (no need to add them to module providers) and makes circular dependencies less likely. The 'providedIn' syntax is the modern, recommended way to provide services. Angular treats 'providedIn: null' as equivalent to omitting the property, so it is flagged by default. Set 'allowProvidedInNull' to true if you need to permit this pattern.
 
 <br>
 
@@ -36,6 +36,10 @@ The rule accepts an options object with the following properties:
 ```ts
 interface Options {
   ignoreClassNamePattern?: string;
+  /**
+   * Default: `false`
+   */
+  allowProvidedInNull?: boolean;
 }
 
 ```
@@ -129,6 +133,34 @@ class Test {}
 const providedIn = 'anotherProperty';
 @Injectable({ [providedIn]: [] })
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+class Test {}
+```
+
+<br>
+
+---
+
+<br>
+
+#### Default Config
+
+```json
+{
+  "rules": {
+    "@angular-eslint/use-injectable-provided-in": [
+      "error"
+    ]
+  }
+}
+```
+
+<br>
+
+#### ❌ Invalid Code
+
+```ts
+@Injectable({ providedIn: null })
+                          ~~~~
 class Test {}
 ```
 
@@ -552,13 +584,16 @@ class Test {}
 
 <br>
 
-#### Default Config
+#### Custom Config
 
 ```json
 {
   "rules": {
     "@angular-eslint/use-injectable-provided-in": [
-      "error"
+      "error",
+      {
+        "allowProvidedInNull": true
+      }
     ]
   }
 }

--- a/packages/eslint-plugin/docs/rules/use-injectable-provided-in.md
+++ b/packages/eslint-plugin/docs/rules/use-injectable-provided-in.md
@@ -25,7 +25,7 @@ Using the `providedIn` property makes `Injectables` tree-shakable
 
 ## Rationale
 
-Using 'providedIn' in the @Injectable() decorator (like '@Injectable({ providedIn: "root" })') enables tree-shaking, which means Angular can remove the service from your production bundle if it's never actually used. Without 'providedIn', services must be registered in a module's providers array, and Angular must include them in the bundle even if they're unused. This can significantly increase bundle size. Additionally, 'providedIn' makes services easier to use (no need to add them to module providers) and makes circular dependencies less likely. The 'providedIn' syntax is the modern, recommended way to provide services.
+Using 'providedIn' in the @Injectable() decorator (like '@Injectable({ providedIn: "root" })') enables tree-shaking, which means Angular can remove the service from your production bundle if it's never actually used. Without 'providedIn', services must be registered in a module's providers array, and Angular must include them in the bundle even if they're unused. This can significantly increase bundle size. Additionally, 'providedIn' makes services easier to use (no need to add them to module providers) and makes circular dependencies less likely. The 'providedIn' syntax is the modern, recommended way to provide services. Setting 'providedIn' to 'null' is an intentional choice to scope the service to a specific injector and is therefore allowed by this rule.
 
 <br>
 
@@ -129,34 +129,6 @@ class Test {}
 const providedIn = 'anotherProperty';
 @Injectable({ [providedIn]: [] })
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-class Test {}
-```
-
-<br>
-
----
-
-<br>
-
-#### Default Config
-
-```json
-{
-  "rules": {
-    "@angular-eslint/use-injectable-provided-in": [
-      "error"
-    ]
-  }
-}
-```
-
-<br>
-
-#### ❌ Invalid Code
-
-```ts
-@Injectable({ providedIn: null })
-                          ~~~~
 class Test {}
 ```
 
@@ -571,6 +543,33 @@ class Test {}
 
 ```ts
 @Service()
+class Test {}
+```
+
+<br>
+
+---
+
+<br>
+
+#### Default Config
+
+```json
+{
+  "rules": {
+    "@angular-eslint/use-injectable-provided-in": [
+      "error"
+    ]
+  }
+}
+```
+
+<br>
+
+#### ✅ Valid Code
+
+```ts
+@Injectable({ providedIn: null })
 class Test {}
 ```
 

--- a/packages/eslint-plugin/src/rules/use-injectable-provided-in.ts
+++ b/packages/eslint-plugin/src/rules/use-injectable-provided-in.ts
@@ -38,10 +38,10 @@ export default createESLintRule<Options, MessageIds>({
       METADATA_PROPERTY_NAME,
     );
     const withoutProvidedInDecorator = `${injectableClassDecorator}:matches([expression.arguments.length=0], [expression.arguments.0.type='ObjectExpression']:not(:has(${providedInMetadataProperty})))`;
-    const nullableProvidedInProperty = `${injectableClassDecorator} ${providedInMetadataProperty}:matches([value.type='Identifier'][value.name='undefined'], [value.type='Literal'][value.raw='null'])`;
+    const undefinedProvidedInProperty = `${injectableClassDecorator} ${providedInMetadataProperty}:matches([value.type='Identifier'][value.name='undefined'], [value.type='Literal'][value.raw='undefined'])`;
     const selectors = [
       withoutProvidedInDecorator,
-      nullableProvidedInProperty,
+      undefinedProvidedInProperty,
     ].join(',');
 
     return {
@@ -69,5 +69,5 @@ export default createESLintRule<Options, MessageIds>({
 });
 
 export const RULE_DOCS_EXTENSION = {
-  rationale: `Using 'providedIn' in the @Injectable() decorator (like '@Injectable({ providedIn: "root" })') enables tree-shaking, which means Angular can remove the service from your production bundle if it's never actually used. Without 'providedIn', services must be registered in a module's providers array, and Angular must include them in the bundle even if they're unused. This can significantly increase bundle size. Additionally, 'providedIn' makes services easier to use (no need to add them to module providers) and makes circular dependencies less likely. The 'providedIn' syntax is the modern, recommended way to provide services.`,
+  rationale: `Using 'providedIn' in the @Injectable() decorator (like '@Injectable({ providedIn: "root" })') enables tree-shaking, which means Angular can remove the service from your production bundle if it's never actually used. Without 'providedIn', services must be registered in a module's providers array, and Angular must include them in the bundle even if they're unused. This can significantly increase bundle size. Additionally, 'providedIn' makes services easier to use (no need to add them to module providers) and makes circular dependencies less likely. The 'providedIn' syntax is the modern, recommended way to provide services. Setting 'providedIn' to 'null' is an intentional choice to scope the service to a specific injector and is therefore allowed by this rule.`,
 };

--- a/packages/eslint-plugin/src/rules/use-injectable-provided-in.ts
+++ b/packages/eslint-plugin/src/rules/use-injectable-provided-in.ts
@@ -2,10 +2,18 @@ import { ASTUtils, RuleFixes, Selectors } from '@angular-eslint/utils';
 import type { TSESTree } from '@typescript-eslint/utils';
 import { createESLintRule } from '../utils/create-eslint-rule';
 
-export type Options = [{ readonly ignoreClassNamePattern?: string }];
+export type Options = [
+  {
+    readonly ignoreClassNamePattern?: string;
+    readonly allowProvidedInNull?: boolean;
+  },
+];
 export type MessageIds = 'useInjectableProvidedIn' | 'suggestInjector';
 export const RULE_NAME = 'use-injectable-provided-in';
 const METADATA_PROPERTY_NAME = 'providedIn';
+const DEFAULT_OPTIONS: Options[0] = {
+  allowProvidedInNull: false,
+};
 
 export default createESLintRule<Options, MessageIds>({
   name: RULE_NAME,
@@ -22,6 +30,10 @@ export default createESLintRule<Options, MessageIds>({
           ignoreClassNamePattern: {
             type: 'string',
           },
+          allowProvidedInNull: {
+            type: 'boolean',
+            default: DEFAULT_OPTIONS.allowProvidedInNull,
+          },
         },
         additionalProperties: false,
       },
@@ -31,17 +43,19 @@ export default createESLintRule<Options, MessageIds>({
       suggestInjector: `Use \`${METADATA_PROPERTY_NAME}: '{{injector}}'\``,
     },
   },
-  defaultOptions: [{}],
-  create(context, [{ ignoreClassNamePattern }]) {
+  defaultOptions: [DEFAULT_OPTIONS],
+  create(context, [{ ignoreClassNamePattern, allowProvidedInNull }]) {
     const injectableClassDecorator = `ClassDeclaration:not([id.name=${ignoreClassNamePattern}]):not(:has(TSClassImplements:matches([expression.property.name='HttpInterceptor'], [expression.name='HttpInterceptor']))) > Decorator[expression.callee.name="Injectable"]`;
     const providedInMetadataProperty = Selectors.metadataProperty(
       METADATA_PROPERTY_NAME,
     );
     const withoutProvidedInDecorator = `${injectableClassDecorator}:matches([expression.arguments.length=0], [expression.arguments.0.type='ObjectExpression']:not(:has(${providedInMetadataProperty})))`;
-    const undefinedProvidedInProperty = `${injectableClassDecorator} ${providedInMetadataProperty}:matches([value.type='Identifier'][value.name='undefined'], [value.type='Literal'][value.raw='undefined'])`;
+    const undefinedProvidedInProperty = `${injectableClassDecorator} ${providedInMetadataProperty}[value.type='Identifier'][value.name='undefined']`;
+    const nullProvidedInProperty = `${injectableClassDecorator} ${providedInMetadataProperty}[value.type='Literal'][value.raw='null']`;
     const selectors = [
       withoutProvidedInDecorator,
       undefinedProvidedInProperty,
+      ...(allowProvidedInNull ? [] : [nullProvidedInProperty]),
     ].join(',');
 
     return {
@@ -69,5 +83,5 @@ export default createESLintRule<Options, MessageIds>({
 });
 
 export const RULE_DOCS_EXTENSION = {
-  rationale: `Using 'providedIn' in the @Injectable() decorator (like '@Injectable({ providedIn: "root" })') enables tree-shaking, which means Angular can remove the service from your production bundle if it's never actually used. Without 'providedIn', services must be registered in a module's providers array, and Angular must include them in the bundle even if they're unused. This can significantly increase bundle size. Additionally, 'providedIn' makes services easier to use (no need to add them to module providers) and makes circular dependencies less likely. The 'providedIn' syntax is the modern, recommended way to provide services. Setting 'providedIn' to 'null' is an intentional choice to scope the service to a specific injector and is therefore allowed by this rule.`,
+  rationale: `Using 'providedIn' in the @Injectable() decorator (like '@Injectable({ providedIn: "root" })') enables tree-shaking, which means Angular can remove the service from your production bundle if it's never actually used. Without 'providedIn', services must be registered in a module's providers array, and Angular must include them in the bundle even if they're unused. This can significantly increase bundle size. Additionally, 'providedIn' makes services easier to use (no need to add them to module providers) and makes circular dependencies less likely. The 'providedIn' syntax is the modern, recommended way to provide services. Angular treats 'providedIn: null' as equivalent to omitting the property, so it is flagged by default. Set 'allowProvidedInNull' to true if you need to permit this pattern.`,
 };

--- a/packages/eslint-plugin/tests/rules/use-injectable-provided-in/cases.ts
+++ b/packages/eslint-plugin/tests/rules/use-injectable-provided-in/cases.ts
@@ -70,6 +70,11 @@ export const valid: readonly (string | ValidTestCase<Options>)[] = [
     @Service()
     class Test {}
   `,
+  // https://github.com/angular-eslint/angular-eslint/issues/3120
+  `
+    @Injectable({ providedIn: null })
+    class Test {}
+  `,
 ];
 
 export const invalid: readonly InvalidTestCase<MessageIds, Options>[] = [
@@ -124,24 +129,6 @@ export const invalid: readonly InvalidTestCase<MessageIds, Options>[] = [
       const providedIn = 'anotherProperty';
       @Injectable({ [providedIn]: [], providedIn: '${injector}' })
       
-      class Test {}
-    `,
-      data: { injector },
-    })),
-  }),
-  convertAnnotatedSourceToFailureCase({
-    description: 'should fail if `providedIn` is set to `null`',
-    annotatedSource: `
-      @Injectable({ providedIn: null })
-                                ~~~~
-      class Test {}
-    `,
-    messageId,
-    suggestions: (['any', 'platform', 'root'] as const).map((injector) => ({
-      messageId: suggestInjector,
-      output: `
-      @Injectable({ providedIn: '${injector}' })
-                                
       class Test {}
     `,
       data: { injector },

--- a/packages/eslint-plugin/tests/rules/use-injectable-provided-in/cases.ts
+++ b/packages/eslint-plugin/tests/rules/use-injectable-provided-in/cases.ts
@@ -71,10 +71,13 @@ export const valid: readonly (string | ValidTestCase<Options>)[] = [
     class Test {}
   `,
   // https://github.com/angular-eslint/angular-eslint/issues/3120
-  `
-    @Injectable({ providedIn: null })
-    class Test {}
-  `,
+  {
+    code: `
+      @Injectable({ providedIn: null })
+      class Test {}
+    `,
+    options: [{ allowProvidedInNull: true }],
+  },
 ];
 
 export const invalid: readonly InvalidTestCase<MessageIds, Options>[] = [
@@ -129,6 +132,24 @@ export const invalid: readonly InvalidTestCase<MessageIds, Options>[] = [
       const providedIn = 'anotherProperty';
       @Injectable({ [providedIn]: [], providedIn: '${injector}' })
       
+      class Test {}
+    `,
+      data: { injector },
+    })),
+  }),
+  convertAnnotatedSourceToFailureCase({
+    description: 'should fail if `providedIn` is set to `null`',
+    annotatedSource: `
+      @Injectable({ providedIn: null })
+                                ~~~~
+      class Test {}
+    `,
+    messageId,
+    suggestions: (['any', 'platform', 'root'] as const).map((injector) => ({
+      messageId: suggestInjector,
+      output: `
+      @Injectable({ providedIn: '${injector}' })
+                                
       class Test {}
     `,
       data: { injector },


### PR DESCRIPTION
## Summary

- Add an `allowProvidedInNull` option (default `false`) to `use-injectable-provided-in`
- `providedIn: null` remains flagged unless users opt in
- `providedIn: undefined` continues to be flagged
- Simplified the `undefined` AST selector per review feedback

Fixes #3120

## Test plan

- [x] Added valid test case for `providedIn: null` with `allowProvidedInNull: true`
- [x] Kept `providedIn: null` as invalid by default
- [x] All rule tests pass (`pnpm nx test eslint-plugin -- use-injectable-provided-in`)
- [x] Rule docs regenerated