### PR TITLE
fix: remove unused @angular/cli peer and report Angular major mismatches at runtime

### DIFF
--- a/docs/ANGULAR_VERSION_SUPPORT.md
+++ b/docs/ANGULAR_VERSION_SUPPORT.md
@@ -13,6 +13,8 @@ Therefore, as an example (because these versions may or may not exist yet when y
 
 > NOTE: the exact minor and patch versions of each library represented here by `x`'s do not need to match each other, just the first (major) number
 
+`ng add angular-eslint` and `ng lint` will warn when they can see that the workspace's `@angular/core` or `@angular/cli` major does not match the installed `angular-eslint` major. This is informational: installation and linting still proceed.
+
 ## Prior to v12
 
 In order to support the above major version alignment to make things MUCH simpler from now on, in `@angular-eslint` we jumped from major version `4` to `12` (i.e. major versions 5-11 do not exist). This makes the version alignment prior to v12 a little harder to follow by comparison, but the following section outlines what you should be using together if you cannot move to Angular v12 yet for whatever reason.

--- a/packages/angular-eslint/package.json
+++ b/packages/angular-eslint/package.json
@@ -19,7 +19,6 @@
     "LICENSE"
   ],
   "peerDependencies": {
-    "@angular/cli": "catalog:other-runtime-dependencies",
     "eslint": "^9.0.0 || ^10.0.0",
     "typescript": "*",
     "typescript-eslint": "^8.0.0"

--- a/packages/builder/package.json
+++ b/packages/builder/package.json
@@ -24,7 +24,6 @@
     "@angular-devkit/core": "catalog:other-runtime-dependencies"
   },
   "peerDependencies": {
-    "@angular/cli": "catalog:other-runtime-dependencies",
     "eslint": "^9.0.0 || ^10.0.0",
     "typescript": "*"
   },

--- a/packages/builder/src/lint.impl.spec.ts
+++ b/packages/builder/src/lint.impl.spec.ts
@@ -168,6 +168,51 @@ describe('Linter Builder', () => {
     expect(result.error).toBeUndefined();
   });
 
