### PR TITLE
fix(eslint-plugin): [reactive-context-must-read-signal] improve getter and function detection

### DIFF
--- a/packages/eslint-plugin/docs/rules/reactive-context-must-read-signal.md
+++ b/packages/eslint-plugin/docs/rules/reactive-context-must-read-signal.md
@@ -23,7 +23,7 @@ Ensures that reactive contexts such as computed(), linkedSignal() and effect() r
 
 ## Rationale
 
-Reactive contexts like `computed()`, `linkedSignal()`, `effect()` and `afterRenderEffect()` re-run whenever a signal they read changes. If the relevant function never reads a signal, the context runs once and can never react to anything, so it adds overhead without providing reactivity. This is usually a mistake: either the developer forgot to call a signal (e.g. wrote `firstName` instead of `firstName()`), or the value is actually static and should be a plain constant, a `signal()`, or an `afterNextRender()` in the case of `afterRenderEffect()`. To avoid false positives, the rule only reports when everything the tracked function does is known not to read a signal. Calls into the TypeScript standard library (arrays, strings, `Math`, `JSON`, `console`, DOM APIs, etc.) are known to be safe; anything else keeps the rule silent, including a helper function, a service method, a getter, an unresolved symbol, and any Angular API such as `untracked()`. For `resource()`/`rxResource()` only the `params` function defines the dependencies, and these are opt-in via the `checkResources` option.
+Reactive contexts like `computed()`, `linkedSignal()`, `effect()` and `afterRenderEffect()` re-run whenever a signal they read changes. If the relevant function never reads a signal, the context runs once and can never react to anything, so it adds overhead without providing reactivity. This is usually a mistake: either the developer forgot to call a signal (e.g. wrote `firstName` instead of `firstName()`), or the value is actually static and should be a plain constant, a `signal()`, or an `afterNextRender()` in the case of `afterRenderEffect()`. To avoid false positives, the rule only reports when everything the tracked function does is known not to read a signal. Calls into the TypeScript standard library (arrays, strings, `Math`, `JSON`, `console`, DOM APIs, etc.) are known to be safe; anything else keeps the rule silent, including a helper function, a service method, a getter, an unresolved symbol, and any Angular API such as `untracked()`. One known limitation: a standard library call that reaches user code through a protocol method, such as `toJSON()` in `JSON.stringify()` or `toString()` in a template literal, is still treated as safe, so a signal read inside such a method is not detected. For `resource()`/`rxResource()` only the `params` function defines the dependencies, and these are opt-in via the `checkResources` option.
 
 <br>
 
@@ -132,6 +132,42 @@ class Test {
   name = 'x';
   c = computed(() => this.name);
       ~~~~~~~~~~~~~~~~~~~~~~~~~
+}
+```
+
+<br>
+
+---
+
+<br>
+
+#### Default Config
+
+```json
+{
+  "rules": {
+    "@angular-eslint/reactive-context-must-read-signal": [
+      "error"
+    ]
+  }
+}
+```
+
+<br>
+
+#### ❌ Invalid Code
+
+```ts
+class Test {
+  name = 'x';
+  c = computed(() => {
+      ~~~~~~~~~~~~~~~~
+    const { name } = this;
+    ~~~~~~~~~~~~~~~~~~~~~~
+    return name;
+    ~~~~~~~~~~~~
+  });
+  ~~
 }
 ```
 
@@ -857,6 +893,67 @@ class Test {
 #### ✅ Valid Code
 
 ```ts
