### PR TITLE
fix(eslint-plugin): [no-implicit-take-until-destroyed] report methods also called outside DI context

### DIFF
--- a/packages/eslint-plugin/docs/rules/no-implicit-take-until-destroyed.md
+++ b/packages/eslint-plugin/docs/rules/no-implicit-take-until-destroyed.md
@@ -361,6 +361,124 @@ class Test {
 }
 ```
 
+<br>
+
+---
+
+<br>
+
+#### Default Config
+
+```json
+{
+  "rules": {
+    "@angular-eslint/no-implicit-take-until-destroyed": [
+      "error"
+    ]
+  }
+}
+```
+
+<br>
+
+#### ❌ Invalid Code
+
+```ts
+@Component()
+class Test {
+  constructor() {
+    this.loadData();
+  }
+
+  ngOnInit() {
+    this.loadData();
+  }
+
+  loadData() {
+    this.data$.pipe(takeUntilDestroyed()).subscribe();
+                    ~~~~~~~~~~~~~~~~~~~~
+  }
+}
+```
+
+<br>
+
+---
+
+<br>
+
+#### Default Config
+
+```json
+{
+  "rules": {
+    "@angular-eslint/no-implicit-take-until-destroyed": [
+      "error"
+    ]
+  }
+}
+```
+
+<br>
+
+#### ❌ Invalid Code
+
+```ts
+@Component()
+class Test {
+  private data = this.loadData();
+
+  ngOnInit() {
+    this.loadData();
+  }
+
+  private loadData() {
+    return this.data$.pipe(takeUntilDestroyed());
+                           ~~~~~~~~~~~~~~~~~~~~
+  }
+}
+```
+
+<br>
+
+---
+
+<br>
+
+#### Default Config
+
+```json
+{
+  "rules": {
+    "@angular-eslint/no-implicit-take-until-destroyed": [
+      "error"
+    ]
+  }
+}
+```
+
+<br>
+
+#### ❌ Invalid Code
+
+```ts
+@Injectable()
+class TestService {
+  constructor() {
+    this.#subscribe();
+  }
+
+  refresh() {
+    this.#subscribe();
+  }
+
+  #subscribe() {
+    this.data$.pipe(takeUntilDestroyed()).subscribe();
+                    ~~~~~~~~~~~~~~~~~~~~
+  }
+}
+```
+
 </details>
 
 <br>
@@ -933,6 +1051,81 @@ class TestService {
   }
 
   private init() {
+    this.data$.pipe(takeUntilDestroyed()).subscribe();
+  }
+}
+```
+
+<br>
+
+---
+
+<br>
+
+#### Default Config
+
+```json
+{
+  "rules": {
+    "@angular-eslint/no-implicit-take-until-destroyed": [
+      "error"
+    ]
+  }
+}
+```
+
+<br>
+
+#### ✅ Valid Code
+
+```ts
+@Component()
+class Test {
+  private data = this.init();
+
+  constructor() {
+    this.init();
+  }
+
+  private init() {
+    return this.data$.pipe(takeUntilDestroyed());
+  }
+}
+```
+
+<br>
+
+---
+
+<br>
+
+#### Default Config
+
+```json
+{
+  "rules": {
+    "@angular-eslint/no-implicit-take-until-destroyed": [
+      "error"
+    ]
+  }
+}
+```
+
+<br>
+
+#### ✅ Valid Code
+
+```ts
+@Component()
+class Test {
+  constructor() {
+    this.init(0);
+  }
+
+  private init(attempt: number) {
+    if (attempt < 3) {
+      this.init(attempt + 1);
+    }
     this.data$.pipe(takeUntilDestroyed()).subscribe();
   }
 }

--- a/packages/eslint-plugin/src/rules/no-implicit-take-until-destroyed.ts
+++ b/packages/eslint-plugin/src/rules/no-implicit-take-until-destroyed.ts
@@ -137,20 +137,29 @@ function isMethodCalledFromInjectionContext(
 
   const isPrivateField = method.key.type === AST_NODE_TYPES.PrivateIdentifier;
 
+  let isCalledFromInjectionContext = false;
+
   for (const member of classDeclaration.body.body) {
-    if (
-      !isConstructorMethod(member) &&
-      !ASTUtils.isPropertyDefinition(member)
-    ) {
+    // Ignore recursive calls from the method to itself
+    if (member === method) {
       continue;
     }
 
-    if (containsCallToMethod(member, methodName, isPrivateField)) {
-      return true;
+    if (!containsCallToMethod(member, methodName, isPrivateField)) {
+      continue;
+    }
+
+    if (isConstructorMethod(member) || ASTUtils.isPropertyDefinition(member)) {
+      isCalledFromInjectionContext = true;
+    } else {
+      // The method is also called from somewhere that is not an injection
+      // context (e.g. a lifecycle hook or a regular method), so we cannot
+      // assume that `takeUntilDestroyed()` will always run within one.
+      return false;
     }
   }
 
-  return false;
+  return isCalledFromInjectionContext;
 }
 
 function isASTNode(value: unknown): value is TSESTree.Node {

--- a/packages/eslint-plugin/tests/rules/no-implicit-take-until-destroyed/cases.ts
+++ b/packages/eslint-plugin/tests/rules/no-implicit-take-until-destroyed/cases.ts
@@ -324,4 +324,26 @@ export const invalid: readonly InvalidTestCase<MessageIds, Options>[] = [
     `,
     messageId,
   }),
