### PR TITLE
feat(eslint-plugin): [inject-at-top] add additionalInjectFunctions option

### DIFF
--- a/packages/eslint-plugin/docs/rules/inject-at-top.md
+++ b/packages/eslint-plugin/docs/rules/inject-at-top.md
@@ -23,13 +23,25 @@ Requires inject() calls to be declared at the top of the class, before any other
 
 ## Rationale
 
-Class fields are initialized in the order they are declared, so a field that calls inject() only creates its value when the initializer runs. Anything declared above that line which tries to read the injected service will see undefined, and the error message (usually something like 'Cannot read properties of undefined') points at the consumer, not at the field that was initialized out of order. TypeScript catches the obvious shape of this bug when a later-declared field is referenced directly from an earlier initializer, but it does not trace through a getter body or a method call, so the moment the read of this.someService happens behind that indirection the compiler lets it through and the failure only shows up at runtime. The scenario is deceptively easy to introduce: a getter that reads an injected service is defined below the inject() call, someone later adds a small convenience field above the getter that references it, and the class breaks at construction time even though nothing about the change looks suspicious. Keeping every inject() call at the very top of the class removes the ordering concern entirely, because every dependency is guaranteed to exist before any other field, getter, method, or constructor statement runs.
+Class fields are initialized in the order they are declared, so a field that calls inject() only creates its value when the initializer runs. Anything declared above that line which tries to read the injected service will see undefined, and the error message (usually something like 'Cannot read properties of undefined') points at the consumer, not at the field that was initialized out of order. TypeScript catches the obvious shape of this bug when a later-declared field is referenced directly from an earlier initializer, but it does not trace through a getter body or a method call, so the moment the read of this.someService happens behind that indirection the compiler lets it through and the failure only shows up at runtime. The scenario is deceptively easy to introduce: a getter that reads an injected service is defined below the inject() call, someone later adds a small convenience field above the getter that references it, and the class breaks at construction time even though nothing about the change looks suspicious. Keeping every inject() call at the very top of the class removes the ordering concern entirely, because every dependency is guaranteed to exist before any other field, getter, method, or constructor statement runs. Codebases often wrap inject() in their own helpers, for example an injectTranslations() function that injects a translation service and derives a scoped accessor from it; such a helper has exactly the same ordering constraint, so it can be declared through the additionalInjectFunctions option to be treated like inject() itself.
 
 <br>
 
 ## Rule Options
 
-The rule does not have any configuration options.
+The rule accepts an options object with the following properties:
+
+```ts
+interface Options {
+  /**
+   * A list of additional functions which perform injection, such as your own `injectTranslations()` helper. Each entry is a regular expression which must match the whole function name, so plain names such as `injectTranslations` work as well as patterns such as `inject[A-Z].*`.
+   *
+   * Default: `[]`
+   */
+  additionalInjectFunctions?: string[];
+}
+
+```
 
 <br>
 
