### PR TITLE
feat(eslint-plugin-template): [click-events-have-key-events] add requireKeyCode and allowedKeyCodes options

### DIFF
--- a/packages/eslint-plugin-template/docs/rules/click-events-have-key-events.md
+++ b/packages/eslint-plugin-template/docs/rules/click-events-have-key-events.md
@@ -37,6 +37,18 @@ interface Options {
    * Default: `[]`
    */
   ignoreWithDirectives?: string[];
+  /**
+   * Require key events to specify a key via a pseudo-event, e.g. `(keydown.enter)`. A bare `(keydown)` will not satisfy the rule.
+   *
+   * Default: `false`
+   */
+  requireKeyCode?: boolean;
+  /**
+   * Only key events whose key (the last segment of the pseudo-event, e.g. `enter` in `(keydown.shift.enter)`) is in this list satisfy the rule. Implies `requireKeyCode`.
+   *
+   * Default: `[]`
+   */
+  allowedKeyCodes?: string[];
 }
 
 ```
@@ -378,6 +390,132 @@ interface Options {
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 ```
 
+<br>
+
+---
+
+<br>
+
+#### Custom Config
+
+```json
+{
+  "rules": {
+    "@angular-eslint/template/click-events-have-key-events": [
+      "error",
+      {
+        "requireKeyCode": true
+      }
+    ]
+  }
+}
+```
+
+<br>
+
+#### ❌ Invalid Code
+
+```html
+<div (click)="onClick()" (keydown)="onKeydown()"></div>
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+```
+
+<br>
+
+---
+
+<br>
+
+#### Custom Config
+
+```json
+{
+  "rules": {
+    "@angular-eslint/template/click-events-have-key-events": [
+      "error",
+      {
+        "requireKeyCode": true
+      }
+    ]
+  }
+}
+```
+
+<br>
+
+#### ❌ Invalid Code
+
+```html
+<div (click)="onClick()"></div>
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+```
+
+<br>
+
+---
+
+<br>
+
+#### Custom Config
+
+```json
+{
+  "rules": {
+    "@angular-eslint/template/click-events-have-key-events": [
+      "error",
+      {
+        "allowedKeyCodes": [
+          "Enter",
+          "ArrowLeft",
+          "ArrowRight"
+        ]
+      }
+    ]
+  }
+}
+```
+
+<br>
+
+#### ❌ Invalid Code
+
+```html
+<div (click)="onClick()" (keydown.space)="onKeydown()"></div>
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+```
+
+<br>
+
+---
+
+<br>
+
+#### Custom Config
+
+```json
+{
+  "rules": {
+    "@angular-eslint/template/click-events-have-key-events": [
+      "error",
+      {
+        "allowedKeyCodes": [
+          "Enter"
+        ]
+      }
+    ]
+  }
+}
+```
+
+<br>
+
+#### ❌ Invalid Code
+
+```html
+<div (click)="onClick()" (keydown)="onKeydown()"></div>
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+```
+
 </details>
 
 <br>
