### PR TITLE
chore: run pnpm dedupe after renovate lockfile updates

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -7,6 +7,11 @@
   // Wait well over npm's three day window for any new package as a precaution against malicious publishes.
   // https://docs.npmjs.com/policies/unpublish/#packages-published-less-than-72-hours-ago
   "minimumReleaseAge": "7 days",
+  // Run `pnpm dedupe` after every lockfile update. Without this, transitive ranges
+  // (e.g. @nx/eslint-plugin -> @typescript-eslint/utils@^8) can resolve to a newer
+  // version than the one pinned in our catalog, leaving two copies of the same
+  // package in the lockfile and breaking the build with incompatible types.
+  "postUpdateOptions": ["pnpmDedupe"],
   "packageRules": [
     {
       "groupName": "typescript-eslint packages",


### PR DESCRIPTION
## Summary

Enables Renovate's `pnpmDedupe` post-update option so `pnpm dedupe` runs after every `pnpm-lock.yaml` update.

## Why

On https://github.com/angular-eslint/angular-eslint/pull/3158 Renovate regenerated the lockfile for the typescript-eslint 8.68.0 catalog bump after 8.69.0 had been published. Our `minimumReleaseAge` of 7 days correctly kept the catalog at 8.68.0, but it only constrains what Renovate itself picks: pnpm still resolved the transitive `@nx/eslint-plugin -> @typescript-eslint/utils@^8` range to 8.69.0. That left two copies of the typescript-eslint packages in the lockfile and broke the `@angular-eslint/test-utils` build with incompatible `RuleModule` types.

Running `pnpm dedupe` collapses those transitive resolutions onto the catalog-pinned version, which is exactly the manual fix that got #3158 green. With typescript-eslint shipping weekly and a 7 day release-age gate, this collision will recur without it.

## Changes

- `.github/renovate.json`: add `"postUpdateOptions": ["pnpmDedupe"]` with a comment explaining why.

## Validation

- `prettier --check .github/renovate.json` passes.
- Config-only change; no code or lockfile changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TYgZEztsYLnk7AZR9SLtNy

---
_Generated by [Claude Code](https://claude.ai/code/session_01TYgZEztsYLnk7AZR9SLtNy)_