@@ -704,6 +716,115 @@ class UserService {
 
   private readonly http = inject(HttpClient);
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+}
+```
+
+<br>
+
+---
+
+<br>
+
+#### Custom Config
+
+```json
+{
+  "rules": {
+    "@angular-eslint/inject-at-top": [
+      "error",
+      {
+        "additionalInjectFunctions": [
+          "injectTranslations"
+        ]
+      }
+    ]
+  }
+}
+```
+
+<br>
+
+#### ❌ Invalid Code
+
+```ts
+@Component({})
+class MyComponent {
+  private count = 0;
+  private readonly t = injectTranslations();
+  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+}
+```
+
+<br>
+
+---
+
+<br>
+
+#### Custom Config
+
+```json
+{
+  "rules": {
+    "@angular-eslint/inject-at-top": [
+      "error",
+      {
+        "additionalInjectFunctions": [
+          "inject[A-Z].*"
+        ]
+      }
+    ]
+  }
+}
+```
+
+<br>
+
+#### ❌ Invalid Code
+
+```ts
+@Injectable()
+class MyService {
+  private readonly http = inject(HttpClient);
+  private count = 0;
+  private readonly flags = injectFeatureFlags();
+  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+}
+```
+
+<br>
+
+---
+
+<br>
+
+#### Custom Config
+
+```json
+{
+  "rules": {
+    "@angular-eslint/inject-at-top": [
+      "error",
+      {
+        "additionalInjectFunctions": [
+          "injectTranslations"
+        ]
+      }
+    ]
+  }
+}
+```
+
+<br>
+
+#### ❌ Invalid Code
+
+```ts
+@Component({})
+class MyComponent {
+  private count = 0;
+  private readonly t = withScope(injectTranslations());
+  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 }
 ```
 
@@ -1477,6 +1598,179 @@ class MyComponent {
 class MyComponent {
   private count = 0;
   private readonly handlersFactory = () => collectHandlers([inject(HandlerA), inject(HandlerB)]);
+}
+```
+
+<br>
+
+---
+
+<br>
+
+#### Default Config
+
+```json
+{
+  "rules": {
+    "@angular-eslint/inject-at-top": [
+      "error"
+    ]
+  }
+}
+```
+
+<br>
+
+#### ✅ Valid Code
+
+```ts
+@Component({})
+class MyComponent {
+  private count = 0;
+  private readonly t = injectTranslations();
+}
+```
+
+<br>
+
+---
+
+<br>
+
+#### Custom Config
+
+```json
+{
+  "rules": {
+    "@angular-eslint/inject-at-top": [
+      "error",
+      {
+        "additionalInjectFunctions": [
+          "injectTranslations"
+        ]
+      }
+    ]
+  }
+}
+```
+
+<br>
+
+#### ✅ Valid Code
+
+```ts
+@Component({})
+class MyComponent {
+  private readonly t = injectTranslations();
+  private count = 0;
+}
+```
+
+<br>
+
+---
+
+<br>
+
+#### Custom Config
+
+```json
+{
+  "rules": {
+    "@angular-eslint/inject-at-top": [
+      "error",
+      {
+        "additionalInjectFunctions": [
+          "inject[A-Z].*"
+        ]
+      }
+    ]
+  }
+}
+```
+
+<br>
+
+#### ✅ Valid Code
+
+```ts
+@Injectable()
+class MyService {
+  private readonly http = inject(HttpClient);
+  private readonly t = injectTranslations();
+  private readonly flags = injectFeatureFlags();
+
+  doThing() {}
+}
+```
+
+<br>
+
+---
+
+<br>
+
+#### Custom Config
+
+```json
+{
+  "rules": {
+    "@angular-eslint/inject-at-top": [
+      "error",
+      {
+        "additionalInjectFunctions": [
+          "injectTranslations"
+        ]
+      }
+    ]
+  }
+}
+```
+
+<br>
+
+#### ✅ Valid Code
+
+```ts
+@Component({})
+class MyComponent {
+  private count = 0;
+  private readonly t = injectTranslationsLater();
+}
+```
+
+<br>
+
+---
+
+<br>
+
+#### Custom Config
+
+```json
+{
+  "rules": {
+    "@angular-eslint/inject-at-top": [
+      "error",
+      {
+        "additionalInjectFunctions": [
+          "injectTranslations"
+        ]
+      }
+    ]
+  }
+}
+```
+
+<br>
+
+#### ✅ Valid Code
+
+```ts
+@Component({})
+class MyComponent {
+  private count = 0;
+  private readonly translationsFactory = () => injectTranslations();
 }
 ```
 

--- a/packages/eslint-plugin/src/rules/inject-at-top.ts
+++ b/packages/eslint-plugin/src/rules/inject-at-top.ts
@@ -2,10 +2,16 @@ import { Selectors, toPattern } from '@angular-eslint/utils';
 import { AST_NODE_TYPES, TSESTree } from '@typescript-eslint/utils';
 import { createESLintRule } from '../utils/create-eslint-rule';
 
-export type Options = [];
+export type Options = [
+  {
+    readonly additionalInjectFunctions?: readonly string[];
+  },
+];
 
 export type MessageIds = 'injectAtTop';
 export const RULE_NAME = 'inject-at-top';