@@ -618,6 +756,72 @@ interface Options {
 
 ```html
 <div [myDirective] (click)="onClick()"></div>
+```
+
+<br>
+
+---
+
+<br>
+
+#### Custom Config
+
+```json
+{
+  "rules": {
+    "@angular-eslint/template/click-events-have-key-events": [
+      "error",
+      {
+        "requireKeyCode": true
+      }
+    ]
+  }
+}
+```
+
+<br>
+
+#### ✅ Valid Code
+
+```html
+<div (click)="onClick()" (keydown.enter)="onKeydown()"></div>
+<div (click)="onClick()" (keyup.shift.space)="onKeyup()"></div>
+<div (click)="onClick()" (keydown)="onKeydown()" (keydown.enter)="onKeydown()"></div>
+```
+
+<br>
+
+---
+
+<br>
+
+#### Custom Config
+
+```json
+{
+  "rules": {
+    "@angular-eslint/template/click-events-have-key-events": [
+      "error",
+      {
+        "allowedKeyCodes": [
+          "Enter",
+          "ArrowLeft"
+        ]
+      }
+    ]
+  }
+}
+```
+
+<br>
+
+#### ✅ Valid Code
+
+```html
+<div (click)="onClick()" (keydown.enter)="onKeydown()"></div>
+<div (click)="onClick()" (keyup.Enter)="onKeyup()"></div>
+<div (click)="onClick()" (keydown.shift.arrowleft)="onKeydown()"></div>
+<div (click)="onClick()" (keydown.space)="onKeydown()" (keydown.enter)="onKeydown()"></div>
 ```
 
 </details>

--- a/packages/eslint-plugin-template/src/rules/click-events-have-key-events.ts
+++ b/packages/eslint-plugin-template/src/rules/click-events-have-key-events.ts
@@ -1,4 +1,7 @@
-import type { TmplAstElement } from '@angular-eslint/bundled-angular-compiler';
+import type {
+  TmplAstBoundEvent,
+  TmplAstElement,
+} from '@angular-eslint/bundled-angular-compiler';
 import { getTemplateParserServices } from '@angular-eslint/utils';
 import { createESLintRule } from '../utils/create-eslint-rule';
 import { getDomElements } from '../utils/get-dom-elements';
@@ -11,13 +14,22 @@ import { ARIARole } from 'aria-query';
 export type Options = [
   {
     readonly ignoreWithDirectives?: string[];
+    readonly requireKeyCode?: boolean;
+    readonly allowedKeyCodes?: string[];
   },
 ];
-export type MessageIds = 'clickEventsHaveKeyEvents';
+export type MessageIds =
+  | 'clickEventsHaveKeyEvents'
+  | 'clickEventsHaveKeyCode'
+  | 'clickEventsHaveAllowedKeyCode';
 export const RULE_NAME = 'click-events-have-key-events';
 const DEFAULT_OPTIONS: Options[number] = {
   ignoreWithDirectives: [],
+  requireKeyCode: false,
+  allowedKeyCodes: [],
 };
+
+const KEY_EVENTS = ['keyup', 'keydown', 'keypress'];
 
 export default createESLintRule<Options, MessageIds>({
   name: RULE_NAME,
@@ -38,6 +50,20 @@ export default createESLintRule<Options, MessageIds>({
             default: DEFAULT_OPTIONS.ignoreWithDirectives as
               string[] | undefined,
           },
+          requireKeyCode: {
+            type: 'boolean',
+            description:
+              'Require key events to specify a key via a pseudo-event, e.g. `(keydown.enter)`. A bare `(keydown)` will not satisfy the rule.',
+            default: DEFAULT_OPTIONS.requireKeyCode,
+          },
+          allowedKeyCodes: {
+            type: 'array',
+            items: { type: 'string' },
+            uniqueItems: true,
+            description:
+              'Only key events whose key (the last segment of the pseudo-event, e.g. `enter` in `(keydown.shift.enter)`) is in this list satisfy the rule. Implies `requireKeyCode`.',
+            default: DEFAULT_OPTIONS.allowedKeyCodes as string[] | undefined,
+          },
         },
         additionalProperties: false,
       },
@@ -45,10 +71,18 @@ export default createESLintRule<Options, MessageIds>({
     messages: {
       clickEventsHaveKeyEvents:
         'click must be accompanied by either keyup, keydown or keypress event for accessibility.',
+      clickEventsHaveKeyCode:
+        'click must be accompanied by a keyup, keydown or keypress event that specifies a key (e.g. `(keydown.enter)`) for accessibility.',
+      clickEventsHaveAllowedKeyCode:
+        'click must be accompanied by a keyup, keydown or keypress event for one of the allowed keys ({{allowedKeyCodes}}) for accessibility.',
     },
     defaultOptions: [DEFAULT_OPTIONS],
   },
-  create(context, [{ ignoreWithDirectives }]) {
+  create(context, [{ ignoreWithDirectives, requireKeyCode, allowedKeyCodes }]) {
+    const normalizedAllowedKeyCodes = (allowedKeyCodes ?? []).map((keyCode) =>
+      keyCode.toLowerCase(),
+    );
+
     return {
       Element(node: TmplAstElement) {
         if (!getDomElements().has(node.name.toLowerCase())) {
@@ -72,32 +106,78 @@ export default createESLintRule<Options, MessageIds>({
         }
 
         let hasClick = false,
-          hasKeyEvent = false;
+          hasKeyEvent = false,
+          hasSatisfyingKeyEvent = false;
 
         for (const output of node.outputs) {
           hasClick = hasClick || output.name === 'click';
-          hasKeyEvent =
-            hasKeyEvent ||
-            output.name.startsWith('keyup') ||
-            output.name.startsWith('keydown') ||
-            output.name.startsWith('keypress');
+
+          if (!isKeyEvent(output)) {
+            continue;
+          }
+          hasKeyEvent = true;
+
+          const keyCode = getKeyCode(output);
+          if (normalizedAllowedKeyCodes.length > 0) {
+            hasSatisfyingKeyEvent =
+              hasSatisfyingKeyEvent ||
+              (keyCode !== undefined &&
+                normalizedAllowedKeyCodes.includes(keyCode));
+          } else if (requireKeyCode) {
+            hasSatisfyingKeyEvent =
+              hasSatisfyingKeyEvent || keyCode !== undefined;
+          } else {
+            hasSatisfyingKeyEvent = true;
+          }
         }
 
-        if (!hasClick || hasKeyEvent) {
+        if (!hasClick || hasSatisfyingKeyEvent) {
           return;
         }
 
         const parserServices = getTemplateParserServices(context);
         const loc = parserServices.convertNodeSourceSpanToLoc(node.sourceSpan);
 
-        context.report({
-          loc,
-          messageId: 'clickEventsHaveKeyEvents',
-        });
+        if (!hasKeyEvent) {
+          context.report({
+            loc,
+            messageId: 'clickEventsHaveKeyEvents',
+          });
+        } else if (normalizedAllowedKeyCodes.length > 0) {
+          context.report({
+            loc,
+            messageId: 'clickEventsHaveAllowedKeyCode',
+            data: { allowedKeyCodes: normalizedAllowedKeyCodes.join(', ') },
+          });
+        } else {
+          context.report({
+            loc,
+            messageId: 'clickEventsHaveKeyCode',
+          });
+        }
       },
     };
   },
 });
+
+function isKeyEvent({ name }: TmplAstBoundEvent): boolean {
+  return KEY_EVENTS.some(
+    (keyEvent) => name === keyEvent || name.startsWith(`${keyEvent}.`),
+  );
+}
+
+/**
+ * Returns the key targeted by a key pseudo-event, e.g. `enter` for
+ * `(keydown.shift.enter)`, or `undefined` for a bare `(keydown)`.
+ */
+function getKeyCode({ name }: TmplAstBoundEvent): string | undefined {
+  const segments = name.split('.');
+  if (segments.length < 2) {
+    return undefined;
+  }
+  const keyCode = segments[segments.length - 1].toLowerCase();
+  return keyCode.length > 0 ? keyCode : undefined;
+}
 
 function isIgnored(
   ignoreWithDirectives: string[] | undefined,

--- a/packages/eslint-plugin-template/tests/rules/click-events-have-key-events/cases.ts
+++ b/packages/eslint-plugin-template/tests/rules/click-events-have-key-events/cases.ts
@@ -9,6 +9,8 @@ import type {
 } from '../../../src/rules/click-events-have-key-events';
 
 const messageId: MessageIds = 'clickEventsHaveKeyEvents';
+const keyCodeMessageId: MessageIds = 'clickEventsHaveKeyCode';
+const allowedKeyCodeMessageId: MessageIds = 'clickEventsHaveAllowedKeyCode';
 
 export const valid: readonly (string | ValidTestCase<Options>)[] = [
   {
@@ -67,6 +69,25 @@ export const valid: readonly (string | ValidTestCase<Options>)[] = [
   {
     code: `<div [myDirective] (click)="onClick()"></div>`,
     options: [{ ignoreWithDirectives: ['myDirective'] }],
+  },
+  {
+    // It should work when requireKeyCode is set and the key event specifies a key.
+    code: `
+        <div (click)="onClick()" (keydown.enter)="onKeydown()"></div>
+        <div (click)="onClick()" (keyup.shift.space)="onKeyup()"></div>
+        <div (click)="onClick()" (keydown)="onKeydown()" (keydown.enter)="onKeydown()"></div>
+      `,
+    options: [{ requireKeyCode: true }],
+  },
+  {
+    // It should work when allowedKeyCodes is set and the key event uses an allowed key.
+    code: `
+        <div (click)="onClick()" (keydown.enter)="onKeydown()"></div>
+        <div (click)="onClick()" (keyup.Enter)="onKeyup()"></div>
+        <div (click)="onClick()" (keydown.shift.arrowleft)="onKeydown()"></div>
+        <div (click)="onClick()" (keydown.space)="onKeydown()" (keydown.enter)="onKeydown()"></div>
+      `,
+    options: [{ allowedKeyCodes: ['Enter', 'ArrowLeft'] }],
   },
 ];
 
@@ -190,5 +211,47 @@ export const invalid: readonly InvalidTestCase<MessageIds, Options>[] = [
       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     `,
     options: [{ ignoreWithDirectives: ['testDirective', 'otherDirective'] }],
+  }),
+  convertAnnotatedSourceToFailureCase({
+    messageId: keyCodeMessageId,
+    description:
+      'should fail when requireKeyCode is set and the key event does not specify a key',
+    annotatedSource: `
+      <div (click)="onClick()" (keydown)="onKeydown()"></div>
+      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    `,
+    options: [{ requireKeyCode: true }],
+  }),
+  convertAnnotatedSourceToFailureCase({
+    messageId,
+    description:
+      'should fail with the default message when requireKeyCode is set and there is no key event at all',
+    annotatedSource: `
+      <div (click)="onClick()"></div>
+      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    `,
+    options: [{ requireKeyCode: true }],
+  }),
+  convertAnnotatedSourceToFailureCase({
+    messageId: allowedKeyCodeMessageId,
+    description:
+      'should fail when allowedKeyCodes is set and the key event uses a key that is not allowed',
+    annotatedSource: `
+      <div (click)="onClick()" (keydown.space)="onKeydown()"></div>
+      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    `,
+    options: [{ allowedKeyCodes: ['Enter', 'ArrowLeft', 'ArrowRight'] }],
+    data: { allowedKeyCodes: 'enter, arrowleft, arrowright' },
+  }),
+  convertAnnotatedSourceToFailureCase({
+    messageId: allowedKeyCodeMessageId,
+    description:
+      'should fail when allowedKeyCodes is set and the key event does not specify a key',
+    annotatedSource: `
+      <div (click)="onClick()" (keydown)="onKeydown()"></div>
+      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    `,
+    options: [{ allowedKeyCodes: ['Enter'] }],
+    data: { allowedKeyCodes: 'enter' },
   }),
 ];


### PR DESCRIPTION
Closes #1521

Adds two opt-in options to `click-events-have-key-events` so teams can be stricter about which keyboard handlers satisfy the rule:

- `requireKeyCode` (default `false`): a bare `(keydown)` / `(keyup)` / `(keypress)` no longer satisfies the rule. The handler must target a key via a pseudo-event, e.g. `(keydown.enter)`.
- `allowedKeyCodes` (default `[]`): only key events whose key is in the list satisfy the rule. The key is the last segment of the pseudo-event (so `(keydown.shift.enter)` matches `enter`) and matching is case-insensitive. Setting this implies `requireKeyCode`.

Two new message ids are reported for these cases so the error text explains what is actually missing, rather than the generic "must be accompanied by keyup, keydown or keypress". Behaviour with no options set is unchanged.

Rule docs regenerated. All `eslint-plugin-template` tests pass (1271).

---
_Generated by [Claude Code](https://claude.ai/code/session_017yVtH9pxrPj4inf3fyNYpf)_