+  convertAnnotatedSourceToFailureCase({
+    description:
+      'should fail in method called both from constructor and from not constructor',
+    annotatedSource: `
+      @Component()
+      class Test {
+        constructor() {
+          this.loadData();
+        }
+
+        ngOnInit() {
+          this.loadData();
+        }
+
+        loadData() {
+          this.data$.pipe(takeUntilDestroyed()).subscribe();
+                          ~~~~~~~~~~~~~~~~~~~~
+        }
+      }
+    `,
+    messageId,
+  }),
 ];

--- a/packages/eslint-plugin/tests/rules/no-implicit-take-until-destroyed/cases.ts
+++ b/packages/eslint-plugin/tests/rules/no-implicit-take-until-destroyed/cases.ts
@@ -185,6 +185,37 @@ export const valid: readonly (string | ValidTestCase<Options>)[] = [
       }
     }
   `,
+  // in method called from both constructor and field initializer (both injection contexts)
+  `
+    @Component()
+    class Test {
+      private data = this.init();
+
+      constructor() {
+        this.init();
+      }
+
+      private init() {
+        return this.data$.pipe(takeUntilDestroyed());
+      }
+    }
+  `,
+  // in method called from constructor which also calls itself recursively (self-call is ignored)
+  `
+    @Component()
+    class Test {
+      constructor() {
+        this.init(0);
+      }
+
+      private init(attempt: number) {
+        if (attempt < 3) {
+          this.init(attempt + 1);
+        }
+        this.data$.pipe(takeUntilDestroyed()).subscribe();
+      }
+    }
+  `,
 ];
 
 export const invalid: readonly InvalidTestCase<MessageIds, Options>[] = [
@@ -339,6 +370,48 @@ export const invalid: readonly InvalidTestCase<MessageIds, Options>[] = [
         }
 
         loadData() {
+          this.data$.pipe(takeUntilDestroyed()).subscribe();
+                          ~~~~~~~~~~~~~~~~~~~~
+        }
+      }
+    `,
+    messageId,
+  }),
+  convertAnnotatedSourceToFailureCase({
+    description:
+      'should fail in method called both from field initializer and from lifecycle hook',
+    annotatedSource: `
+      @Component()
+      class Test {
+        private data = this.loadData();
+
+        ngOnInit() {
+          this.loadData();
+        }
+
+        private loadData() {
+          return this.data$.pipe(takeUntilDestroyed());
+                                 ~~~~~~~~~~~~~~~~~~~~
+        }
+      }
+    `,
+    messageId,
+  }),
+  convertAnnotatedSourceToFailureCase({
+    description:
+      'should fail in private method called both from constructor and from regular method',
+    annotatedSource: `
+      @Injectable()
+      class TestService {
+        constructor() {
+          this.#subscribe();
+        }
+
+        refresh() {
+          this.#subscribe();
+        }
+
+        #subscribe() {
           this.data$.pipe(takeUntilDestroyed()).subscribe();
                           ~~~~~~~~~~~~~~~~~~~~
         }


### PR DESCRIPTION
## Summary

Supersedes #3067 (thanks @PowerKiKi for the report and the failing test case, which is preserved as the first commit on this branch).

#3011 fixed the false positive from #2929 by treating a method as running in an injection context when it is called from a constructor or field initializer. However, it returned `true` as soon as it found *any* such caller, so a method that is called from **both** the constructor and a lifecycle hook (or any regular method) was no longer reported, even though the non-constructor call site throws `NG0203` at runtime.

```ts
@Component()
class Test {
  constructor() { this.loadData(); } // injection context
  ngOnInit()    { this.loadData(); } // NOT an injection context
  loadData() {
    this.data$.pipe(takeUntilDestroyed()).subscribe(); // was not reported
  }
}
```

## Changes

- `isMethodCalledFromInjectionContext` now inspects every member of the class that calls the method. It only treats the method as an injection context when all callers are constructors or field initializers. Any lifecycle hook, regular method, getter or setter caller disqualifies it.
- Recursive calls from the method to itself are ignored.
- Tests: the failing case from #3067, plus:
  - valid: method called from both constructor and field initializer
  - valid: method called from constructor that also calls itself recursively
  - invalid: method called from both field initializer and `ngOnInit`
  - invalid: private `#method` called from both constructor and a regular method
- Regenerated the rule docs from the updated cases.

## Trade-off

As discussed on #3067, this deliberately keeps the analysis local to the class. A method that is only ever called from an injection context in *another* class (e.g. `ServiceB.constructor` calling `ServiceA.loadData()`) will still be reported. That is a false positive with an existing escape hatch (`eslint-disable-next-line` or passing an explicit `DestroyRef`), which is preferable to a false negative that silently ships a runtime error.

## Not addressed here

Callbacks inside a constructor (e.g. `constructor() { this.x$.subscribe(() => this.loadData()); }`) are still treated as an injection context by the existing call-detection walk, even though they run later. That pre-dates this PR and is worth a separate issue.