+
+const DEFAULT_OPTIONS: Options[number] = { additionalInjectFunctions: [] };
 
 export default createESLintRule<Options, MessageIds>({
   name: RULE_NAME,
@@ -15,14 +21,30 @@ export default createESLintRule<Options, MessageIds>({
       description:
         'Requires inject() calls to be declared at the top of the class, before any other member',
     },
-    schema: [],
+    schema: [
+      {
+        type: 'object',
+        properties: {
+          additionalInjectFunctions: {
+            type: 'array',
+            items: {
+              type: 'string',
+            },
+            description:
+              'A list of additional functions which perform injection, such as your own `injectTranslations()` helper. Each entry is a regular expression which must match the whole function name, so plain names such as `injectTranslations` work as well as patterns such as `inject[A-Z].*`.',
+            uniqueItems: true,
+          },
+        },
+        additionalProperties: false,
+      },
+    ],
     messages: {
       injectAtTop:
-        'Move this inject() to the top of the class. Class fields are initialized in the order they are written, so anything declared above this line cannot safely use the service yet.',
+        'Move this {{functionName}}() to the top of the class. Class fields are initialized in the order they are written, so anything declared above this line cannot safely use the service yet.',
     },
-    defaultOptions: [],
+    defaultOptions: [DEFAULT_OPTIONS],
   },
-  create(context) {
+  create(context, [{ additionalInjectFunctions = [] }]) {
     const angularDecoratorsPattern = toPattern([
       'Component',
       'Directive',
@@ -31,17 +53,22 @@ export default createESLintRule<Options, MessageIds>({
       'Service',
     ]);
 
-    function hasEagerInject(node: TSESTree.Node | null): boolean {
+    const injectFunctionsPattern = toPattern([
+      'inject',
+      ...additionalInjectFunctions,
+    ]);
+
+    function findEagerInjectName(node: TSESTree.Node | null): string | null {
       if (!node) {
-        return false;
+        return null;
       }
 
       if (
         node.type === AST_NODE_TYPES.CallExpression &&
         node.callee.type === AST_NODE_TYPES.Identifier &&
-        node.callee.name === 'inject'
+        injectFunctionsPattern.test(node.callee.name)
       ) {
-        return true;
+        return node.callee.name;
       }
 
       const isFn =
@@ -54,19 +81,25 @@ export default createESLintRule<Options, MessageIds>({
         node.parent.callee === node;
 
       if (node.type === AST_NODE_TYPES.ClassExpression || (isFn && !isIIFE)) {
-        return false;
+        return null;
       }
 
-      return Object.values(node)
-        .flat()
-        .some(
-          (child) =>
-            child &&
-            typeof child === 'object' &&
-            'type' in child &&
-            child !== node.parent &&
-            hasEagerInject(child as TSESTree.Node),
-        );
+      for (const child of Object.values(node).flat()) {
+        if (
+          child &&
+          typeof child === 'object' &&
+          'type' in child &&
+          child !== node.parent
+        ) {
+          const name = findEagerInjectName(child as TSESTree.Node);
+
+          if (name) {
+            return name;
+          }
+        }
+      }
+
+      return null;
     }
 
     return {
@@ -80,15 +113,20 @@ export default createESLintRule<Options, MessageIds>({
             continue;
           }
 
-          if (
-            member.type === AST_NODE_TYPES.PropertyDefinition &&
-            hasEagerInject(member.value)
-          ) {
-            if (seenNonInject) {
-              context.report({ node: member, messageId: 'injectAtTop' });
-            }
+          if (member.type === AST_NODE_TYPES.PropertyDefinition) {
+            const functionName = findEagerInjectName(member.value);
 
-            continue;
+            if (functionName) {
+              if (seenNonInject) {
+                context.report({
+                  node: member,
+                  messageId: 'injectAtTop',
+                  data: { functionName },
+                });
+              }
+
+              continue;
+            }
           }
 
           seenNonInject = true;
@@ -100,5 +138,5 @@ export default createESLintRule<Options, MessageIds>({
 
 export const RULE_DOCS_EXTENSION = {
   rationale:
-    "Class fields are initialized in the order they are declared, so a field that calls inject() only creates its value when the initializer runs. Anything declared above that line which tries to read the injected service will see undefined, and the error message (usually something like 'Cannot read properties of undefined') points at the consumer, not at the field that was initialized out of order. TypeScript catches the obvious shape of this bug when a later-declared field is referenced directly from an earlier initializer, but it does not trace through a getter body or a method call, so the moment the read of this.someService happens behind that indirection the compiler lets it through and the failure only shows up at runtime. The scenario is deceptively easy to introduce: a getter that reads an injected service is defined below the inject() call, someone later adds a small convenience field above the getter that references it, and the class breaks at construction time even though nothing about the change looks suspicious. Keeping every inject() call at the very top of the class removes the ordering concern entirely, because every dependency is guaranteed to exist before any other field, getter, method, or constructor statement runs.",
+    "Class fields are initialized in the order they are declared, so a field that calls inject() only creates its value when the initializer runs. Anything declared above that line which tries to read the injected service will see undefined, and the error message (usually something like 'Cannot read properties of undefined') points at the consumer, not at the field that was initialized out of order. TypeScript catches the obvious shape of this bug when a later-declared field is referenced directly from an earlier initializer, but it does not trace through a getter body or a method call, so the moment the read of this.someService happens behind that indirection the compiler lets it through and the failure only shows up at runtime. The scenario is deceptively easy to introduce: a getter that reads an injected service is defined below the inject() call, someone later adds a small convenience field above the getter that references it, and the class breaks at construction time even though nothing about the change looks suspicious. Keeping every inject() call at the very top of the class removes the ordering concern entirely, because every dependency is guaranteed to exist before any other field, getter, method, or constructor statement runs. Codebases often wrap inject() in their own helpers, for example an injectTranslations() function that injects a translation service and derives a scoped accessor from it; such a helper has exactly the same ordering constraint, so it can be declared through the additionalInjectFunctions option to be treated like inject() itself.",
 };

--- a/packages/eslint-plugin/tests/rules/inject-at-top/cases.ts
+++ b/packages/eslint-plugin/tests/rules/inject-at-top/cases.ts
@@ -224,6 +224,61 @@ export const valid: readonly (string | ValidTestCase<Options>)[] = [
     private readonly handlersFactory = () => collectHandlers([inject(HandlerA), inject(HandlerB)]);
   }
   `,
+  // should ignore a custom inject function which is not listed in additionalInjectFunctions
+  `
+  @Component({})
+  class MyComponent {
+    private count = 0;
+    private readonly t = injectTranslations();
+  }
+  `,
+  // should pass when a listed custom inject function is at the top
+  {
+    code: `
+    @Component({})
+    class MyComponent {
+      private readonly t = injectTranslations();
+      private count = 0;
+    }
+    `,
+    options: [{ additionalInjectFunctions: ['injectTranslations'] }],
+  },
+  // should pass when custom inject functions matched by a regex are grouped at the top
+  {
+    code: `
+    @Injectable()
+    class MyService {
+      private readonly http = inject(HttpClient);
+      private readonly t = injectTranslations();
+      private readonly flags = injectFeatureFlags();
+
+      doThing() {}
+    }
+    `,
+    options: [{ additionalInjectFunctions: ['inject[A-Z].*'] }],
+  },
+  // should not treat a function whose name merely starts with a listed name as an inject function
+  {
+    code: `
+    @Component({})
+    class MyComponent {
+      private count = 0;
+      private readonly t = injectTranslationsLater();
+    }
+    `,
+    options: [{ additionalInjectFunctions: ['injectTranslations'] }],
+  },
+  // should ignore a listed custom inject function inside a factory
+  {
+    code: `
+    @Component({})
+    class MyComponent {
+      private count = 0;
+      private readonly translationsFactory = () => injectTranslations();
+    }
+    `,
+    options: [{ additionalInjectFunctions: ['injectTranslations'] }],
+  },
 ];
 
 export const invalid: readonly InvalidTestCase<MessageIds, Options>[] = [
@@ -244,6 +299,7 @@ export const invalid: readonly InvalidTestCase<MessageIds, Options>[] = [
       }
     `,
     messageId,
+    data: { functionName: 'inject' },
   }),
   convertAnnotatedSourceToFailureCase({
     description:
@@ -257,6 +313,7 @@ export const invalid: readonly InvalidTestCase<MessageIds, Options>[] = [
       }
     `,
     messageId,
+    data: { functionName: 'inject' },
   }),
   convertAnnotatedSourceToFailureCase({
     description: 'should fail when inject() is declared below a method',
@@ -270,6 +327,7 @@ export const invalid: readonly InvalidTestCase<MessageIds, Options>[] = [
       }
     `,
     messageId,
+    data: { functionName: 'inject' },
   }),
   convertAnnotatedSourceToFailureCase({
     description: 'should fail when inject() is declared below the constructor',
@@ -283,6 +341,7 @@ export const invalid: readonly InvalidTestCase<MessageIds, Options>[] = [
       }
     `,
     messageId,
+    data: { functionName: 'inject' },
   }),
   convertAnnotatedSourceToFailureCase({
     description:
@@ -297,6 +356,7 @@ export const invalid: readonly InvalidTestCase<MessageIds, Options>[] = [
       }
     `,
     messageId,
+    data: { functionName: 'inject' },
   }),
   convertAnnotatedSourceToFailureCase({
     description:
@@ -317,8 +377,8 @@ export const invalid: readonly InvalidTestCase<MessageIds, Options>[] = [
       }
     `,
     messages: [
-      { char: '~', messageId },
-      { char: '^', messageId },
+      { char: '~', messageId, data: { functionName: 'inject' } },
+      { char: '^', messageId, data: { functionName: 'inject' } },
     ],
   }),
   convertAnnotatedSourceToFailureCase({
@@ -333,6 +393,7 @@ export const invalid: readonly InvalidTestCase<MessageIds, Options>[] = [
       }
     `,
     messageId,
+    data: { functionName: 'inject' },
   }),
   convertAnnotatedSourceToFailureCase({
     description:
@@ -346,6 +407,7 @@ export const invalid: readonly InvalidTestCase<MessageIds, Options>[] = [
       }
     `,
     messageId,
+    data: { functionName: 'inject' },
   }),
   convertAnnotatedSourceToFailureCase({
     description:
@@ -359,6 +421,7 @@ export const invalid: readonly InvalidTestCase<MessageIds, Options>[] = [
       }
     `,
     messageId,
+    data: { functionName: 'inject' },
   }),
   convertAnnotatedSourceToFailureCase({
     description: 'should fail when inject() is hidden inside a TSAsExpression',
@@ -371,6 +434,7 @@ export const invalid: readonly InvalidTestCase<MessageIds, Options>[] = [
       }
     `,
     messageId,
+    data: { functionName: 'inject' },
   }),
   convertAnnotatedSourceToFailureCase({
     description:
@@ -384,6 +448,7 @@ export const invalid: readonly InvalidTestCase<MessageIds, Options>[] = [
       }
     `,
     messageId,
+    data: { functionName: 'inject' },
   }),
   convertAnnotatedSourceToFailureCase({
     description: 'should fail when inject() is hidden inside a NewExpression',
@@ -396,6 +461,7 @@ export const invalid: readonly InvalidTestCase<MessageIds, Options>[] = [
       }
     `,
     messageId,
+    data: { functionName: 'inject' },
   }),
   convertAnnotatedSourceToFailureCase({
     description:
@@ -409,6 +475,7 @@ export const invalid: readonly InvalidTestCase<MessageIds, Options>[] = [
       }
     `,
     messageId,
+    data: { functionName: 'inject' },
   }),
   convertAnnotatedSourceToFailureCase({
     description:
@@ -422,6 +489,7 @@ export const invalid: readonly InvalidTestCase<MessageIds, Options>[] = [
       }
     `,
     messageId,
+    data: { functionName: 'inject' },
   }),
   convertAnnotatedSourceToFailureCase({
     description:
@@ -435,6 +503,7 @@ export const invalid: readonly InvalidTestCase<MessageIds, Options>[] = [
       }
     `,
     messageId,
+    data: { functionName: 'inject' },
   }),
   convertAnnotatedSourceToFailureCase({
     description: 'should fail when inject() is hidden inside a TemplateLiteral',
@@ -447,6 +516,7 @@ export const invalid: readonly InvalidTestCase<MessageIds, Options>[] = [
       }
     `,
     messageId,
+    data: { functionName: 'inject' },
   }),
   convertAnnotatedSourceToFailureCase({
     description:
@@ -460,6 +530,7 @@ export const invalid: readonly InvalidTestCase<MessageIds, Options>[] = [
       }
     `,
     messageId,
+    data: { functionName: 'inject' },
   }),
   convertAnnotatedSourceToFailureCase({
     description:
@@ -473,6 +544,7 @@ export const invalid: readonly InvalidTestCase<MessageIds, Options>[] = [
       }
     `,
     messageId,
+    data: { functionName: 'inject' },
   }),
   convertAnnotatedSourceToFailureCase({
     description:
@@ -486,6 +558,7 @@ export const invalid: readonly InvalidTestCase<MessageIds, Options>[] = [
       }
     `,
     messageId,
+    data: { functionName: 'inject' },
   }),
   convertAnnotatedSourceToFailureCase({
     description:
@@ -499,6 +572,7 @@ export const invalid: readonly InvalidTestCase<MessageIds, Options>[] = [
       }
     `,
     messageId,
+    data: { functionName: 'inject' },
   }),
   convertAnnotatedSourceToFailureCase({
     description:
@@ -515,5 +589,52 @@ export const invalid: readonly InvalidTestCase<MessageIds, Options>[] = [
       }
     `,
     messageId,
+    data: { functionName: 'inject' },
+  }),
+  convertAnnotatedSourceToFailureCase({
+    description:
+      'should fail when a listed custom inject function is declared below another member',
+    annotatedSource: `
+      @Component({})
+      class MyComponent {
+        private count = 0;
+        private readonly t = injectTranslations();
+        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      }
+    `,
+    messageId,
+    options: [{ additionalInjectFunctions: ['injectTranslations'] }],
+    data: { functionName: 'injectTranslations' },
+  }),
+  convertAnnotatedSourceToFailureCase({
+    description:
+      'should fail when a custom inject function matched by a regex is declared below another member',
+    annotatedSource: `
+      @Injectable()
+      class MyService {
+        private readonly http = inject(HttpClient);
+        private count = 0;
+        private readonly flags = injectFeatureFlags();
+        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      }
+    `,
+    messageId,
+    options: [{ additionalInjectFunctions: ['inject[A-Z].*'] }],
+    data: { functionName: 'injectFeatureFlags' },
+  }),
+  convertAnnotatedSourceToFailureCase({
+    description:
+      'should fail when a listed custom inject function is wrapped in another expression',
+    annotatedSource: `
+      @Component({})
+      class MyComponent {
+        private count = 0;
+        private readonly t = withScope(injectTranslations());
+        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      }
+    `,
+    messageId,
+    options: [{ additionalInjectFunctions: ['injectTranslations'] }],
+    data: { functionName: 'injectTranslations' },
   }),
 ];


### PR DESCRIPTION
## Motivation

`inject-at-top` only knows about the built-in `inject()` call. Codebases commonly wrap it in their own helpers — e.g. an `injectTranslations()` that injects a translation service and derives a scoped accessor from it. Those helpers have exactly the same field-initialization ordering constraint as `inject()` itself, but the rule currently ignores them, so the very bug the rule exists to prevent can still slip through.

## What this PR does

Adds an `additionalInjectFunctions` option: a list of function names to treat like `inject()`.

Each entry is a **regular expression matched against the whole callee name**, so both plain names and patterns work:

```jsonc
{
  "rules": {
    // plain names
    "@angular-eslint/inject-at-top": [
      "error",
      { "additionalInjectFunctions": ["injectTranslations", "injectFeatureFlags"] }
    ]
  }
}
```

```jsonc
{
  "rules": {
    // or a pattern covering a whole family of helpers
    "@angular-eslint/inject-at-top": [
      "error",
      { "additionalInjectFunctions": ["inject[A-Z].*"] }
    ]
  }
}
```

```ts
// with { "additionalInjectFunctions": ["injectTranslations"] }
@Component({})
class MyComponent {
  private count = 0;
  private readonly t = injectTranslations(); // now reported
}
```

Listed functions go through the exact same detection as `inject()`, so they are also found when wrapped (`withScope(injectTranslations())`, IIFEs, arrays, …) and are still ignored inside factory functions.

The report message is now parameterised with the actual function name (`Move this injectTranslations() to the top of the class. …`) instead of hard-coding `inject()`.

## Notes

- Default behaviour is unchanged: with no option, only `inject()` is considered.
- The name must match in full, so `injectTranslationsLater()` is not matched by `injectTranslations`.
- Docs regenerated via `pnpm update-rule-docs`.

<br>

Tests: `pnpm nx test eslint-plugin tests/rules/inject-at-top/spec.ts` passes (54 cases).