+  it('should warn when the workspace Angular major does not match', async () => {
+    const actualFs = await vi.importActual<typeof import('node:fs')>('node:fs');
+    const pkgPath = join(testWorkspaceRoot, 'package.json');
+    actualFs.writeFileSync(
+      pkgPath,
+      JSON.stringify({
+        dependencies: { '@angular/core': '^21.2.0' },
+      }),
+    );
+    mockReports = [
+      {
+        errorCount: 0,
+        warningCount: 0,
+        results: [],
+        messages: [],
+        usedDeprecatedRules: [],
+      },
+    ];
+    const logger = new logging.Logger('compat');
+    const warnings: string[] = [];
+    logger.subscribe((entry) => {
+      if (entry.level === 'warn') {
+        warnings.push(entry.message);
+      }
+    });
+    const run = await architect.scheduleBuilder(
+      builderName,
+      createValidRunBuilderOptions({
+        lintFilePatterns: ['includedFile1'],
+        format: 'stylish',
+        silent: false,
+      }),
+      { logger },
+    );
+    await run.result;
+    actualFs.writeFileSync(pkgPath, '{}');
+    expect(
+      warnings.some(
+        (message) =>
+          message.includes('angular-eslint v22 is intended for Angular v22') &&
+          message.includes('@angular/core@^21.2.0 (v21)'),
+      ),
+    ).toBe(true);
+  });
+
   it('should resolve and instantiate ESLint with the options that were passed to the builder', async () => {
     await runBuilder(
       createValidRunBuilderOptions({

--- a/packages/builder/src/lint.impl.ts
+++ b/packages/builder/src/lint.impl.ts
@@ -1,12 +1,20 @@
 import { createBuilder, type BuilderOutput } from '@angular-devkit/architect';
 import type { ESLint } from 'eslint';
 import { existsSync, mkdirSync, writeFileSync } from 'fs';
+import { createRequire } from 'node:module';
 import { dirname, join, resolve } from 'path';
 import type { Schema } from './schema';
+import { parseMajorVersion } from './utils/angular-version-compat';
 import {
   defaultFlatConfigNames,
   resolveAndInstantiateESLint,
 } from './utils/eslint-utils';
+import { reportAngularVersionCompatibility } from './utils/report-angular-version-compat';
+
+const requireFromModule = createRequire(__filename);
+const { version: builderVersion } = requireFromModule('../package.json') as {
+  version: string;
+};
 
 export default createBuilder(
   async (options: Schema, context): Promise<BuilderOutput> => {
@@ -37,6 +45,17 @@ export default createBuilder(
 
       if (printInfo) {
         console.info(`\nLinting ${JSON.stringify(projectName)}...`);
+      }
+
+      const expectedMajor = parseMajorVersion(builderVersion);
+      if (expectedMajor !== null) {
+        reportAngularVersionCompatibility(
+          systemRoot,
+          expectedMajor,
+          (message) => {
+            context.logger.warn(message);
+          },
+        );
       }
 
       const eslintConfigPath = options.eslintConfig

--- a/packages/builder/src/utils/angular-version-compat.spec.ts
+++ b/packages/builder/src/utils/angular-version-compat.spec.ts
@@ -1,0 +1,89 @@
+import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, expect, it, vi } from 'vitest';
+import {
+  findAngularVersionMismatches,
+  formatAngularVersionMismatchMessage,
+  parseMajorVersion,
+} from './angular-version-compat';
+import { reportAngularVersionCompatibility } from './report-angular-version-compat';
+
+describe('parseMajorVersion', () => {
+  it('parses caret ranges and exact versions', () => {
+    expect(parseMajorVersion('^22.1.0')).toBe(22);
+    expect(parseMajorVersion('21.2.0')).toBe(21);
+  });
+});
+
+describe('findAngularVersionMismatches', () => {
+  it('ignores workspaces with no Angular packages', () => {
+    expect(findAngularVersionMismatches({}, 22)).toEqual([]);
+  });
+
+  it('flags a declared Angular 21 workspace', () => {
+    expect(
+      findAngularVersionMismatches(
+        { dependencies: { '@angular/core': '~21.2.0' } },
+        22,
+      ),
+    ).toEqual([
+      {
+        packageName: '@angular/core',
+        specifier: '~21.2.0',
+        foundMajor: 21,
+      },
+    ]);
+  });
+});
+
+describe('reportAngularVersionCompatibility', () => {
+  it('does not warn when package.json has no Angular packages', () => {
+    const workspace = mkdtempSync(join(tmpdir(), 'ae-compat-'));
+    writeFileSync(join(workspace, 'package.json'), JSON.stringify({}));
+    const warn = vi.fn();
+    reportAngularVersionCompatibility(workspace, 22, warn);
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it('warns from the workspace package.json when majors differ', () => {
+    const workspace = mkdtempSync(join(tmpdir(), 'ae-compat-'));
+    writeFileSync(
+      join(workspace, 'package.json'),
+      JSON.stringify({
+        dependencies: { '@angular/core': '^21.2.0' },
+      }),
+    );
+    const warn = vi.fn();
+    reportAngularVersionCompatibility(workspace, 22, warn);
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(warn.mock.calls[0][0]).toBe(
+      formatAngularVersionMismatchMessage(22, [
+        {
+          packageName: '@angular/core',
+          specifier: '^21.2.0',
+          foundMajor: 21,
+        },
+      ]),
+    );
+  });
+
+  it('prefers the installed package major under node_modules', () => {
+    const workspace = mkdtempSync(join(tmpdir(), 'ae-compat-'));
+    writeFileSync(
+      join(workspace, 'package.json'),
+      JSON.stringify({
+        dependencies: { '@angular/core': '^21.2.0' },
+      }),
+    );
+    const coreDir = join(workspace, 'node_modules', '@angular', 'core');
+    mkdirSync(coreDir, { recursive: true });
+    writeFileSync(
+      join(coreDir, 'package.json'),
+      JSON.stringify({ name: '@angular/core', version: '22.1.3' }),
+    );
+    const warn = vi.fn();
+    reportAngularVersionCompatibility(workspace, 22, warn);
+    expect(warn).not.toHaveBeenCalled();
+  });
+});

--- a/packages/builder/src/utils/angular-version-compat.spec.ts
+++ b/packages/builder/src/utils/angular-version-compat.spec.ts
@@ -13,6 +13,12 @@ describe('parseMajorVersion', () => {
   it('parses caret ranges and exact versions', () => {
     expect(parseMajorVersion('^22.1.0')).toBe(22);
     expect(parseMajorVersion('21.2.0')).toBe(21);
+    expect(parseMajorVersion('22.0.0-e2e')).toBe(22);
+  });
+
+  it('treats 0.x placeholders such as 0.0.0-e2e as undetectable', () => {
+    expect(parseMajorVersion('0.0.0-e2e')).toBeNull();
+    expect(parseMajorVersion('0.0.0')).toBeNull();
   });
 });
 

--- a/packages/builder/src/utils/angular-version-compat.spec.ts
+++ b/packages/builder/src/utils/angular-version-compat.spec.ts
@@ -4,21 +4,38 @@ import { join } from 'node:path';
 import { describe, expect, it, vi } from 'vitest';
 import {
   findAngularVersionMismatches,
+  formatAngularVersionMatchMessage,
   formatAngularVersionMismatchMessage,
+  hasDetectableAngularVersion,
   parseMajorVersion,
 } from './angular-version-compat';
 import { reportAngularVersionCompatibility } from './report-angular-version-compat';
 
 describe('parseMajorVersion', () => {
-  it('parses caret ranges and exact versions', () => {
-    expect(parseMajorVersion('^22.1.0')).toBe(22);
-    expect(parseMajorVersion('21.2.0')).toBe(21);
-    expect(parseMajorVersion('22.0.0-e2e')).toBe(22);
+  it.each([
+    ['22.1.0', 22],
+    ['^22.1.4', 22],
+    ['~21.2.0', 21],
+    ['>= 22.0.0 < 23.0.0', 22],
+    ['v21.0.0', 21],
+    ['22.0.0-e2e', 22],
+  ])('parses %s as %s', (specifier, expected) => {
+    expect(parseMajorVersion(specifier)).toBe(expected);
   });
 
-  it('treats 0.x placeholders such as 0.0.0-e2e as undetectable', () => {
-    expect(parseMajorVersion('0.0.0-e2e')).toBeNull();
-    expect(parseMajorVersion('0.0.0')).toBeNull();
+  it.each([
+    '',
+    '*',
+    'latest',
+    'workspace:*',
+    'catalog:other',
+    'file:../pkg',
+    'not-a-version',
+    '0.0.0-e2e',
+    '0.0.0',
+    undefined,
+  ])('returns null for %s', (specifier) => {
+    expect(parseMajorVersion(specifier)).toBeNull();
   });
 });
 
@@ -40,6 +57,46 @@ describe('findAngularVersionMismatches', () => {
         foundMajor: 21,
       },
     ]);
+  });
+
+  it('reads Angular packages from peerDependencies', () => {
+    expect(
+      findAngularVersionMismatches(
+        { peerDependencies: { '@angular/core': '^21.2.0' } },
+        22,
+      ),
+    ).toEqual([
+      {
+        packageName: '@angular/core',
+        specifier: '^21.2.0',
+        foundMajor: 21,
+      },
+    ]);
+  });
+
+  it('uses an installed major when the specifier is not declared', () => {
+    expect(
+      findAngularVersionMismatches({}, 22, { '@angular/cli': 21 }),
+    ).toEqual([
+      {
+        packageName: '@angular/cli',
+        specifier: 'v21',
+        foundMajor: 21,
+      },
+    ]);
+  });
+});
+
+describe('messages', () => {
+  it('formats a match confirmation', () => {
+    expect(formatAngularVersionMatchMessage(22)).toBe(
+      "angular-eslint v22 matches this workspace's Angular v22.",
+    );
+  });
+
+  it('detects Angular from an installed major even without a declaration', () => {
+    expect(hasDetectableAngularVersion({})).toBe(false);
+    expect(hasDetectableAngularVersion({}, { '@angular/core': 22 })).toBe(true);
   });
 });
 

--- a/packages/builder/src/utils/angular-version-compat.ts
+++ b/packages/builder/src/utils/angular-version-compat.ts
@@ -1,0 +1,122 @@
+/**
+ * Shared helpers for reporting Angular major mismatches without using a
+ * package-manager peer on `@angular/cli`.
+ */
+
+export const ANGULAR_PACKAGES_TO_CHECK = [
+  '@angular/core',
+  '@angular/cli',
+] as const;
+
+export interface PackageJsonLike {
+  dependencies?: Record<string, string>;
+  devDependencies?: Record<string, string>;
+  peerDependencies?: Record<string, string>;
+  version?: string;
+}
+
+export interface AngularVersionMismatch {
+  packageName: string;
+  specifier: string;
+  foundMajor: number;
+}
+
+/**
+ * Best-effort major from a semver version or range (`^22.1.0`, `~21.2.0`,
+ * `>= 22.0.0 < 23.0.0`, `22.1.0`).
+ */
+export function parseMajorVersion(
+  specifier: string | undefined | null,
+): number | null {
+  if (!specifier) {
+    return null;
+  }
+  const trimmed = specifier.trim();
+  if (
+    !trimmed ||
+    trimmed === '*' ||
+    trimmed === 'latest' ||
+    /^(workspace|catalog|file|link|portal|git|http|https):/i.test(trimmed)
+  ) {
+    return null;
+  }
+  const match = trimmed.match(/(\d+)/);
+  if (!match) {
+    return null;
+  }
+  return Number(match[1]);
+}
+
+export function findDeclaredDependency(
+  pkg: PackageJsonLike,
+  name: string,
+): string | undefined {
+  return (
+    pkg.dependencies?.[name] ??
+    pkg.devDependencies?.[name] ??
+    pkg.peerDependencies?.[name]
+  );
+}
+
+export function findAngularVersionMismatches(
+  workspacePackageJson: PackageJsonLike,
+  expectedMajor: number,
+  installedMajors?: Partial<Record<string, number | null>>,
+): AngularVersionMismatch[] {
+  const mismatches: AngularVersionMismatch[] = [];
+  for (const name of ANGULAR_PACKAGES_TO_CHECK) {
+    const declared = findDeclaredDependency(workspacePackageJson, name);
+    const installedMajor = installedMajors?.[name];
+    const major = installedMajor ?? parseMajorVersion(declared);
+    if (major == null || major === expectedMajor) {
+      continue;
+    }
+    mismatches.push({
+      packageName: name,
+      specifier: declared ?? `v${major}`,
+      foundMajor: major,
+    });
+  }
+  return mismatches;
+}
+
+export function hasDetectableAngularVersion(
+  workspacePackageJson: PackageJsonLike,
+  installedMajors?: Partial<Record<string, number | null>>,
+): boolean {
+  return ANGULAR_PACKAGES_TO_CHECK.some((name) => {
+    const installed = installedMajors?.[name];
+    if (installed != null) {
+      return true;
+    }
+    return (
+      parseMajorVersion(findDeclaredDependency(workspacePackageJson, name)) !==
+      null
+    );
+  });
+}
+
+export function formatAngularVersionMismatchMessage(
+  expectedMajor: number,
+  mismatches: AngularVersionMismatch[],
+): string {
+  const details = mismatches
+    .map(
+      (mismatch) =>
+        `  - ${mismatch.packageName}@${mismatch.specifier} (v${mismatch.foundMajor})`,
+    )
+    .join('\n');
+  return `
+angular-eslint v${expectedMajor} is intended for Angular v${expectedMajor}.
+This workspace is using a different Angular major:
+${details}
+
+See https://github.com/angular-eslint/angular-eslint/blob/main/docs/ANGULAR_VERSION_SUPPORT.md
+`.trim();
+}
+
+export function formatAngularVersionMatchMessage(
+  expectedMajor: number,
+): string {
+  return `angular-eslint v${expectedMajor} matches this workspace's Angular v${expectedMajor}.`;
+}

--- a/packages/builder/src/utils/angular-version-compat.ts
+++ b/packages/builder/src/utils/angular-version-compat.ts
@@ -44,7 +44,13 @@ export function parseMajorVersion(
   if (!match) {
     return null;
   }
-  return Number(match[1]);
+  const major = Number(match[1]);
+  // 0.x (including the e2e publish version `0.0.0-e2e`) is not an
+  // Angular-aligned major; treat it as undetectable rather than v0.
+  if (major === 0) {
+    return null;
+  }
+  return major;
 }
 
 export function findDeclaredDependency(

--- a/packages/builder/src/utils/report-angular-version-compat.ts
+++ b/packages/builder/src/utils/report-angular-version-compat.ts
@@ -1,0 +1,69 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import {
+  ANGULAR_PACKAGES_TO_CHECK,
+  findAngularVersionMismatches,
+  formatAngularVersionMismatchMessage,
+  parseMajorVersion,
+  type PackageJsonLike,
+} from './angular-version-compat';
+
+function readWorkspacePackageJson(workspaceRoot: string): PackageJsonLike {
+  try {
+    return JSON.parse(
+      readFileSync(join(workspaceRoot, 'package.json'), 'utf8'),
+    ) as PackageJsonLike;
+  } catch {
+    return {};
+  }
+}
+
+/**
+ * Read an installed package version from this workspace only (no walk-up
+ * into parent node_modules, which would lie in monorepo tests and nested
+ * workspaces).
+ */
+function readInstalledMajor(
+  workspaceRoot: string,
+  packageName: string,
+): number | null {
+  try {
+    const pkgJsonPath = join(
+      workspaceRoot,
+      'node_modules',
+      ...packageName.split('/'),
+      'package.json',
+    );
+    const pkg = JSON.parse(readFileSync(pkgJsonPath, 'utf8')) as {
+      version?: string;
+    };
+    return parseMajorVersion(pkg.version);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Warn when the workspace Angular major does not match this builder's major.
+ * Does not fail the lint; package managers should not be the compatibility UI.
+ */
+export function reportAngularVersionCompatibility(
+  workspaceRoot: string,
+  expectedMajor: number,
+  warn: (message: string) => void,
+): void {
+  const workspacePackageJson = readWorkspacePackageJson(workspaceRoot);
+  const installedMajors: Partial<Record<string, number | null>> = {};
+  for (const name of ANGULAR_PACKAGES_TO_CHECK) {
+    installedMajors[name] = readInstalledMajor(workspaceRoot, name);
+  }
+  const mismatches = findAngularVersionMismatches(
+    workspacePackageJson,
+    expectedMajor,
+    installedMajors,
+  );
+  if (mismatches.length === 0) {
+    return;
+  }
+  warn(formatAngularVersionMismatchMessage(expectedMajor, mismatches));
+}

--- a/packages/schematics/package.json
+++ b/packages/schematics/package.json
@@ -36,9 +36,6 @@
   "ng-add": {
     "save": "devDependencies"
   },
-  "peerDependencies": {
-    "@angular/cli": "catalog:other-runtime-dependencies"
-  },
   "dependencies": {
     "@angular-devkit/core": "catalog:other-runtime-dependencies",
     "@angular-devkit/schematics": "catalog:other-runtime-dependencies",

--- a/packages/schematics/src/angular-version-compat.ts
+++ b/packages/schematics/src/angular-version-compat.ts
@@ -1,0 +1,122 @@
+/**
+ * Shared helpers for reporting Angular major mismatches without using a
+ * package-manager peer on `@angular/cli`.
+ */
+
+export const ANGULAR_PACKAGES_TO_CHECK = [
+  '@angular/core',
+  '@angular/cli',
+] as const;
+
+export interface PackageJsonLike {
+  dependencies?: Record<string, string>;
+  devDependencies?: Record<string, string>;
+  peerDependencies?: Record<string, string>;
+  version?: string;
+}
+
+export interface AngularVersionMismatch {
+  packageName: string;
+  specifier: string;
+  foundMajor: number;
+}
+
+/**
+ * Best-effort major from a semver version or range (`^22.1.0`, `~21.2.0`,
+ * `>= 22.0.0 < 23.0.0`, `22.1.0`).
+ */
+export function parseMajorVersion(
+  specifier: string | undefined | null,
+): number | null {
+  if (!specifier) {
+    return null;
+  }
+  const trimmed = specifier.trim();
+  if (
+    !trimmed ||
+    trimmed === '*' ||
+    trimmed === 'latest' ||
+    /^(workspace|catalog|file|link|portal|git|http|https):/i.test(trimmed)
+  ) {
+    return null;
+  }
+  const match = trimmed.match(/(\d+)/);
+  if (!match) {
+    return null;
+  }
+  return Number(match[1]);
+}
+
+export function findDeclaredDependency(
+  pkg: PackageJsonLike,
+  name: string,
+): string | undefined {
+  return (
+    pkg.dependencies?.[name] ??
+    pkg.devDependencies?.[name] ??
+    pkg.peerDependencies?.[name]
+  );
+}
+
+export function findAngularVersionMismatches(
+  workspacePackageJson: PackageJsonLike,
+  expectedMajor: number,
+  installedMajors?: Partial<Record<string, number | null>>,
+): AngularVersionMismatch[] {
+  const mismatches: AngularVersionMismatch[] = [];
+  for (const name of ANGULAR_PACKAGES_TO_CHECK) {
+    const declared = findDeclaredDependency(workspacePackageJson, name);
+    const installedMajor = installedMajors?.[name];
+    const major = installedMajor ?? parseMajorVersion(declared);
+    if (major == null || major === expectedMajor) {
+      continue;
+    }
+    mismatches.push({
+      packageName: name,
+      specifier: declared ?? `v${major}`,
+      foundMajor: major,
+    });
+  }
+  return mismatches;
+}
+
+export function hasDetectableAngularVersion(
+  workspacePackageJson: PackageJsonLike,
+  installedMajors?: Partial<Record<string, number | null>>,
+): boolean {
+  return ANGULAR_PACKAGES_TO_CHECK.some((name) => {
+    const installed = installedMajors?.[name];
+    if (installed != null) {
+      return true;
+    }
+    return (
+      parseMajorVersion(findDeclaredDependency(workspacePackageJson, name)) !==
+      null
+    );
+  });
+}
+
+export function formatAngularVersionMismatchMessage(
+  expectedMajor: number,
+  mismatches: AngularVersionMismatch[],
+): string {
+  const details = mismatches
+    .map(
+      (mismatch) =>
+        `  - ${mismatch.packageName}@${mismatch.specifier} (v${mismatch.foundMajor})`,
+    )
+    .join('\n');
+  return `
+angular-eslint v${expectedMajor} is intended for Angular v${expectedMajor}.
+This workspace is using a different Angular major:
+${details}
+
+See https://github.com/angular-eslint/angular-eslint/blob/main/docs/ANGULAR_VERSION_SUPPORT.md
+`.trim();
+}
+
+export function formatAngularVersionMatchMessage(
+  expectedMajor: number,
+): string {
+  return `angular-eslint v${expectedMajor} matches this workspace's Angular v${expectedMajor}.`;
+}

--- a/packages/schematics/src/angular-version-compat.ts
+++ b/packages/schematics/src/angular-version-compat.ts
@@ -44,7 +44,13 @@ export function parseMajorVersion(
   if (!match) {
     return null;
   }
-  return Number(match[1]);
+  const major = Number(match[1]);
+  // 0.x (including the e2e publish version `0.0.0-e2e`) is not an
+  // Angular-aligned major; treat it as undetectable rather than v0.
+  if (major === 0) {
+    return null;
+  }
+  return major;
 }
 
 export function findDeclaredDependency(

--- a/packages/schematics/src/ng-add/index.ts
+++ b/packages/schematics/src/ng-add/index.ts
@@ -3,6 +3,14 @@ import { chain, schematic } from '@angular-devkit/schematics';
 import { NodePackageInstallTask } from '@angular-devkit/schematics/tasks';
 import type { Schema } from './schema';
 import {
+  findAngularVersionMismatches,
+  formatAngularVersionMatchMessage,
+  formatAngularVersionMismatchMessage,
+  hasDetectableAngularVersion,
+  parseMajorVersion,
+  type PackageJsonLike,
+} from '../angular-version-compat';
+import {
   createStringifiedRootESLintConfig,
   getTargetsConfigFromProject,
   readJsonInTree,
@@ -184,12 +192,37 @@ Please see https://github.com/angular-eslint/angular-eslint for more information
  *
  * @param options Configuration options passed to the schematic.
  */
+function reportAngularVersionCompatibility(
+  workspacePackageJson: PackageJsonLike,
+  context: SchematicContext,
+): void {
+  const expectedMajor = parseMajorVersion(packageJSON.version);
+  if (expectedMajor == null) {
+    return;
+  }
+  const mismatches = findAngularVersionMismatches(
+    workspacePackageJson,
+    expectedMajor,
+  );
+  if (mismatches.length > 0) {
+    context.logger.warn(
+      formatAngularVersionMismatchMessage(expectedMajor, mismatches),
+    );
+    return;
+  }
+  if (hasDetectableAngularVersion(workspacePackageJson)) {
+    context.logger.info(formatAngularVersionMatchMessage(expectedMajor));
+  }
+}
+
 export default function (options: Schema): Rule {
   return (host: Tree, context: SchematicContext) => {
     const workspacePackageJSON = (host.read('package.json') as Buffer).toString(
       'utf-8',
     );
     const json = JSON.parse(workspacePackageJSON);
+
+    reportAngularVersionCompatibility(json, context);
 
     return chain([
       addAngularESLintPackages(json, options),

--- a/packages/schematics/tests/angular-version-compat.test.ts
+++ b/packages/schematics/tests/angular-version-compat.test.ts
@@ -19,12 +19,22 @@ describe('parseMajorVersion', () => {
     expect(parseMajorVersion(specifier)).toBe(expected);
   });
 
-  it.each(['', '*', 'latest', 'workspace:*', 'file:../pkg', undefined])(
-    'returns null for %s',
-    (specifier) => {
-      expect(parseMajorVersion(specifier)).toBeNull();
-    },
-  );
+  it.each([
+    '',
+    '*',
+    'latest',
+    'workspace:*',
+    'file:../pkg',
+    '0.0.0-e2e',
+    '0.0.0',
+    undefined,
+  ])('returns null for %s', (specifier) => {
+    expect(parseMajorVersion(specifier)).toBeNull();
+  });
+
+  it('still parses a real major from a prerelease like 22.0.0-e2e', () => {
+    expect(parseMajorVersion('22.0.0-e2e')).toBe(22);
+  });
 });
 
 describe('findAngularVersionMismatches', () => {

--- a/packages/schematics/tests/angular-version-compat.test.ts
+++ b/packages/schematics/tests/angular-version-compat.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it } from 'vitest';
+import {
+  findAngularVersionMismatches,
+  formatAngularVersionMatchMessage,
+  formatAngularVersionMismatchMessage,
+  hasDetectableAngularVersion,
+  parseMajorVersion,
+} from '../src/angular-version-compat';
+
+describe('parseMajorVersion', () => {
+  it.each([
+    ['22.1.0', 22],
+    ['^22.1.4', 22],
+    ['~21.2.0', 21],
+    ['>= 22.0.0 < 23.0.0', 22],
+    ['v21.0.0', 21],
+    ['10', 10],
+  ])('parses %s as %s', (specifier, expected) => {
+    expect(parseMajorVersion(specifier)).toBe(expected);
+  });
+
+  it.each(['', '*', 'latest', 'workspace:*', 'file:../pkg', undefined])(
+    'returns null for %s',
+    (specifier) => {
+      expect(parseMajorVersion(specifier)).toBeNull();
+    },
+  );
+});
+
+describe('findAngularVersionMismatches', () => {
+  it('returns nothing when no Angular packages are declared', () => {
+    expect(findAngularVersionMismatches({ devDependencies: {} }, 22)).toEqual(
+      [],
+    );
+  });
+
+  it('returns nothing when declared majors match', () => {
+    expect(
+      findAngularVersionMismatches(
+        {
+          dependencies: { '@angular/core': '^22.1.0' },
+          devDependencies: { '@angular/cli': '22.1.4' },
+        },
+        22,
+      ),
+    ).toEqual([]);
+  });
+
+  it('reports mismatched @angular/core and @angular/cli', () => {
+    expect(
+      findAngularVersionMismatches(
+        {
+          dependencies: { '@angular/core': '^21.2.0' },
+          devDependencies: { '@angular/cli': '21.2.0' },
+        },
+        22,
+      ),
+    ).toEqual([
+      {
+        packageName: '@angular/core',
+        specifier: '^21.2.0',
+        foundMajor: 21,
+      },
+      {
+        packageName: '@angular/cli',
+        specifier: '21.2.0',
+        foundMajor: 21,
+      },
+    ]);
+  });
+
+  it('prefers an installed major over the declared range', () => {
+    expect(
+      findAngularVersionMismatches(
+        { dependencies: { '@angular/core': '^21.2.0' } },
+        22,
+        { '@angular/core': 22 },
+      ),
+    ).toEqual([]);
+  });
+});
+
+describe('messages', () => {
+  it('formats a mismatch for humans', () => {
+    const message = formatAngularVersionMismatchMessage(22, [
+      {
+        packageName: '@angular/core',
+        specifier: '^21.2.0',
+        foundMajor: 21,
+      },
+    ]);
+    expect(message).toContain(
+      'angular-eslint v22 is intended for Angular v22.',
+    );
+    expect(message).toContain('@angular/core@^21.2.0 (v21)');
+    expect(message).toContain('ANGULAR_VERSION_SUPPORT.md');
+  });
+
+  it('formats a match confirmation', () => {
+    expect(formatAngularVersionMatchMessage(22)).toBe(
+      "angular-eslint v22 matches this workspace's Angular v22.",
+    );
+  });
+
+  it('detects whether any Angular version is visible', () => {
+    expect(hasDetectableAngularVersion({})).toBe(false);
+    expect(
+      hasDetectableAngularVersion({
+        dependencies: { '@angular/core': '^22.0.0' },
+      }),
+    ).toBe(true);
+  });
+});

--- a/packages/schematics/tests/angular-version-compat.test.ts
+++ b/packages/schematics/tests/angular-version-compat.test.ts
@@ -25,6 +25,8 @@ describe('parseMajorVersion', () => {
     'latest',
     'workspace:*',
     'file:../pkg',
+    'catalog:other',
+    'not-a-version',
     '0.0.0-e2e',
     '0.0.0',
     undefined,
@@ -88,6 +90,33 @@ describe('findAngularVersionMismatches', () => {
       ),
     ).toEqual([]);
   });
+
+  it('uses an installed major when the specifier is not declared', () => {
+    expect(
+      findAngularVersionMismatches({}, 22, { '@angular/cli': 21 }),
+    ).toEqual([
+      {
+        packageName: '@angular/cli',
+        specifier: 'v21',
+        foundMajor: 21,
+      },
+    ]);
+  });
+
+  it('reads Angular packages from peerDependencies', () => {
+    expect(
+      findAngularVersionMismatches(
+        { peerDependencies: { '@angular/core': '^21.2.0' } },
+        22,
+      ),
+    ).toEqual([
+      {
+        packageName: '@angular/core',
+        specifier: '^21.2.0',
+        foundMajor: 21,
+      },
+    ]);
+  });
 });
 
 describe('messages', () => {
@@ -119,5 +148,6 @@ describe('messages', () => {
         dependencies: { '@angular/core': '^22.0.0' },
       }),
     ).toBe(true);
+    expect(hasDetectableAngularVersion({}, { '@angular/core': 22 })).toBe(true);
   });
 });

--- a/packages/schematics/tests/ng-add/index.test.ts
+++ b/packages/schematics/tests/ng-add/index.test.ts
@@ -460,4 +460,85 @@ describe('ng-add', () => {
       });
     });
   });
+
+  describe('Angular major compatibility feedback', () => {
+    let workspaceTree: UnitTestTree;
+
+    beforeEach(() => {
+      workspaceTree = new UnitTestTree(Tree.empty());
+      workspaceTree.create(
+        'angular.json',
+        JSON.stringify({
+          version: 1,
+          newProjectRoot: 'projects',
+          projects: {},
+        }),
+      );
+    });
+
+    it('should warn when the workspace Angular major does not match', async () => {
+      workspaceTree.create(
+        'package.json',
+        JSON.stringify({
+          dependencies: { '@angular/core': '^21.2.0' },
+          devDependencies: { '@angular/cli': '21.2.0' },
+        }),
+      );
+      const messages: string[] = [];
+      const subscription = schematicRunner.logger.subscribe((entry) => {
+        messages.push(`${entry.level}: ${entry.message}`);
+      });
+      await schematicRunner.runSchematic('ng-add', {}, workspaceTree);
+      subscription.unsubscribe();
+      expect(
+        messages.some(
+          (message) =>
+            message.startsWith('warn:') &&
+            message.includes(
+              'angular-eslint v22 is intended for Angular v22',
+            ) &&
+            message.includes('@angular/core@^21.2.0 (v21)'),
+        ),
+      ).toBe(true);
+    });
+
+    it('should confirm when the workspace Angular major matches', async () => {
+      workspaceTree.create(
+        'package.json',
+        JSON.stringify({
+          dependencies: { '@angular/core': '^22.1.0' },
+          devDependencies: {},
+        }),
+      );
+      const messages: string[] = [];
+      const subscription = schematicRunner.logger.subscribe((entry) => {
+        messages.push(`${entry.level}: ${entry.message}`);
+      });
+      await schematicRunner.runSchematic('ng-add', {}, workspaceTree);
+      subscription.unsubscribe();
+      expect(
+        messages.some((message) =>
+          message.includes(
+            "angular-eslint v22 matches this workspace's Angular v22.",
+          ),
+        ),
+      ).toBe(true);
+    });
+
+    it('should stay quiet when Angular is not declared', async () => {
+      workspaceTree.create(
+        'package.json',
+        JSON.stringify({ devDependencies: {} }),
+      );
+      const messages: string[] = [];
+      const subscription = schematicRunner.logger.subscribe((entry) => {
+        messages.push(entry.message);
+      });
+      await schematicRunner.runSchematic('ng-add', {}, workspaceTree);
+      subscription.unsubscribe();
+      expect(
+        messages.some((message) => message.includes('angular-eslint v22')),
+      ).toBe(false);
+    });
+  });
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -166,9 +166,6 @@ catalogs:
     '@angular-devkit/schematics':
       specifier: '>= 22.0.0 < 23.0.0'
       version: 22.1.4
-    '@angular/cli':
-      specifier: '>= 22.0.0 < 23.0.0'
-      version: 22.1.5
     aria-query:
       specifier: 5.3.2
       version: 5.3.2
@@ -394,9 +391,6 @@ importers:
       '@angular-eslint/template-parser':
         specifier: workspace:*
         version: link:../template-parser
-      '@angular/cli':
-        specifier: catalog:other-runtime-dependencies
-        version: 22.1.5(@types/node@25.9.5)(supports-color@8.1.1)
       '@typescript-eslint/types':
         specifier: ^8.0.0
         version: 8.67.0
@@ -421,9 +415,6 @@ importers:
       '@angular-devkit/core':
         specifier: catalog:other-runtime-dependencies
         version: 22.1.4
-      '@angular/cli':
-        specifier: catalog:other-runtime-dependencies
-        version: 22.1.5(@types/node@25.9.5)(supports-color@8.1.1)
       eslint:
         specifier: ^9.0.0 || ^10.0.0
         version: 10.9.0(jiti@2.6.1)(supports-color@8.1.1)
@@ -511,9 +502,6 @@ importers:
       '@angular-eslint/eslint-plugin-template':
         specifier: workspace:*
         version: link:../eslint-plugin-template
-      '@angular/cli':
-        specifier: catalog:other-runtime-dependencies
-        version: 22.1.5(@types/node@25.9.5)(supports-color@8.1.1)
       ignore:
         specifier: catalog:other-runtime-dependencies
         version: 7.0.6
@@ -6509,28 +6497,6 @@ snapshots:
       - chokidar
       - supports-color
 
-  '@angular/cli@22.1.5(@types/node@25.9.5)(supports-color@8.1.1)':
-    dependencies:
-      '@angular-devkit/architect': 0.2201.5
-      '@angular-devkit/core': 22.1.5
-      '@angular-devkit/schematics': 22.1.5
-      '@inquirer/prompts': 8.5.2(@types/node@25.9.5)
-      '@listr2/prompt-adapter-inquirer': 4.2.5(@inquirer/prompts@8.5.2(@types/node@25.9.5))(@types/node@25.9.5)(listr2@11.0.0)
-      '@modelcontextprotocol/sdk': 1.30.0(supports-color@8.1.1)(zod@4.4.3)
-      '@schematics/angular': 22.1.5
-      jsonc-parser: 3.3.1
-      listr2: 11.0.0
-      npm-package-arg: 14.0.0
-      parse5-html-rewriting-stream: 8.0.1
-      semver: 7.8.5
-      yargs: 18.1.0
-      zod: 4.4.3
-    transitivePeerDependencies:
-      - '@cfworker/json-schema'
-      - '@types/node'
-      - chokidar
-      - supports-color
-
   '@angular/compiler@22.1.3':
     dependencies:
       tslib: 2.8.1
@@ -8014,28 +7980,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@modelcontextprotocol/sdk@1.30.0(supports-color@8.1.1)(zod@4.4.3)':
-    dependencies:
-      '@hono/node-server': 1.19.14(hono@4.12.23)
-      ajv: 8.20.0
-      ajv-formats: 3.0.1(ajv@8.20.0)
-      content-type: 1.0.5
-      cors: 2.8.6
-      cross-spawn: 7.0.6
-      eventsource: 3.0.7
-      eventsource-parser: 3.1.0
-      express: 5.2.1(supports-color@8.1.1)
-      express-rate-limit: 8.5.2(express@5.2.1(supports-color@7.2.0))
-      hono: 4.12.23
-      jose: 6.2.3
-      json-schema-typed: 8.0.2
-      pkce-challenge: 5.0.1
-      raw-body: 3.0.2
-      zod: 4.4.3
-      zod-to-json-schema: 3.25.2(zod@4.4.3)
-    transitivePeerDependencies:
-      - supports-color
-
   '@napi-rs/nice-android-arm-eabi@1.1.1':
     optional: true
 
@@ -8966,7 +8910,7 @@ snapshots:
       '@typescript-eslint/types': 8.67.0
       '@typescript-eslint/visitor-keys': 8.67.0
       debug: 4.4.3(supports-color@7.2.0)
-      minimatch: 10.2.5
+      minimatch: 10.2.6
       semver: 7.8.5
       tinyglobby: 0.2.17
       ts-api-utils: 2.5.0(typescript@6.0.3)
@@ -8981,7 +8925,7 @@ snapshots:
       '@typescript-eslint/types': 8.67.0
       '@typescript-eslint/visitor-keys': 8.67.0
       debug: 4.4.3(supports-color@8.1.1)
-      minimatch: 10.2.5
+      minimatch: 10.2.6
       semver: 7.8.5
       tinyglobby: 0.2.17
       ts-api-utils: 2.5.0(typescript@6.0.3)
@@ -9736,20 +9680,6 @@ snapshots:
       bytes: 3.1.2
       content-type: 1.0.5
       debug: 4.4.3(supports-color@7.2.0)
-      http-errors: 2.0.1
-      iconv-lite: 0.7.2
-      on-finished: 2.4.1
-      qs: 6.15.2
-      raw-body: 3.0.2
-      type-is: 2.1.0
-    transitivePeerDependencies:
-      - supports-color
-
-  body-parser@2.2.2(supports-color@8.1.1):
-    dependencies:
-      bytes: 3.1.2
-      content-type: 1.0.5
-      debug: 4.4.3(supports-color@8.1.1)
       http-errors: 2.0.1
       iconv-lite: 0.7.2
       on-finished: 2.4.1
@@ -10551,39 +10481,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  express@5.2.1(supports-color@8.1.1):
-    dependencies:
-      accepts: 2.0.0
-      body-parser: 2.2.2(supports-color@8.1.1)
-      content-disposition: 1.1.0
-      content-type: 1.0.5
-      cookie: 0.7.2
-      cookie-signature: 1.2.2
-      debug: 4.4.3(supports-color@8.1.1)
-      depd: 2.0.0
-      encodeurl: 2.0.0
-      escape-html: 1.0.3
-      etag: 1.8.1
-      finalhandler: 2.1.1(supports-color@8.1.1)
-      fresh: 2.0.0
-      http-errors: 2.0.1
-      merge-descriptors: 2.0.0
-      mime-types: 3.0.2
-      on-finished: 2.4.1
-      once: 1.4.0
-      parseurl: 1.3.3
-      proxy-addr: 2.0.7
-      qs: 6.15.2
-      range-parser: 1.2.1
-      router: 2.2.0(supports-color@8.1.1)
-      send: 1.2.1(supports-color@8.1.1)
-      serve-static: 2.2.1(supports-color@8.1.1)
-      statuses: 2.0.2
-      type-is: 2.1.0
-      vary: 1.1.2
-    transitivePeerDependencies:
-      - supports-color
-
   ext-list@2.2.2:
     dependencies:
       mime-db: 1.54.0
@@ -10689,17 +10586,6 @@ snapshots:
   finalhandler@2.1.1(supports-color@7.2.0):
     dependencies:
       debug: 4.4.3(supports-color@7.2.0)
-      encodeurl: 2.0.0
-      escape-html: 1.0.3
-      on-finished: 2.4.1
-      parseurl: 1.3.3
-      statuses: 2.0.2
-    transitivePeerDependencies:
-      - supports-color
-
-  finalhandler@2.1.1(supports-color@8.1.1):
-    dependencies:
-      debug: 4.4.3(supports-color@8.1.1)
       encodeurl: 2.0.0
       escape-html: 1.0.3
       on-finished: 2.4.1
@@ -12441,16 +12327,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  router@2.2.0(supports-color@8.1.1):
-    dependencies:
-      debug: 4.4.3(supports-color@8.1.1)
-      depd: 2.0.0
-      is-promise: 4.0.0
-      parseurl: 1.3.3
-      path-to-regexp: 8.4.2
-    transitivePeerDependencies:
-      - supports-color
-
   run-applescript@7.0.0: {}
 
   run-async@2.4.1: {}
@@ -12525,22 +12401,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  send@1.2.1(supports-color@8.1.1):
-    dependencies:
-      debug: 4.4.3(supports-color@8.1.1)
-      encodeurl: 2.0.0
-      escape-html: 1.0.3
-      etag: 1.8.1
-      fresh: 2.0.0
-      http-errors: 2.0.1
-      mime-types: 3.0.2
-      ms: 2.1.3
-      on-finished: 2.4.1
-      range-parser: 1.2.1
-      statuses: 2.0.2
-    transitivePeerDependencies:
-      - supports-color
-
   serve-static@1.16.3(supports-color@7.2.0):
     dependencies:
       encodeurl: 2.0.0
@@ -12556,15 +12416,6 @@ snapshots:
       escape-html: 1.0.3
       parseurl: 1.3.3
       send: 1.2.1(supports-color@7.2.0)
-    transitivePeerDependencies:
-      - supports-color
-
-  serve-static@2.2.1(supports-color@8.1.1):
-    dependencies:
-      encodeurl: 2.0.0
-      escape-html: 1.0.3
-      parseurl: 1.3.3
-      send: 1.2.1(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Context

`@angular/cli` was declared as a peer on `angular-eslint`, `@angular-eslint/builder`, and `@angular-eslint/schematics` (#2820) for version-alignment communication. Nothing in those packages imports it.

On npm, pnpm, and bun, a required peer is auto-installed. That pulls the CLI (and ~120 extra packages) into workspaces that only wanted ESLint — Nx, Analog, and “just eslint” setups. Yarn does not auto-install it, but it does emit unmet-peer warnings.

#3125 removes the peer from `angular-eslint` only. That is not enough: builder and schematics still declare it, and they are dependencies of `angular-eslint`, so npm/pnpm/bun still install the CLI.

Optional peers were considered as a middle ground. They stop auto-install when the CLI is absent, but they are a poor compatibility UI: npm still `ERESOLVE`s on a wrong major, and Yarn Berry still warns (`YN0060`).

## This PR

- Drops the `@angular/cli` peer from all three packages.
- `ng add angular-eslint` warns when `@angular/core` or `@angular/cli` is a different major than `angular-eslint`, and confirms when they match. The schematic still completes.
- `ng lint` warns on the same mismatch via the builder logger, without failing the lint.
- Neither path talks to the package manager about this peer, so Yarn stays quiet.
- `0.x` package versions (including the e2e publish version `0.0.0-e2e`) are treated as having no detectable major, so local-registry tests do not warn about a fake v0 vs Angular 22 mismatch.

See `docs/ANGULAR_VERSION_SUPPORT.md`.

## Screenshots

Recorded against this branch’s compiled `ng-add` schematic and lint builder. Mismatch workspaces declare Angular 21; match workspaces declare Angular 22. Installation still succeeds either way.

### `ng add` — mismatch (Angular 21 + angular-eslint 22)

The schematic warns and continues.

**npm**

[ng add npm incorrect](https://cursor.com/agents/bc-681bf27b-f4e0-4000-bd3b-448d482dc326/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fng_add_npm_incorrect.png)

**Yarn classic**

[ng add yarn classic incorrect](https://cursor.com/agents/bc-681bf27b-f4e0-4000-bd3b-448d482dc326/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fng_add_yarn_classic_incorrect.png)

**Yarn Berry**

[ng add yarn berry incorrect](https://cursor.com/agents/bc-681bf27b-f4e0-4000-bd3b-448d482dc326/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fng_add_yarn_berry_incorrect.png)

**pnpm**

[ng add pnpm incorrect](https://cursor.com/agents/bc-681bf27b-f4e0-4000-bd3b-448d482dc326/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fng_add_pnpm_incorrect.png)

**bun**

[ng add bun incorrect](https://cursor.com/agents/bc-681bf27b-f4e0-4000-bd3b-448d482dc326/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fng_add_bun_incorrect.png)

### `ng add` — match (Angular 22 + angular-eslint 22)

The schematic confirms the aligned major.

**npm**

[ng add npm correct](https://cursor.com/agents/bc-681bf27b-f4e0-4000-bd3b-448d482dc326/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fng_add_npm_correct.png)

**Yarn classic**

[ng add yarn classic correct](https://cursor.com/agents/bc-681bf27b-f4e0-4000-bd3b-448d482dc326/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fng_add_yarn_classic_correct.png)

**Yarn Berry**

[ng add yarn berry correct](https://cursor.com/agents/bc-681bf27b-f4e0-4000-bd3b-448d482dc326/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fng_add_yarn_berry_correct.png)

**pnpm**

[ng add pnpm correct](https://cursor.com/agents/bc-681bf27b-f4e0-4000-bd3b-448d482dc326/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fng_add_pnpm_correct.png)

**bun**

[ng add bun correct](https://cursor.com/agents/bc-681bf27b-f4e0-4000-bd3b-448d482dc326/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fng_add_bun_correct.png)

### `ng lint`

Mismatch warns, then lint proceeds. Match stays silent about versions.

**incorrect (Angular 21)**

[ng lint incorrect](https://cursor.com/agents/bc-681bf27b-f4e0-4000-bd3b-448d482dc326/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fng_lint_incorrect.png)

**correct (Angular 22)**

[ng lint correct](https://cursor.com/agents/bc-681bf27b-f4e0-4000-bd3b-448d482dc326/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fng_lint_correct.png)

## Test plan

- [x] Unit tests for major parsing / mismatch detection
- [x] `ng-add` schematic tests for warn / confirm / silent
- [x] Builder test that a mismatched workspace package.json produces a logger warning
- [x] Screenshots of `ng add` (correct + incorrect) on npm, Yarn classic, Yarn Berry, pnpm, and bun
- [x] Screenshots of `ng lint` correct + incorrect
- [x] CI Main green after treating `0.0.0-e2e` as an undetectable major
- [x] codecov/patch above 90%


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-681bf27b-f4e0-4000-bd3b-448d482dc326?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-681bf27b-f4e0-4000-bd3b-448d482dc326&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