+declare const transform: any;
+class Test {
+  items = [1, 2, 3];
+  c = computed(() => this.items.map(transform));
+}
+```
+
+<br>
+
+---
+
+<br>
+
+#### Default Config
+
+```json
+{
+  "rules": {
+    "@angular-eslint/reactive-context-must-read-signal": [
+      "error"
+    ]
+  }
+}
+```
+
+<br>
+
+#### ✅ Valid Code
+
+```ts
+class Test {
+  items = [1, 2, 3];
+  transform: ((value: number) => number) | ((value: number) => string) =
+    (value) => value;
+  c = computed(() => this.items.map(this.transform));
+}
+```
+
+<br>
+
+---
+
+<br>
+
+#### Default Config
+
+```json
+{
+  "rules": {
+    "@angular-eslint/reactive-context-must-read-signal": [
+      "error"
+    ]
+  }
+}
+```
+
+<br>
+
+#### ✅ Valid Code
+
+```ts
 class Test {
   values = [1, 2, 3];
   c = computed(() => Math.max(...this.values));
@@ -952,6 +1049,76 @@ class Test {
     return this.count() * 2;
   }
   c = computed(() => this.double);
+}
+```
+
+<br>
+
+---
+
+<br>
+
+#### Default Config
+
+```json
+{
+  "rules": {
+    "@angular-eslint/reactive-context-must-read-signal": [
+      "error"
+    ]
+  }
+}
+```
+
+<br>
+
+#### ✅ Valid Code
+
+```ts
+class Test {
+  count = signal(0);
+  get double(): number {
+    return this.count() * 2;
+  }
+  c = computed(() => {
+    const { double } = this;
+    return double;
+  });
+}
+```
+
+<br>
+
+---
+
+<br>
+
+#### Default Config
+
+```json
+{
+  "rules": {
+    "@angular-eslint/reactive-context-must-read-signal": [
+      "error"
+    ]
+  }
+}
+```
+
+<br>
+
+#### ✅ Valid Code
+
+```ts
+class Test {
+  count = signal(0);
+  get double(): number {
+    return this.count() * 2;
+  }
+  c = computed(() => {
+    const { count, ...rest } = this;
+    return rest;
+  });
 }
 ```
 

--- a/packages/eslint-plugin/src/rules/reactive-context-must-read-signal.ts
+++ b/packages/eslint-plugin/src/rules/reactive-context-must-read-signal.ts
@@ -178,7 +178,32 @@ export default createESLintRule<Options, MessageIds>({
         // We cannot tell what a spread expands to, so assume the worst.
         return true;
       }
-      return services.getTypeAtLocation(node).getCallSignatures().length > 0;
+      const type = services.getTypeAtLocation(node);
+      if (
+        tsutils.isTypeFlagSet(type, ts.TypeFlags.Any | ts.TypeFlags.Unknown)
+      ) {
+        // We know nothing about the value, so it could well be a function
+        // that reads a signal.
+        return true;
+      }
+      return tsutils
+        .unionConstituents(type)
+        .some((constituent) => constituent.getCallSignatures().length > 0);
+    }
+
+    /**
+     * Returns true if the property with the given name is a getter on any
+     * constituent of the type. A getter runs arbitrary code, so it can read a
+     * signal even though reading the property does not look like a call.
+     */
+    function isGetter(type: ts.Type, name: string): boolean {
+      return tsutils.unionConstituents(type).some((constituent) => {
+        const property = constituent.getProperty(name);
+        return (
+          property !== undefined &&
+          tsutils.isSymbolFlagSet(property, ts.SymbolFlags.GetAccessor)
+        );
+      });
     }
 
     /**
@@ -304,6 +329,29 @@ export default createESLintRule<Options, MessageIds>({
         }
       },
 
+      ObjectPattern(node: TSESTree.ObjectPattern) {
+        const analysis = currentAnalysis();
+        if (!analysis) {
+          return;
+        }
+        // Destructuring invokes getters just like a member expression does,
+        // e.g. `const { double } = this`.
+        const type = services.getTypeAtLocation(node);
+        for (const property of node.properties) {
+          if (
+            property.type !== AST_NODE_TYPES.Property ||
+            property.computed ||
+            property.key.type !== AST_NODE_TYPES.Identifier
+          ) {
+            // A rest element copies every property and a computed or literal
+            // key can name any property, so assume a getter could be involved.
+            analysis.hasUnknown = true;
+          } else if (isGetter(type, property.key.name)) {
+            analysis.hasUnknown = true;
+          }
+        }
+      },
+
       NewExpression(node: TSESTree.NewExpression) {
         const analysis = currentAnalysis();
         if (analysis) {
@@ -380,5 +428,5 @@ export default createESLintRule<Options, MessageIds>({
 
 export const RULE_DOCS_EXTENSION = {
   rationale:
-    'Reactive contexts like `computed()`, `linkedSignal()`, `effect()` and `afterRenderEffect()` re-run whenever a signal they read changes. If the relevant function never reads a signal, the context runs once and can never react to anything, so it adds overhead without providing reactivity. This is usually a mistake: either the developer forgot to call a signal (e.g. wrote `firstName` instead of `firstName()`), or the value is actually static and should be a plain constant, a `signal()`, or an `afterNextRender()` in the case of `afterRenderEffect()`. To avoid false positives, the rule only reports when everything the tracked function does is known not to read a signal. Calls into the TypeScript standard library (arrays, strings, `Math`, `JSON`, `console`, DOM APIs, etc.) are known to be safe; anything else keeps the rule silent, including a helper function, a service method, a getter, an unresolved symbol, and any Angular API such as `untracked()`. For `resource()`/`rxResource()` only the `params` function defines the dependencies, and these are opt-in via the `checkResources` option.',
+    'Reactive contexts like `computed()`, `linkedSignal()`, `effect()` and `afterRenderEffect()` re-run whenever a signal they read changes. If the relevant function never reads a signal, the context runs once and can never react to anything, so it adds overhead without providing reactivity. This is usually a mistake: either the developer forgot to call a signal (e.g. wrote `firstName` instead of `firstName()`), or the value is actually static and should be a plain constant, a `signal()`, or an `afterNextRender()` in the case of `afterRenderEffect()`. To avoid false positives, the rule only reports when everything the tracked function does is known not to read a signal. Calls into the TypeScript standard library (arrays, strings, `Math`, `JSON`, `console`, DOM APIs, etc.) are known to be safe; anything else keeps the rule silent, including a helper function, a service method, a getter, an unresolved symbol, and any Angular API such as `untracked()`. One known limitation: a standard library call that reaches user code through a protocol method, such as `toJSON()` in `JSON.stringify()` or `toString()` in a template literal, is still treated as safe, so a signal read inside such a method is not detected. For `resource()`/`rxResource()` only the `params` function defines the dependencies, and these are opt-in via the `checkResources` option.',
 };

--- a/packages/eslint-plugin/tests/rules/reactive-context-must-read-signal/cases.ts
+++ b/packages/eslint-plugin/tests/rules/reactive-context-must-read-signal/cases.ts
@@ -88,6 +88,25 @@ export const valid: readonly (string | ValidTestCase<Options>)[] = [
       c = computed(() => this.items.map(this.transform));
     }
   `,
