### PR TITLE
chore: refactor deprecated defaultOptions

### DIFF
--- a/packages/eslint-plugin-template/src/rules/alt-text.ts
+++ b/packages/eslint-plugin-template/src/rules/alt-text.ts
@@ -22,8 +22,8 @@ export default createESLintRule<Options, MessageIds>({
     messages: {
       altText: '<{{element}}/> element must have a text alternative.',
     },
+    defaultOptions: [],
   },
-  defaultOptions: [],
   create(context) {
     const parserServices = getTemplateParserServices(context);
 

--- a/packages/eslint-plugin-template/src/rules/attributes-order.ts
+++ b/packages/eslint-plugin-template/src/rules/attributes-order.ts
@@ -117,8 +117,8 @@ export default createESLintRule<Options, MessageIds>({
     messages: {
       attributesOrder: `The element's attributes/bindings did not match the expected order: expected {{expected}} instead of {{actual}}`,
     },
+    defaultOptions: [DEFAULT_OPTIONS],
   },
-  defaultOptions: [DEFAULT_OPTIONS],
   create(context, [{ alphabetical, order }]) {
     const parserServices = getTemplateParserServices(context);
 

--- a/packages/eslint-plugin-template/src/rules/banana-in-box.ts
+++ b/packages/eslint-plugin-template/src/rules/banana-in-box.ts
@@ -22,8 +22,8 @@ export default createESLintRule<Options, MessageIds>({
     messages: {
       bananaInBox: 'Invalid binding syntax. Use [(expr)] instead',
     },
+    defaultOptions: [],
   },
-  defaultOptions: [],
   create(context) {
     const parserServices = getTemplateParserServices(context);
     const sourceCode = context.sourceCode;

--- a/packages/eslint-plugin-template/src/rules/button-has-type.ts
+++ b/packages/eslint-plugin-template/src/rules/button-has-type.ts
@@ -56,8 +56,8 @@ export default createESLintRule<Options, MessageIds>({
       missingType: 'Type for <button> is missing',
       invalidType: `"{{${INVALID_TYPE_DATA_KEY}}}" can not be used as a type for <button>`,
     },
+    defaultOptions: [{}],
   },
-  defaultOptions: [{}],
   create(context, [{ ignoreWithDirectives }]) {
     const parserServices = getTemplateParserServices(context);
 

--- a/packages/eslint-plugin-template/src/rules/click-events-have-key-events.ts
+++ b/packages/eslint-plugin-template/src/rules/click-events-have-key-events.ts
@@ -46,8 +46,8 @@ export default createESLintRule<Options, MessageIds>({
       clickEventsHaveKeyEvents:
         'click must be accompanied by either keyup, keydown or keypress event for accessibility.',
     },
+    defaultOptions: [DEFAULT_OPTIONS],
   },
-  defaultOptions: [DEFAULT_OPTIONS],
   create(context, [{ ignoreWithDirectives }]) {
     return {
       Element(node: TmplAstElement) {

--- a/packages/eslint-plugin-template/src/rules/conditional-complexity.ts
+++ b/packages/eslint-plugin-template/src/rules/conditional-complexity.ts
@@ -45,8 +45,8 @@ export default createESLintRule<Options, MessageIds>({
       conditionalComplexity:
         'The conditional complexity {{totalComplexity}} exceeds the defined limit {{maxComplexity}}',
     },
+    defaultOptions: [{ maxComplexity: DEFAULT_MAX_COMPLEXITY }],
   },
-  defaultOptions: [{ maxComplexity: DEFAULT_MAX_COMPLEXITY }],
   create(context, [{ maxComplexity }]) {
     ensureTemplateParser(context);
     const sourceCode = context.sourceCode;

--- a/packages/eslint-plugin-template/src/rules/cyclomatic-complexity.ts
+++ b/packages/eslint-plugin-template/src/rules/cyclomatic-complexity.ts
@@ -49,13 +49,13 @@ export default createESLintRule<Options, MessageIds>({
       cyclomaticComplexity:
         'The cyclomatic complexity {{totalComplexity}} exceeds the defined limit {{maxComplexity}}',
     },
+    defaultOptions: [
+      {
+        maxComplexity: DEFAULT_OPTIONS.maxComplexity,
+        variant: DEFAULT_OPTIONS.variant,
+      },
+    ],
   },
-  defaultOptions: [
-    {
-      maxComplexity: DEFAULT_OPTIONS.maxComplexity,
-      variant: DEFAULT_OPTIONS.variant,
-    },
-  ],
   create(
     context,
     [

--- a/packages/eslint-plugin-template/src/rules/elements-content.ts
+++ b/packages/eslint-plugin-template/src/rules/elements-content.ts
@@ -47,8 +47,8 @@ export default createESLintRule<Options, MessageIds>({
     messages: {
       elementsContent: '<{{element}}> should have content',
     },
+    defaultOptions: [DEFAULT_OPTIONS],
   },
-  defaultOptions: [DEFAULT_OPTIONS],
   create(context, [{ allowList }]) {
     const parserServices = getTemplateParserServices(context);
 

--- a/packages/eslint-plugin-template/src/rules/eqeqeq.ts
+++ b/packages/eslint-plugin-template/src/rules/eqeqeq.ts
@@ -46,8 +46,8 @@ export default createESLintRule<Options, MessageIds>({
       suggestStrictEquality:
         'Replace `{{actualOperation}}` with `{{expectedOperation}}`',
     },
+    defaultOptions: [DEFAULT_OPTIONS],
   },
-  defaultOptions: [DEFAULT_OPTIONS],
   create(context, [{ allowNullOrUndefined }]) {
     ensureTemplateParser(context);
     const sourceCode = context.sourceCode;

--- a/packages/eslint-plugin-template/src/rules/i18n.ts
+++ b/packages/eslint-plugin-template/src/rules/i18n.ts
@@ -199,8 +199,8 @@ export default createESLintRule<Options, MessageIds>({
       i18nMarkupInContent:
         'Avoid HTML markup in an element with an i18n attribute.',
     },
+    defaultOptions: [DEFAULT_OPTIONS],
   },
-  defaultOptions: [DEFAULT_OPTIONS],
   create(
     context,
     [

--- a/packages/eslint-plugin-template/src/rules/interactive-supports-focus.ts
+++ b/packages/eslint-plugin-template/src/rules/interactive-supports-focus.ts
@@ -45,8 +45,8 @@ export default createESLintRule<Options, MessageIds>({
       interactiveSupportsFocus:
         'Elements with interaction handlers must be focusable.',
     },
+    defaultOptions: [{ allowList: DEFAULT_ALLOW_LIST }],
   },
-  defaultOptions: [{ allowList: DEFAULT_ALLOW_LIST }],
   create(context, [{ allowList }]) {
     return {
       Element(node: TmplAstElement) {

--- a/packages/eslint-plugin-template/src/rules/label-has-associated-control.ts
+++ b/packages/eslint-plugin-template/src/rules/label-has-associated-control.ts
@@ -79,8 +79,8 @@ export default createESLintRule<Options, MessageIds>({
       labelHasAssociatedControl:
         'A label component must be associated with a form element',
     },
+    defaultOptions: [DEFAULT_OPTIONS],
   },
-  defaultOptions: [DEFAULT_OPTIONS],
   create(context, [{ checkIds, controlComponents, labelComponents }]) {
     const parserServices = getTemplateParserServices(context);
     const allControlComponents: ReadonlySet<string> = new Set([

--- a/packages/eslint-plugin-template/src/rules/mouse-events-have-key-events.ts
+++ b/packages/eslint-plugin-template/src/rules/mouse-events-have-key-events.ts
@@ -31,8 +31,8 @@ export default createESLintRule<Options, MessageIds>({
     messages: {
       mouseEventsHaveKeyEvents: `\`{{mouseEvent}}\` must be accompanied by \`{{keyEvent}}\` for accessibility (${STYLE_GUIDE_LINK})`,
     },
+    defaultOptions: [],
   },
-  defaultOptions: [],
   create(context) {
     const parserServices = getTemplateParserServices(context);
     const domElementsPattern = toPattern([...getDomElements()]);

--- a/packages/eslint-plugin-template/src/rules/no-any.ts
+++ b/packages/eslint-plugin-template/src/rules/no-any.ts
@@ -27,8 +27,8 @@ export default createESLintRule<Options, MessageIds>({
       noAny: `Avoid using "${ANY_TYPE_CAST_FUNCTION_NAME}" in templates`,
       suggestRemoveAny: `Remove ${ANY_TYPE_CAST_FUNCTION_NAME}`,
     },
+    defaultOptions: [],
   },
-  defaultOptions: [],
   create(context) {
     ensureTemplateParser(context);
     const sourceCode = context.sourceCode;

--- a/packages/eslint-plugin-template/src/rules/no-autofocus.ts
+++ b/packages/eslint-plugin-template/src/rules/no-autofocus.ts
@@ -26,8 +26,8 @@ export default createESLintRule<Options, MessageIds>({
       noAutofocus:
         'The `autofocus` attribute should not be used, as it reduces usability and accessibility for users',
     },
+    defaultOptions: [],
   },
-  defaultOptions: [],
   create(context) {
     const parserServices = getTemplateParserServices(context);
     const elementNamePattern = toPattern([...getDomElements()]);

--- a/packages/eslint-plugin-template/src/rules/no-call-expression.ts
+++ b/packages/eslint-plugin-template/src/rules/no-call-expression.ts
@@ -41,10 +41,10 @@ export default createESLintRule<Options, MessageIds>({
     messages: {
       noCallExpression: 'Avoid calling expressions in templates',
     },
+    defaultOptions: [
+      { allowList: [], allowPrefix: undefined, allowSuffix: undefined },
+    ],
   },
-  defaultOptions: [
-    { allowList: [], allowPrefix: undefined, allowSuffix: undefined },
-  ],
   create(context, [{ allowList, allowPrefix, allowSuffix }]) {
     ensureTemplateParser(context);
     const sourceCode = context.sourceCode;

--- a/packages/eslint-plugin-template/src/rules/no-distracting-elements.ts
+++ b/packages/eslint-plugin-template/src/rules/no-distracting-elements.ts
@@ -20,8 +20,8 @@ export default createESLintRule<Options, MessageIds>({
       noDistractingElements:
         'Do not use <{{element}}> elements as they can create visual accessibility issues and are deprecated',
     },
+    defaultOptions: [],
   },
-  defaultOptions: [],
   create(context) {
     const parserServices = getTemplateParserServices(context);
 

--- a/packages/eslint-plugin-template/src/rules/no-duplicate-attributes.ts
+++ b/packages/eslint-plugin-template/src/rules/no-duplicate-attributes.ts
@@ -61,8 +61,8 @@ export default createESLintRule<Options, MessageIds>({
       noDuplicateAttributes: 'Duplicate attribute `{{attributeName}}`',
       suggestRemoveAttribute: 'Remove attribute `{{attributeName}}`',
     },
+    defaultOptions: [DEFAULT_OPTIONS],
   },
-  defaultOptions: [DEFAULT_OPTIONS],
   create(
     context,
     [{ allowTwoWayDataBinding, allowStylePrecedenceDuplicates, ignore }],

--- a/packages/eslint-plugin-template/src/rules/no-empty-control-flow.ts
+++ b/packages/eslint-plugin-template/src/rules/no-empty-control-flow.ts
@@ -25,8 +25,8 @@ export default createESLintRule<Options, MessageIds>({
     messages: {
       noEmptyControlFlow: 'Unexpected empty control flow block.',
     },
+    defaultOptions: [],
   },
-  defaultOptions: [],
   create(context) {
     const parserServices = getTemplateParserServices(context);
 

--- a/packages/eslint-plugin-template/src/rules/no-inline-styles.ts
+++ b/packages/eslint-plugin-template/src/rules/no-inline-styles.ts
@@ -45,8 +45,8 @@ export default createESLintRule<Options, MessageIds>({
       noInlineStyles:
         '<{{element}}/> element should not have inline styles via style attribute. Please use classes instead.',
     },
+    defaultOptions: [DEFAULT_OPTIONS],
   },
-  defaultOptions: [DEFAULT_OPTIONS],
   create(context, [{ allowNgStyle, allowBindToStyle }]) {
     const parserServices = getTemplateParserServices(context);
 

--- a/packages/eslint-plugin-template/src/rules/no-interpolation-in-attributes.ts
+++ b/packages/eslint-plugin-template/src/rules/no-interpolation-in-attributes.ts
@@ -40,8 +40,8 @@ export default createESLintRule<Options, MessageIds>({
         'Use property binding [attribute]="value" instead of interpolation {{ value }} for an attribute.',
     },
     fixable: 'code',
+    defaultOptions: [{ allowSubstringInterpolation: false }],
   },
-  defaultOptions: [{ allowSubstringInterpolation: false }],
   create(context, [{ allowSubstringInterpolation }]) {
     const sourceCode = context.sourceCode;
 

--- a/packages/eslint-plugin-template/src/rules/no-negated-async.ts
+++ b/packages/eslint-plugin-template/src/rules/no-negated-async.ts
@@ -34,8 +34,8 @@ export default createESLintRule<Options, MessageIds>({
       suggestUndefinedComparison: 'Compare with `undefined`',
       suggestUsingNonNegatedValue: 'Use non-negated value',
     },
+    defaultOptions: [],
   },
-  defaultOptions: [],
   create(context) {
     ensureTemplateParser(context);
     const sourceCode = context.sourceCode;

--- a/packages/eslint-plugin-template/src/rules/no-nested-tags.ts
+++ b/packages/eslint-plugin-template/src/rules/no-nested-tags.ts
@@ -22,8 +22,8 @@ export default createESLintRule<Options, MessageIds>({
       noNestedTags:
         '<{{tag}}> elements must not be nested! This breaks angular incremental hydration as all browsers will convert "<{{tag}}>1<{{tag}}>2</{{tag}}>3</{{tag}}>" into "<{{tag}}>1</{{tag}}><{{tag}}>2</{{tag}}>3", creating a DOM mismatch between SSR and Angular',
     },
+    defaultOptions: [],
   },
-  defaultOptions: [],
   create(context) {
     const parserServices = getTemplateParserServices(context);
 

--- a/packages/eslint-plugin-template/src/rules/no-non-null-assertion.ts
+++ b/packages/eslint-plugin-template/src/rules/no-non-null-assertion.ts
@@ -18,8 +18,8 @@ export default createESLintRule<Options, MessageIds>({
       noNonNullAssertion:
         'Avoid using the non-null assertion operator (!) in templates. This bypasses type safety and can lead to runtime errors.',
     },
+    defaultOptions: [],
   },
-  defaultOptions: [],
   create(context) {
     ensureTemplateParser(context);
     const { sourceCode } = context;

--- a/packages/eslint-plugin-template/src/rules/no-outerhtml.ts
+++ b/packages/eslint-plugin-template/src/rules/no-outerhtml.ts
@@ -24,8 +24,8 @@ export default createESLintRule<Options, MessageIds>({
       noOuterHtml:
         'Do not use `outerHTML`. Binding to `[outerHTML]` throws on update because setting `outerHTML` replaces the host element itself, so Angular loses its reference to the node ("This element has no parent node"); a static `outerHTML` attribute is not a real DOM attribute and has no effect. Use `[innerHTML]` (being mindful of sanitization) or restructure the template instead.',
     },
+    defaultOptions: [],
   },
-  defaultOptions: [],
   create(context) {
     const parserServices = getTemplateParserServices(context);
     const elementNamePattern = toPattern([...getDomElements()]);

--- a/packages/eslint-plugin-template/src/rules/no-positive-tabindex.ts
+++ b/packages/eslint-plugin-template/src/rules/no-positive-tabindex.ts
@@ -25,8 +25,8 @@ export default createESLintRule<Options, MessageIds>({
       noPositiveTabindex: 'The `tabindex` attribute should not be positive',
       suggestNonNegativeTabindex: 'Use `tabindex="{{tabindex}}"`',
     },
+    defaultOptions: [],
   },
-  defaultOptions: [],
   create(context) {
     const parserServices = getTemplateParserServices(context);
     const domElements = [...getDomElements()];

--- a/packages/eslint-plugin-template/src/rules/prefer-at-else.ts
+++ b/packages/eslint-plugin-template/src/rules/prefer-at-else.ts
@@ -43,8 +43,8 @@ export default createESLintRule<Options, MessageIds>({
     messages: {
       preferAtElse: 'Prefer using `@else` instead of a second `@if` clause.',
     },
+    defaultOptions: [],
   },
-  defaultOptions: [],
   create(context) {
     const parserServices = getTemplateParserServices(context);
     const previousNodeStack: (IfNodeInfo | undefined)[] = [undefined];

--- a/packages/eslint-plugin-template/src/rules/prefer-at-empty.ts
+++ b/packages/eslint-plugin-template/src/rules/prefer-at-empty.ts
@@ -32,8 +32,8 @@ export default createESLintRule<Options, MessageIds>({
     messages: {
       preferAtEmpty: 'Prefer using `@for (...) {...} @empty {...}`.',
     },
+    defaultOptions: [],
   },
-  defaultOptions: [],
   create(context) {
     const parserServices = getTemplateParserServices(context);
     const previousNodeStack: (NodeInfo | undefined)[] = [undefined];

--- a/packages/eslint-plugin-template/src/rules/prefer-built-in-pipes.ts
+++ b/packages/eslint-plugin-template/src/rules/prefer-built-in-pipes.ts
@@ -58,13 +58,13 @@ export default createESLintRule<Options, MessageIds>({
       preferBuiltInPipes:
         'Avoid using method "{{ methodName }}" in templates. Prefer the Angular built-in pipes instead (e.g. lowercase, uppercase, titlecase).',
     },
+    defaultOptions: [
+      {
+        disallowList: [...DEFAULT_DISALLOW_LIST],
+        allowInOutputHandlers: true,
+      },
+    ],
   },
-  defaultOptions: [
-    {
-      disallowList: [...DEFAULT_DISALLOW_LIST],
-      allowInOutputHandlers: true,
-    },
-  ],
   create(context, [{ disallowList, allowInOutputHandlers }]) {
     ensureTemplateParser(context);
     const sourceCode = context.sourceCode;

--- a/packages/eslint-plugin-template/src/rules/prefer-class-binding.ts
+++ b/packages/eslint-plugin-template/src/rules/prefer-class-binding.ts
@@ -26,8 +26,8 @@ export default createESLintRule<Options, MessageIds>({
       preferClassBinding:
         'Consider using [class] bindings instead of [ngClass] where applicable.',
     },
+    defaultOptions: [],
   },
-  defaultOptions: [],
   create(context) {
     const parserServices = getTemplateParserServices(context);
 

--- a/packages/eslint-plugin-template/src/rules/prefer-contextual-for-variables.ts
+++ b/packages/eslint-plugin-template/src/rules/prefer-contextual-for-variables.ts
@@ -113,8 +113,8 @@ export default createESLintRule<Options, MessageIds>({
       preferEven: "Use '$even' instead of '{{ expression }}'.",
       preferOdd: "Use '$odd' instead of '{{ expression }}'.",
     },
+    defaultOptions: [DEFAULT_OPTIONS],
   },
-  defaultOptions: [DEFAULT_OPTIONS],
   create(context, [{ allowedAliases }]) {
     const parserServices = getTemplateParserServices(context);
     const forLoops: ForLoopInfo[] = [];

--- a/packages/eslint-plugin-template/src/rules/prefer-control-flow.ts
+++ b/packages/eslint-plugin-template/src/rules/prefer-control-flow.ts
@@ -19,8 +19,8 @@ export default createESLintRule<Options, MessageIds>({
       preferControlFlow:
         'Use built-in control flow instead of directive {{name}}.',
     },
+    defaultOptions: [],
   },
-  defaultOptions: [],
   create(context) {
     const parserServices = getTemplateParserServices(context);
 

--- a/packages/eslint-plugin-template/src/rules/prefer-ngsrc.ts
+++ b/packages/eslint-plugin-template/src/rules/prefer-ngsrc.ts
@@ -34,8 +34,8 @@ export default createESLintRule<Options, MessageIds>({
       suggestReplaceWithNgSrc: 'Replace [src] with [ngSrc]',
       suggestRemoveSrc: 'Remove the [src] attribute',
     },
+    defaultOptions: [],
   },
-  defaultOptions: [],
   create(context) {
     const parserServices = getTemplateParserServices(context);
     const sourceCode = context.sourceCode;

--- a/packages/eslint-plugin-template/src/rules/prefer-self-closing-tags.ts
+++ b/packages/eslint-plugin-template/src/rules/prefer-self-closing-tags.ts
@@ -26,8 +26,8 @@ export default createESLintRule<Options, MessageIds>({
       preferSelfClosingTags:
         'Use self-closing tags for elements with a closing tag but no content.',
     },
+    defaultOptions: [],
   },
-  defaultOptions: [],
   create(context) {
     const parserServices = getTemplateParserServices(context);
 

--- a/packages/eslint-plugin-template/src/rules/prefer-static-string-properties.ts
+++ b/packages/eslint-plugin-template/src/rules/prefer-static-string-properties.ts
@@ -53,8 +53,8 @@ export default createESLintRule<Options, MessageIds>({
       preferStaticStringProperties:
         'Using a property is more efficient than binding a static string.',
     },
+    defaultOptions: [{}],
   },
-  defaultOptions: [{}],
   create(context, [{ ignore = [] }]) {
     const parserServices = getTemplateParserServices(context);
     const ignoredProperties = new Set([...PROPERTY_ONLY_DOM_APIS, ...ignore]);

--- a/packages/eslint-plugin-template/src/rules/prefer-template-literal.ts
+++ b/packages/eslint-plugin-template/src/rules/prefer-template-literal.ts
@@ -124,8 +124,8 @@ export default createESLintRule<Options, MessageIds>({
       preferTemplateLiteral:
         'Prefer using template literal instead of concatenating strings or expressions',
     },
+    defaultOptions: [],
   },
-  defaultOptions: [],
   create(context) {
     // When the template is defined inline in a component, the template will
     // usually be defined as a template string, which means if template

--- a/packages/eslint-plugin-template/src/rules/require-switch-default.ts
+++ b/packages/eslint-plugin-template/src/rules/require-switch-default.ts
@@ -19,8 +19,8 @@ export default createESLintRule<Options, MessageIds>({
       requireSwitchDefault:
         'Switch should have a default block. Add `@default { ... }`, or `@default never` to enforce a compile-time exhaustive switch.',
     },
+    defaultOptions: [],
   },
-  defaultOptions: [],
   create(context) {
     const parserServices = getTemplateParserServices(context);
 

--- a/packages/eslint-plugin-template/src/rules/role-has-required-aria.ts
+++ b/packages/eslint-plugin-template/src/rules/role-has-required-aria.ts
@@ -29,8 +29,8 @@ export default createESLintRule<Options, MessageIds>({
         'The {{element}} with role="{{role}}" does not have required ARIA properties: {{missingProps}}',
       suggestRemoveRole: 'Remove role `{{role}}`',
     },
+    defaultOptions: [],
   },
-  defaultOptions: [],
   create(context) {
     const parserServices = getTemplateParserServices(context);
     const domElements = [...getDomElements()];

--- a/packages/eslint-plugin-template/src/rules/table-scope.ts
+++ b/packages/eslint-plugin-template/src/rules/table-scope.ts
@@ -24,8 +24,8 @@ export default createESLintRule<Options, MessageIds>({
     messages: {
       tableScope: 'The `scope` attribute should only be on the `<th>` element',
     },
+    defaultOptions: [],
   },
-  defaultOptions: [],
   create(context) {
     const parserServices = getTemplateParserServices(context);
     const domElements = [...getDomElements()].filter(

--- a/packages/eslint-plugin-template/src/rules/use-track-by-function.ts
+++ b/packages/eslint-plugin-template/src/rules/use-track-by-function.ts
@@ -36,8 +36,8 @@ export default createESLintRule<Options, MessageIds>({
     messages: {
       useTrackByFunction: 'Missing trackBy function in ngFor directive',
     },
+    defaultOptions: [{ alias: DEFAULT_ALIAS }],
   },
-  defaultOptions: [{ alias: DEFAULT_ALIAS }],
   create(context, [{ alias }]) {
     const isNgForTrackBy = isNgForTrackByFactory(alias);
     const parserServices = getTemplateParserServices(context);

--- a/packages/eslint-plugin-template/src/rules/valid-aria.ts
+++ b/packages/eslint-plugin-template/src/rules/valid-aria.ts
@@ -35,8 +35,8 @@ export default createESLintRule<Options, MessageIds>({
         'The `{{attribute}}` has an invalid value. Check the valid values at https://raw.githack.com/w3c/aria/stable/#roles',
       suggestRemoveInvalidAria: 'Remove attribute `{{attribute}}`',
     },
+    defaultOptions: [],
   },
-  defaultOptions: [],
   create(context) {
     const parserServices = getTemplateParserServices(context);
     const domElements = [...getDomElements()];

--- a/packages/eslint-plugin-template/src/utils/create-eslint-rule.ts
+++ b/packages/eslint-plugin-template/src/utils/create-eslint-rule.ts
@@ -9,9 +9,9 @@ export interface RuleDocs {
  * to use as part of documentation generation.
  */
 const patchedRuleCreator: typeof ESLintUtils.RuleCreator = (urlCreator) => {
-  return function createRule({ name, meta, defaultOptions, create }) {
-    const resolvedDefaultOptions = (defaultOptions ?? []) as NonNullable<
-      typeof defaultOptions
+  return function createRule({ name, meta, create }) {
+    const resolvedDefaultOptions = (meta.defaultOptions ?? []) as Readonly<
+      NonNullable<typeof meta.defaultOptions>
     >;
 
     return {

--- a/packages/eslint-plugin-template/src/utils/create-eslint-rule.ts
+++ b/packages/eslint-plugin-template/src/utils/create-eslint-rule.ts
@@ -4,38 +4,7 @@ export interface RuleDocs {
   recommended?: string;
 }
 
-/**
- * We need to patch the RuleCreator in order to preserve the defaultOptions
- * to use as part of documentation generation.
- */
-const patchedRuleCreator: typeof ESLintUtils.RuleCreator = (urlCreator) => {
-  return function createRule({ name, meta, create }) {
-    const resolvedDefaultOptions = (meta.defaultOptions ?? []) as Readonly<
-      NonNullable<typeof meta.defaultOptions>
-    >;
-
-    return {
-      name,
-      meta: Object.assign(Object.assign({}, meta), {
-        docs: Object.assign(Object.assign({}, meta.docs), {
-          url: urlCreator(name),
-        }),
-      }),
-      defaultOptions: resolvedDefaultOptions,
-      create(context) {
-        const optionsWithDefault = ESLintUtils.applyDefault(
-          resolvedDefaultOptions,
-          context.options,
-        );
-        return create(context, optionsWithDefault);
-      },
-    };
-  };
-};
-
-patchedRuleCreator.withoutDocs = ESLintUtils.RuleCreator.withoutDocs;
-
-export const createESLintRule = patchedRuleCreator<RuleDocs>(
+export const createESLintRule = ESLintUtils.RuleCreator<RuleDocs>(
   (ruleName) =>
     `https://github.com/angular-eslint/angular-eslint/blob/main/packages/eslint-plugin-template/docs/rules/${ruleName}.md`,
 );

--- a/packages/eslint-plugin/src/rules/component-class-suffix.ts
+++ b/packages/eslint-plugin/src/rules/component-class-suffix.ts
@@ -38,12 +38,12 @@ export default createESLintRule<Options, MessageIds>({
     messages: {
       componentClassSuffix: `Component class names should end with one of these suffixes: {{suffixes}}`,
     },
+    defaultOptions: [
+      {
+        suffixes: ['Component'],
+      },
+    ],
   },
-  defaultOptions: [
-    {
-      suffixes: ['Component'],
-    },
-  ],
   create(context, [{ suffixes }]) {
     return {
       [Selectors.COMPONENT_CLASS_DECORATOR](node: TSESTree.Decorator) {

--- a/packages/eslint-plugin/src/rules/component-max-inline-declarations.ts
+++ b/packages/eslint-plugin/src/rules/component-max-inline-declarations.ts
@@ -49,14 +49,14 @@ export default createESLintRule<Options, MessageIds>({
     messages: {
       componentMaxInlineDeclarations: `\`{{propertyType}}\` has too many lines ({{lineCount}}). Maximum allowed is {{max}}`,
     },
+    defaultOptions: [
+      {
+        template: DEFAULT_TEMPLATE_LIMIT,
+        styles: DEFAULT_STYLES_LIMIT,
+        animations: DEFAULT_ANIMATIONS_LIMIT,
+      },
+    ],
   },
-  defaultOptions: [
-    {
-      template: DEFAULT_TEMPLATE_LIMIT,
-      styles: DEFAULT_STYLES_LIMIT,
-      animations: DEFAULT_ANIMATIONS_LIMIT,
-    },
-  ],
   create(
     context,
     [

--- a/packages/eslint-plugin/src/rules/component-selector.ts
+++ b/packages/eslint-plugin/src/rules/component-selector.ts
@@ -111,14 +111,14 @@ export default createESLintRule<Options, MessageIds>({
       shadowDomEncapsulatedStyleFailure: `The selector of a ShadowDom-encapsulated component should be \`${ASTUtils.OPTION_STYLE_KEBAB_CASE}\` (${SHADOW_DOM_ENCAPSULATED_STYLE_LINK})`,
       selectorAfterPrefixFailure: `There should be a selector after the {{prefix}} prefix`,
     },
-    defaultOptions: [
-      {
-        type: undefined as unknown as string,
-        prefix: 'app', // Match default Angular CLI prefix
-        style: undefined as unknown as string,
-      },
-    ],
   },
+  defaultOptions: [
+    {
+      type: undefined as unknown as string,
+      prefix: 'app', // Match default Angular CLI prefix
+      style: undefined as unknown as string,
+    },
+  ],
   create(context, [options]) {
     // Options are required by schema, so if undefined, ESLint will throw an error
     if (!options) {

--- a/packages/eslint-plugin/src/rules/component-selector.ts
+++ b/packages/eslint-plugin/src/rules/component-selector.ts
@@ -111,14 +111,14 @@ export default createESLintRule<Options, MessageIds>({
       shadowDomEncapsulatedStyleFailure: `The selector of a ShadowDom-encapsulated component should be \`${ASTUtils.OPTION_STYLE_KEBAB_CASE}\` (${SHADOW_DOM_ENCAPSULATED_STYLE_LINK})`,
       selectorAfterPrefixFailure: `There should be a selector after the {{prefix}} prefix`,
     },
+    defaultOptions: [
+      {
+        type: undefined as unknown as string,
+        prefix: 'app', // Match default Angular CLI prefix
+        style: undefined as unknown as string,
+      },
+    ],
   },
-  defaultOptions: [
-    {
-      type: undefined as unknown as string,
-      prefix: 'app', // Match default Angular CLI prefix
-      style: undefined as unknown as string,
-    },
-  ],
   create(context, [options]) {
     // Options are required by schema, so if undefined, ESLint will throw an error
     if (!options) {

--- a/packages/eslint-plugin/src/rules/computed-must-return.ts
+++ b/packages/eslint-plugin/src/rules/computed-must-return.ts
@@ -16,8 +16,8 @@ export default createESLintRule<[], MessageIds>({
     messages: {
       computedMissingReturn: 'computed() is missing a return value',
     },
+    defaultOptions: [],
   },
-  defaultOptions: [],
   create(context) {
     const functionStack: {
       node: TSESTree.FunctionExpression | TSESTree.ArrowFunctionExpression;

--- a/packages/eslint-plugin/src/rules/consistent-component-styles.ts
+++ b/packages/eslint-plugin/src/rules/consistent-component-styles.ts
@@ -32,8 +32,8 @@ export default createESLintRule<Options, MessageIds>({
       useStylesString:
         'Use a `string` instead of a `string[]` for the `styles` property',
     },
+    defaultOptions: ['string'],
   },
-  defaultOptions: ['string'],
   create(context, [mode]) {
     const { COMPONENT_CLASS_DECORATOR, metadataProperty } = Selectors;
     const LITERAL_OR_TEMPLATE_LITERAL = ':matches(Literal, TemplateLiteral)';

--- a/packages/eslint-plugin/src/rules/contextual-decorator.ts
+++ b/packages/eslint-plugin/src/rules/contextual-decorator.ts
@@ -19,8 +19,8 @@ export default createESLintRule<Options, MessageIds>({
       contextualDecorator:
         'Decorator out of context for "@{{classDecoratorName}}()"',
     },
+    defaultOptions: [],
   },
-  defaultOptions: [],
   create(context) {
     return {
       'MethodDefinition[kind=/^(get|set|method)$/], PropertyDefinition, TSParameterProperty'(

--- a/packages/eslint-plugin/src/rules/contextual-lifecycle.ts
+++ b/packages/eslint-plugin/src/rules/contextual-lifecycle.ts
@@ -19,8 +19,8 @@ export default createESLintRule<Options, MessageIds>({
     messages: {
       contextualLifecycle: `Angular will not invoke the \`{{methodName}}\` lifecycle method within \`@{{classDecoratorName}}()\` classes`,
     },
+    defaultOptions: [],
   },
-  defaultOptions: [],
   create(context) {
     function checkContext(
       { parent }: TSESTree.Decorator,

--- a/packages/eslint-plugin/src/rules/directive-class-suffix.ts
+++ b/packages/eslint-plugin/src/rules/directive-class-suffix.ts
@@ -36,8 +36,8 @@ export default createESLintRule<Options, MessageIds>({
     messages: {
       directiveClassSuffix: `Directive class names should end with one of these suffixes: {{suffixes}}`,
     },
+    defaultOptions: [{ suffixes: DEFAULT_SUFFIXES }],
   },
-  defaultOptions: [{ suffixes: DEFAULT_SUFFIXES }],
   create(context, [{ suffixes }]) {
     return {
       [Selectors.DIRECTIVE_CLASS_DECORATOR](node: TSESTree.Decorator) {

--- a/packages/eslint-plugin/src/rules/directive-selector.ts
+++ b/packages/eslint-plugin/src/rules/directive-selector.ts
@@ -101,14 +101,14 @@ export default createESLintRule<Options, MessageIds>({
       typeFailure: 'The selector should be used as an {{type}}',
       selectorAfterPrefixFailure: `There should be a selector after the {{prefix}} prefix`,
     },
+    defaultOptions: [
+      {
+        type: undefined as unknown as string,
+        prefix: 'app', // Match default Angular CLI prefix
+        style: undefined as unknown as string,
+      },
+    ],
   },
-  defaultOptions: [
-    {
-      type: undefined as unknown as string,
-      prefix: 'app', // Match default Angular CLI prefix
-      style: undefined as unknown as string,
-    },
-  ],
   create(context, [options]) {
     // Options are required by schema, so if undefined, ESLint will throw an error
     if (!options) {

--- a/packages/eslint-plugin/src/rules/directive-selector.ts
+++ b/packages/eslint-plugin/src/rules/directive-selector.ts
@@ -101,14 +101,14 @@ export default createESLintRule<Options, MessageIds>({
       typeFailure: 'The selector should be used as an {{type}}',
       selectorAfterPrefixFailure: `There should be a selector after the {{prefix}} prefix`,
     },
-    defaultOptions: [
-      {
-        type: undefined as unknown as string,
-        prefix: 'app', // Match default Angular CLI prefix
-        style: undefined as unknown as string,
-      },
-    ],
   },
+  defaultOptions: [
+    {
+      type: undefined as unknown as string,
+      prefix: 'app', // Match default Angular CLI prefix
+      style: undefined as unknown as string,
+    },
+  ],
   create(context, [options]) {
     // Options are required by schema, so if undefined, ESLint will throw an error
     if (!options) {

--- a/packages/eslint-plugin/src/rules/inject-at-top.ts
+++ b/packages/eslint-plugin/src/rules/inject-at-top.ts
@@ -20,8 +20,8 @@ export default createESLintRule<Options, MessageIds>({
       injectAtTop:
         'Move this inject() to the top of the class. Class fields are initialized in the order they are written, so anything declared above this line cannot safely use the service yet.',
     },
+    defaultOptions: [],
   },
-  defaultOptions: [],
   create(context) {
     const angularDecoratorsPattern = toPattern([
       'Component',

--- a/packages/eslint-plugin/src/rules/no-async-lifecycle-method.ts
+++ b/packages/eslint-plugin/src/rules/no-async-lifecycle-method.ts
@@ -17,8 +17,8 @@ export default createESLintRule<Options, MessageIds>({
     messages: {
       noAsyncLifecycleMethod: 'Angular Lifecycle method should not be async',
     },
+    defaultOptions: [],
   },
-  defaultOptions: [],
   create(context) {
     const angularDecoratorsPattern = toPattern([
       'Component',

--- a/packages/eslint-plugin/src/rules/no-attribute-decorator.ts
+++ b/packages/eslint-plugin/src/rules/no-attribute-decorator.ts
@@ -17,8 +17,8 @@ export default createESLintRule<Options, MessageIds>({
       noAttributeDecorator:
         '@Attribute can only obtain a single value and is rarely what is required. Use @Input instead to retrieve a stream of values.',
     },
+    defaultOptions: [],
   },
-  defaultOptions: [],
   create(context) {
     return {
       'ClassDeclaration MethodDefinition[key.name="constructor"] Decorator[expression.callee.name="Attribute"]'(

--- a/packages/eslint-plugin/src/rules/no-developer-preview.ts
+++ b/packages/eslint-plugin/src/rules/no-developer-preview.ts
@@ -22,8 +22,8 @@ export default createESLintRule<Options, MessageIds>({
     messages: {
       noDeveloperPreview: '`{{name}}` is in developer preview',
     },
+    defaultOptions: [],
   },
-  defaultOptions: [],
   create(context) {
     const services = getParserServices(context);
     const checker = services.program.getTypeChecker();

--- a/packages/eslint-plugin/src/rules/no-duplicates-in-metadata-arrays.ts
+++ b/packages/eslint-plugin/src/rules/no-duplicates-in-metadata-arrays.ts
@@ -19,8 +19,8 @@ export default createESLintRule<Options, MessageIds>({
     messages: {
       noDuplicatesInMetadataArrays: 'Entry is duplicated in metadata array',
     },
+    defaultOptions: [],
   },
-  defaultOptions: [],
   create(context) {
     const selectors = [
       // https://angular.dev/api/core/NgModule

--- a/packages/eslint-plugin/src/rules/no-empty-lifecycle-method.ts
+++ b/packages/eslint-plugin/src/rules/no-empty-lifecycle-method.ts
@@ -27,8 +27,8 @@ export default createESLintRule<Options, MessageIds>({
       noEmptyLifecycleMethod: 'Lifecycle methods should not be empty',
       suggestRemoveLifecycleMethod: 'Remove lifecycle method',
     },
+    defaultOptions: [],
   },
-  defaultOptions: [],
   create(context) {
     const sourceCode = context.sourceCode;
 

--- a/packages/eslint-plugin/src/rules/no-experimental.ts
+++ b/packages/eslint-plugin/src/rules/no-experimental.ts
@@ -22,8 +22,8 @@ export default createESLintRule<Options, MessageIds>({
     messages: {
       noExperimental: '`{{name}}` is experimental',
     },
+    defaultOptions: [],
   },
-  defaultOptions: [],
   create(context) {
     const services = getParserServices(context);
     const checker = services.program.getTypeChecker();

--- a/packages/eslint-plugin/src/rules/no-forward-ref.ts
+++ b/packages/eslint-plugin/src/rules/no-forward-ref.ts
@@ -19,8 +19,8 @@ export default createESLintRule<Options, MessageIds>({
     messages: {
       noForwardRef: `Avoid using \`${FORWARD_REF}\``,
     },
+    defaultOptions: [],
   },
-  defaultOptions: [],
   create(context) {
     return {
       [`CallExpression[callee.type="Identifier"][callee.name="${FORWARD_REF}"]`](

--- a/packages/eslint-plugin/src/rules/no-implicit-take-until-destroyed.ts
+++ b/packages/eslint-plugin/src/rules/no-implicit-take-until-destroyed.ts
@@ -22,8 +22,8 @@ export default createESLintRule<Options, MessageIds>({
     messages: {
       noImplicitTakeUntilDestroyed: `\`takeUntilDestroyed()\` must be called with an explicit \`DestroyRef\` parameter when used outside of an injection context. See more at ${DEPENDENCY_INJECTION_CONTEXT} and ${RXJS_INTEROP_LINK}`,
     },
+    defaultOptions: [],
   },
-  defaultOptions: [],
   create(context) {
     return {
       CallExpression(node: TSESTree.CallExpression) {

--- a/packages/eslint-plugin/src/rules/no-input-prefix.ts
+++ b/packages/eslint-plugin/src/rules/no-input-prefix.ts
@@ -36,8 +36,8 @@ export default createESLintRule<Options, MessageIds>({
       noInputPrefix:
         'Input bindings, including aliases, should not be named, nor prefixed by {{prefixes}}',
     },
+    defaultOptions: [{ prefixes: [] }],
   },
-  defaultOptions: [{ prefixes: [] }],
   create(context, [{ prefixes }]) {
     return {
       [Selectors.INPUT_PROPERTY_OR_SETTER](

--- a/packages/eslint-plugin/src/rules/no-input-rename.ts
+++ b/packages/eslint-plugin/src/rules/no-input-rename.ts
@@ -51,8 +51,8 @@ export default createESLintRule<Options, MessageIds>({
       suggestReplaceOriginalNameWithAliasName:
         'Remove alias name and use it as the original name',
     },
+    defaultOptions: [{ allowedNames: [] }],
   },
-  defaultOptions: [{ allowedNames: [] }],
   create(context, [{ allowedNames = [] }]) {
     let selectors: ReadonlySet<string> = new Set();
     const ariaAttributeKeys = getAriaAttributeKeys();

--- a/packages/eslint-plugin/src/rules/no-inputs-metadata-property.ts
+++ b/packages/eslint-plugin/src/rules/no-inputs-metadata-property.ts
@@ -20,8 +20,8 @@ export default createESLintRule<Options, MessageIds>({
     messages: {
       noInputsMetadataProperty: `Use \`@Input\` rather than the \`${METADATA_PROPERTY_NAME}\` metadata property`,
     },
+    defaultOptions: [],
   },
-  defaultOptions: [],
   create(context) {
     return {
       [`${

--- a/packages/eslint-plugin/src/rules/no-lifecycle-call.ts
+++ b/packages/eslint-plugin/src/rules/no-lifecycle-call.ts
@@ -18,8 +18,8 @@ export default createESLintRule<Options, MessageIds>({
     messages: {
       noLifecycleCall: 'Avoid explicit calls to lifecycle methods',
     },
+    defaultOptions: [],
   },
-  defaultOptions: [],
   create(context) {
     const angularLifeCycleMethodsPattern = toPattern([
       ...ASTUtils.ANGULAR_LIFECYCLE_METHODS,

--- a/packages/eslint-plugin/src/rules/no-output-native.ts
+++ b/packages/eslint-plugin/src/rules/no-output-native.ts
@@ -24,8 +24,8 @@ export default createESLintRule<Options, MessageIds>({
       noOutputNative:
         'Output bindings, including aliases, should not be named as standard DOM events',
     },
+    defaultOptions: [],
   },
-  defaultOptions: [],
   create(context) {
     const nativeEventNames = getNativeEventNames();
     const selectors = [

--- a/packages/eslint-plugin/src/rules/no-output-on-prefix.ts
+++ b/packages/eslint-plugin/src/rules/no-output-on-prefix.ts
@@ -20,8 +20,8 @@ export default createESLintRule<Options, MessageIds>({
     messages: {
       noOutputOnPrefix: `Output bindings, including aliases, should not be named "on", nor prefixed with it (${STYLE_GUIDE_LINK})`,
     },
+    defaultOptions: [],
   },
-  defaultOptions: [],
   create(context) {
     const outputOnPattern = /^on(([^a-z])|(?=$))/;
     const selectors = [

--- a/packages/eslint-plugin/src/rules/no-output-rename.ts
+++ b/packages/eslint-plugin/src/rules/no-output-rename.ts
@@ -34,8 +34,8 @@ export default createESLintRule<Options, MessageIds>({
       suggestReplaceOriginalNameWithAliasName:
         'Remove alias name and use it as the original name',
     },
+    defaultOptions: [],
   },
-  defaultOptions: [],
   create(context) {
     let selectors: ReadonlySet<string> = new Set();
 

--- a/packages/eslint-plugin/src/rules/no-outputs-metadata-property.ts
+++ b/packages/eslint-plugin/src/rules/no-outputs-metadata-property.ts
@@ -20,8 +20,8 @@ export default createESLintRule<Options, MessageIds>({
     messages: {
       noOutputsMetadataProperty: `Use \`@Output\` rather than the \`${METADATA_PROPERTY_NAME}\` metadata property`,
     },
+    defaultOptions: [],
   },
-  defaultOptions: [],
   create(context) {
     return {
       [`${

--- a/packages/eslint-plugin/src/rules/no-pipe-impure.ts
+++ b/packages/eslint-plugin/src/rules/no-pipe-impure.ts
@@ -20,8 +20,8 @@ export default createESLintRule<Options, MessageIds>({
         'Impure pipes should be avoided because they are invoked on each change-detection cycle',
       suggestRemovePipeImpure: 'Remove `pure` property',
     },
+    defaultOptions: [],
   },
-  defaultOptions: [],
   create(context) {
     const sourceCode = context.sourceCode;
 

--- a/packages/eslint-plugin/src/rules/no-queries-metadata-property.ts
+++ b/packages/eslint-plugin/src/rules/no-queries-metadata-property.ts
@@ -19,8 +19,8 @@ export default createESLintRule<Options, MessageIds>({
     messages: {
       noQueriesMetadataProperty: `Use @${ASTUtils.AngularInnerClassDecorators.Output} rather than the \`${METADATA_PROPERTY_NAME}\` metadata property`,
     },
+    defaultOptions: [],
   },
-  defaultOptions: [],
   create(context) {
     return {
       [Selectors.COMPONENT_OR_DIRECTIVE_CLASS_DECORATOR](

--- a/packages/eslint-plugin/src/rules/no-uncalled-signals.ts
+++ b/packages/eslint-plugin/src/rules/no-uncalled-signals.ts
@@ -43,8 +43,8 @@ export default createESLintRule<Options, MessageIds>({
         'Doing logic operations on signals will give unexpected results, you probably want to invoke the signal to get its value',
       suggestCallSignal: 'Call this signal to get its value.',
     },
+    defaultOptions: [],
   },
-  defaultOptions: [],
   create(context) {
     const services: ParserServicesWithTypeInformation =
       ESLintUtils.getParserServices(context);

--- a/packages/eslint-plugin/src/rules/pipe-prefix.ts
+++ b/packages/eslint-plugin/src/rules/pipe-prefix.ts
@@ -42,12 +42,12 @@ export default createESLintRule<Options, MessageIds>({
       selectorAfterPrefixFailure:
         '@Pipes should have a selector after the {{prefixes}} prefix',
     },
+    defaultOptions: [
+      {
+        prefixes: [],
+      },
+    ],
   },
-  defaultOptions: [
-    {
-      prefixes: [],
-    },
-  ],
   create(context, [{ prefixes }]) {
     function checkValidOption(prefixes: unknown) {
       return Array.isArray(prefixes) && prefixes.length > 0;

--- a/packages/eslint-plugin/src/rules/prefer-host-metadata-property.ts
+++ b/packages/eslint-plugin/src/rules/prefer-host-metadata-property.ts
@@ -23,8 +23,8 @@ export default createESLintRule<Options, MessageIds>({
       preferHostMetadataPropertyForListener:
         'Prefer using the `host` metadata property in the `@Component` decorator for host listeners instead of the `@HostListener` decorator.',
     },
+    defaultOptions: [],
   },
-  defaultOptions: [],
   create(context) {
     return {
       [Selectors.HOST_BINDING_DECORATOR]: (node) => {

--- a/packages/eslint-plugin/src/rules/prefer-inject.ts
+++ b/packages/eslint-plugin/src/rules/prefer-inject.ts
@@ -21,8 +21,8 @@ export default createESLintRule<Options, MessageIds>({
       preferInject:
         "Prefer using the inject() function over constructor parameter injection. Use Angular's migration schematic to automatically refactor: ng generate @angular/core:inject",
     },
+    defaultOptions: [],
   },
-  defaultOptions: [],
   create(context) {
     const angularDecoratorsPattern = toPattern([
       'Component',

--- a/packages/eslint-plugin/src/rules/prefer-on-push-component-change-detection.ts
+++ b/packages/eslint-plugin/src/rules/prefer-on-push-component-change-detection.ts
@@ -46,8 +46,8 @@ export default createESLintRule<Options, MessageIds>({
       suggestRemoveChangeDetection: `Remove \`${METADATA_PROPERTY_NAME}\` to use the default (\`${STRATEGY_ON_PUSH}\`)`,
       redundantOnPushComponentChangeDetection: `\`${METADATA_PROPERTY_NAME}: ${STRATEGY_ON_PUSH}\` is redundant because \`${STRATEGY_ON_PUSH}\` is the default change detection strategy`,
     },
+    defaultOptions: [DEFAULT_OPTIONS],
   },
-  defaultOptions: [DEFAULT_OPTIONS],
   create(context, [{ allowExplicitOnPush }]) {
     const sourceCode = context.sourceCode;
     const changeDetectionMetadataProperty = Selectors.metadataProperty(

--- a/packages/eslint-plugin/src/rules/prefer-output-emitter-ref.ts
+++ b/packages/eslint-plugin/src/rules/prefer-output-emitter-ref.ts
@@ -18,8 +18,8 @@ export default createESLintRule<Options, MessageIds>({
       preferOutputEmitterRef:
         'Use `OutputEmitterRef` via `output()` for Component and Directive outputs rather than the legacy `@Output()` decorator',
     },
+    defaultOptions: [],
   },
-  defaultOptions: [],
   create(context) {
     return {
       [Selectors.OUTPUT_DECORATOR]: (node) => {

--- a/packages/eslint-plugin/src/rules/prefer-output-readonly.ts
+++ b/packages/eslint-plugin/src/rules/prefer-output-readonly.ts
@@ -21,8 +21,8 @@ export default createESLintRule<Options, MessageIds>({
         'Prefer to declare `{{type}}` as `readonly` since they are not supposed to be reassigned',
       suggestAddReadonlyModifier: 'Add `readonly` modifier',
     },
+    defaultOptions: [],
   },
-  defaultOptions: [],
   create(context) {
     return {
       [`PropertyDefinition:not([readonly=true]) > ${Selectors.OUTPUT_DECORATOR}`]({

--- a/packages/eslint-plugin/src/rules/prefer-service-decorator.ts
+++ b/packages/eslint-plugin/src/rules/prefer-service-decorator.ts
@@ -31,8 +31,8 @@ export default createESLintRule<Options, MessageIds>({
       preferServiceDecorator:
         "Use the `@Service()` decorator instead of `@Injectable({ providedIn: 'root' })`",
     },
+    defaultOptions: [],
   },
-  defaultOptions: [],
   create(context) {
     return {
       [Selectors.INJECTABLE_CLASS_DECORATOR](node: TSESTree.Decorator) {

--- a/packages/eslint-plugin/src/rules/prefer-signal-model.ts
+++ b/packages/eslint-plugin/src/rules/prefer-signal-model.ts
@@ -25,8 +25,8 @@ export default createESLintRule<Options, MessageIds>({
       preferSignalModel:
         'Use `model` for two-way bindings instead of `input()` and `output()`',
     },
+    defaultOptions: [],
   },
-  defaultOptions: [],
   create(context) {
     const inputs = new Map<string, TSESTree.PropertyDefinition>();
     const outputs = new Map<string, TSESTree.PropertyDefinition>();

--- a/packages/eslint-plugin/src/rules/prefer-signals.ts
+++ b/packages/eslint-plugin/src/rules/prefer-signals.ts
@@ -90,8 +90,8 @@ export default createESLintRule<Options, MessageIds>({
       preferReadonlySignalProperties:
         'Properties declared using signals should be marked as `readonly` since they should not be reassigned',
     },
+    defaultOptions: [{ ...DEFAULT_OPTIONS }],
   },
-  defaultOptions: [{ ...DEFAULT_OPTIONS }],
   create(
     context,
     [

--- a/packages/eslint-plugin/src/rules/prefer-standalone.ts
+++ b/packages/eslint-plugin/src/rules/prefer-standalone.ts
@@ -24,8 +24,8 @@ export default createESLintRule<Options, MessageIds>({
       preferStandalone: `Components, Directives and Pipes should not opt out of standalone. Following this guide is highly recommended: ${RECOMMENDED_GUIDE_URL}`,
       removeStandaloneFalse: `Quickly remove 'standalone: false'. NOTE - Following this guide is highly recommended: ${RECOMMENDED_GUIDE_URL}`,
     },
+    defaultOptions: [],
   },
-  defaultOptions: [],
   create(context) {
     const standaloneRuleFactory =
       (type: DecoratorTypes) => (node: TSESTree.Decorator) => {

--- a/packages/eslint-plugin/src/rules/relative-url-prefix.ts
+++ b/packages/eslint-plugin/src/rules/relative-url-prefix.ts
@@ -19,8 +19,8 @@ export default createESLintRule<Options, MessageIds>({
     messages: {
       relativeUrlPrefix: `The ./ and ../ prefix is standard syntax for relative URLs.`,
     },
+    defaultOptions: [],
   },
-  defaultOptions: [],
   create(context) {
     return {
       [`${Selectors.COMPONENT_CLASS_DECORATOR} Property[key.name='templateUrl']`]({

--- a/packages/eslint-plugin/src/rules/require-lifecycle-on-prototype.ts
+++ b/packages/eslint-plugin/src/rules/require-lifecycle-on-prototype.ts
@@ -32,8 +32,8 @@ export default createESLintRule<Options, MessageIds>({
     messages: {
       defineOnPrototype: `The {{ method }} lifecycle method should be defined on the object's prototype. See more at ${ISSUE_LINK}`,
     },
+    defaultOptions: [],
   },
-  defaultOptions: [],
   create(context) {
     return {
       [propertyDefinitionSelector](

--- a/packages/eslint-plugin/src/rules/require-localize-metadata.ts
+++ b/packages/eslint-plugin/src/rules/require-localize-metadata.ts
@@ -59,8 +59,8 @@ export default createESLintRule<Options, MessageIds>({
       requireLocalizeMeaning: `$localize tagged messages should contain a meaning. See more at ${STYLE_GUIDE_LINK_METADATA_FOR_TRANSLATION}`,
       requireLocalizeCustomId: `$localize tagged messages should contain a custom id{{patternMessage}}. See more at ${STYLE_GUIDE_LINK_METADATA_FOR_TRANSLATION}`,
     },
+    defaultOptions: [DEFAULT_OPTIONS],
   },
-  defaultOptions: [DEFAULT_OPTIONS],
   create(context, [{ requireDescription, requireMeaning, requireCustomId }]) {
     return {
       TaggedTemplateExpression(

--- a/packages/eslint-plugin/src/rules/runtime-localize.ts
+++ b/packages/eslint-plugin/src/rules/runtime-localize.ts
@@ -18,8 +18,8 @@ export default createESLintRule<Options, MessageIds>({
     messages: {
       runtimeLocalize: `$localize could be called before translations are loaded`,
     },
+    defaultOptions: [],
   },
-  defaultOptions: [],
   create(context) {
     return {
       TaggedTemplateExpression(

--- a/packages/eslint-plugin/src/rules/sort-keys-in-type-decorator.ts
+++ b/packages/eslint-plugin/src/rules/sort-keys-in-type-decorator.ts
@@ -114,8 +114,8 @@ export default createESLintRule<Options, MessageIds>({
       incorrectOrder:
         'Keys in @{{decorator}} decorator should be ordered: {{expectedOrder}}',
     },
+    defaultOptions: [DEFAULT_ORDER],
   },
-  defaultOptions: [DEFAULT_ORDER],
   create(
     context: Readonly<TSESLint.RuleContext<MessageIds, Options>>,
     [orderConfig]: Readonly<Options>,

--- a/packages/eslint-plugin/src/rules/sort-lifecycle-methods.ts
+++ b/packages/eslint-plugin/src/rules/sort-lifecycle-methods.ts
@@ -18,8 +18,8 @@ export default createESLintRule<Options, MessageIds>({
     messages: {
       lifecycleMethodsNotSorted: `Lifecycle Methods are not declared in order of execution`,
     },
+    defaultOptions: [],
   },
-  defaultOptions: [],
   create(context) {
     const isBefore = (
       method1: TSESTree.MethodDefinition,

--- a/packages/eslint-plugin/src/rules/use-component-selector.ts
+++ b/packages/eslint-plugin/src/rules/use-component-selector.ts
@@ -18,8 +18,8 @@ export default createESLintRule<Options, MessageIds>({
     messages: {
       useComponentSelector: 'The selector of the component is mandatory',
     },
+    defaultOptions: [],
   },
-  defaultOptions: [],
   create(context) {
     return {
       [Selectors.COMPONENT_CLASS_DECORATOR](node: TSESTree.Decorator) {

--- a/packages/eslint-plugin/src/rules/use-component-view-encapsulation.ts
+++ b/packages/eslint-plugin/src/rules/use-component-view-encapsulation.ts
@@ -26,8 +26,8 @@ export default createESLintRule<Options, MessageIds>({
       useComponentViewEncapsulation: `Using \`${VIEW_ENCAPSULATION_NONE}\` makes your styles global, which may have an unintended effect`,
       suggestRemoveViewEncapsulationNone: `Remove \`${VIEW_ENCAPSULATION_NONE}\``,
     },
+    defaultOptions: [],
   },
-  defaultOptions: [],
   create(context) {
     const sourceCode = context.sourceCode;
 

--- a/packages/eslint-plugin/src/rules/use-injectable-provided-in.ts
+++ b/packages/eslint-plugin/src/rules/use-injectable-provided-in.ts
@@ -42,8 +42,8 @@ export default createESLintRule<Options, MessageIds>({
       useInjectableProvidedIn: `The \`${METADATA_PROPERTY_NAME}\` property is mandatory for \`Injectables\``,
       suggestInjector: `Use \`${METADATA_PROPERTY_NAME}: '{{injector}}'\``,
     },
+    defaultOptions: [DEFAULT_OPTIONS],
   },
-  defaultOptions: [DEFAULT_OPTIONS],
   create(context, [{ ignoreClassNamePattern, allowProvidedInNull }]) {
     const injectableClassDecorator = `ClassDeclaration:not([id.name=${ignoreClassNamePattern}]):not(:has(TSClassImplements:matches([expression.property.name='HttpInterceptor'], [expression.name='HttpInterceptor']))) > Decorator[expression.callee.name="Injectable"]`;
     const providedInMetadataProperty = Selectors.metadataProperty(

--- a/packages/eslint-plugin/src/rules/use-lifecycle-interface.ts
+++ b/packages/eslint-plugin/src/rules/use-lifecycle-interface.ts
@@ -25,8 +25,8 @@ export default createESLintRule<Options, MessageIds>({
       useLifecycleInterface: `Lifecycle interface '{{interfaceName}}' should be implemented for method '{{methodName}}'. (${STYLE_GUIDE_LINK})`,
     },
     fixable: 'code',
+    defaultOptions: [],
   },
-  defaultOptions: [],
   create(context) {
     const angularLifecycleMethodsPattern = toPattern([
       ...ASTUtils.ANGULAR_LIFECYCLE_METHODS,

--- a/packages/eslint-plugin/src/rules/use-pipe-transform-interface.ts
+++ b/packages/eslint-plugin/src/rules/use-pipe-transform-interface.ts
@@ -20,8 +20,8 @@ export default createESLintRule<Options, MessageIds>({
     messages: {
       usePipeTransformInterface: `Pipes should implement \`${PIPE_TRANSFORM}\` interface`,
     },
+    defaultOptions: [],
   },
-  defaultOptions: [],
   create(context) {
     return {
       [`ClassDeclaration:not(:has(TSClassImplements:matches([expression.name='${PIPE_TRANSFORM}'], [expression.property.name='${PIPE_TRANSFORM}']))) > Decorator[expression.callee.name='Pipe']`]({

--- a/packages/eslint-plugin/src/utils/create-eslint-rule.ts
+++ b/packages/eslint-plugin/src/utils/create-eslint-rule.ts
@@ -9,9 +9,9 @@ export interface RuleDocs {
  * to use as part of documentation generation.
  */
 const patchedRuleCreator: typeof ESLintUtils.RuleCreator = (urlCreator) => {
-  return function createRule({ name, meta, defaultOptions, create }) {
-    const resolvedDefaultOptions = (defaultOptions ?? []) as NonNullable<
-      typeof defaultOptions
+  return function createRule({ name, meta, create }) {
+    const resolvedDefaultOptions = (meta.defaultOptions ?? []) as Readonly<
+      NonNullable<typeof meta.defaultOptions>
     >;
 
     return {

--- a/packages/eslint-plugin/src/utils/create-eslint-rule.ts
+++ b/packages/eslint-plugin/src/utils/create-eslint-rule.ts
@@ -4,38 +4,7 @@ export interface RuleDocs {
   recommended?: string;
 }
 
-/**
- * We need to patch the RuleCreator in order to preserve the defaultOptions
- * to use as part of documentation generation.
- */
-const patchedRuleCreator: typeof ESLintUtils.RuleCreator = (urlCreator) => {
-  return function createRule({ name, meta, create }) {
-    const resolvedDefaultOptions = (meta.defaultOptions ?? []) as Readonly<
-      NonNullable<typeof meta.defaultOptions>
-    >;
-
-    return {
-      name,
-      meta: Object.assign(Object.assign({}, meta), {
-        docs: Object.assign(Object.assign({}, meta.docs), {
-          url: urlCreator(name),
-        }),
-      }),
-      defaultOptions: resolvedDefaultOptions,
-      create(context) {
-        const optionsWithDefault = ESLintUtils.applyDefault(
-          resolvedDefaultOptions,
-          context.options,
-        );
-        return create(context, optionsWithDefault);
-      },
-    };
-  };
-};
-
-patchedRuleCreator.withoutDocs = ESLintUtils.RuleCreator.withoutDocs;
-
-export const createESLintRule = patchedRuleCreator<RuleDocs>(
+export const createESLintRule = ESLintUtils.RuleCreator<RuleDocs>(
   (ruleName) =>
     `https://github.com/angular-eslint/angular-eslint/blob/main/packages/eslint-plugin/docs/rules/${ruleName}.md`,
 );

--- a/tools/scripts/generate-rule-docs.ts
+++ b/tools/scripts/generate-rule-docs.ts
@@ -41,8 +41,18 @@ const testDirs = readdirSync(testDirsDir);
   for (const [ruleName, ruleData] of Object.entries(allRuleData)) {
     const {
       ruleConfig: {
-        meta: { deprecated, replacedBy, type, fixable, schema, hasSuggestions },
-        defaultOptions,
+        meta: {
+          deprecated,
+          replacedBy,
+          type,
+          fixable,
+          schema,
+          hasSuggestions,
+          defaultOptions: metaDefaultOptions,
+        },
+        // component-selector/directive-selector have to rely on the deprecated
+        // top-level defaultOptions instead of meta.defaultOptions
+        defaultOptions: topLevelDefaultOptions,
       },
       docsExtension,
       ruleFilePath,
@@ -51,6 +61,7 @@ const testDirs = readdirSync(testDirsDir);
 
     const docs = ruleData.ruleConfig.meta.docs!;
     const { description } = docs;
+    const defaultOptionsForDocs = metaDefaultOptions ?? topLevelDefaultOptions;
 
     let schemaAsInterface = '';
     if (Array.isArray(schema) && schema[0]) {
@@ -71,8 +82,8 @@ const testDirs = readdirSync(testDirsDir);
           if (typeof schemaNode.default !== 'undefined') {
             defaultValue = schemaNode.default;
             hasDefaultValue = true;
-          } else if (defaultOptions?.length) {
-            for (const defaultOption of defaultOptions) {
+          } else if (defaultOptionsForDocs?.length) {
+            for (const defaultOption of defaultOptionsForDocs) {
               if (
                 typeof defaultOption === 'object' &&
                 (keyIndex as string) in defaultOption
@@ -241,6 +252,7 @@ interface RuleData {
   ruleFilePath: string;
   testCasesFilePath: string;
   ruleConfig: TSESLint.RuleModule<string, []> & {
+    meta: { defaultOptions?: Record<string, unknown>[] };
     defaultOptions?: Record<string, unknown>[];
   };
   // Rules can optionally export extended documentation content (outside of ESLint's concept of "docs")


### PR DESCRIPTION
`defaultOptions` in root were deprecated upstream, so I've removed them and moved to recommended `meta.defaultOptions`.
This allowed me to get rid of `patchedRuleCreator`.
However,  `component-selector` and `directive-selector` are special in that they provide meaningless placeholder default options. They also don't match the schema, so if I make the replacement there, eslint won't let it through. I kept them as is and added an exception in `general-rule-docs`.