+    // Conservative: a standard library call that is handed an 'any' value might
+    // be given a function that reads a signal.
+    `
+    declare const transform: any;
+    class Test {
+      items = [1, 2, 3];
+      c = computed(() => this.items.map(transform));
+    }
+  `,
+    // Conservative: a union that includes a function value we cannot look
+    // inside might read a signal.
+    `
+    class Test {
+      items = [1, 2, 3];
+      transform: ((value: number) => number) | ((value: number) => string) =
+        (value) => value;
+      c = computed(() => this.items.map(this.transform));
+    }
+  `,
     // Conservative: a spread argument could expand to a function that reads a
     // signal, so a standard library call that receives one stays unknown.
     `
@@ -120,6 +139,33 @@ export const valid: readonly (string | ValidTestCase<Options>)[] = [
         return this.count() * 2;
       }
       c = computed(() => this.double);
+    }
+  `,
+    // Conservative: destructuring invokes a getter just like a member
+    // expression does.
+    `
+    class Test {
+      count = signal(0);
+      get double(): number {
+        return this.count() * 2;
+      }
+      c = computed(() => {
+        const { double } = this;
+        return double;
+      });
+    }
+  `,
+    // Conservative: a rest element copies every property, including getters.
+    `
+    class Test {
+      count = signal(0);
+      get double(): number {
+        return this.count() * 2;
+      }
+      c = computed(() => {
+        const { count, ...rest } = this;
+        return rest;
+      });
     }
   `,
     // computed() that reads the result of a nested computed.
@@ -240,6 +286,24 @@ const invalidBase: readonly InvalidTestCase<MessageIds, Options>[] = [
           name = 'x';
           c = computed(() => this.name);
               ~~~~~~~~~~~~~~~~~~~~~~~~~
+        }
+      `,
+    messageId,
+    data: { primitive: 'computed' },
+  }),
+  convertAnnotatedSourceToFailureCase<MessageIds, Options>({
+    description: 'computed() destructures only a plain property',
+    annotatedSource: `
+        class Test {
+          name = 'x';
+          c = computed(() => {
+              ~~~~~~~~~~~~~~~~
+            const { name } = this;
+            ~~~~~~~~~~~~~~~~~~~~~~
+            return name;
+            ~~~~~~~~~~~~
+          });
+          ~~
         }
       `,
     messageId,


### PR DESCRIPTION
## Summary

Improves the `reactive-context-must-read-signal` rule to more accurately detect when getters and functions are involved in reactive contexts, reducing false negatives while maintaining conservative behavior to avoid false positives.

## Key Changes

- **Enhanced function detection**: Updated `isFunction()` to handle `any` and `unknown` types conservatively, and check all constituents of union types for call signatures
- **Added getter detection**: Introduced new `isGetter()` helper function to identify getter properties on type constituents
- **Object pattern analysis**: Added `ObjectPattern` visitor to detect when destructuring accesses getters (e.g., `const { double } = this`) or uses rest elements that could copy getters
- **Documentation updates**: 
  - Added known limitation about standard library protocol methods (`toJSON()`, `toString()`) that can reach user code
  - Added test cases demonstrating conservative handling of `any` types, union types with functions, and destructuring patterns with getters

## Implementation Details

The rule now:
1. Treats `any` and `unknown` types as potentially containing functions that could read signals
2. Checks all union type constituents when determining if a value is callable
3. Detects getters accessed through destructuring patterns, which invoke arbitrary code just like member expressions
4. Maintains conservative behavior for spread elements and computed property keys in destructuring
5. Properly documents the limitation where callbacks passed to standard library methods (like `Array.map()`) cannot be analyzed for signal reads

https://claude.ai/code/session_01Jqg6y5ar7nAWZP9ymuu4WB