### PR TITLE
feat(eslint-plugin-template): support regex entries in ignoreWithDirectives option

### DIFF
--- a/packages/eslint-plugin-template/docs/rules/button-has-type.md
+++ b/packages/eslint-plugin-template/docs/rules/button-has-type.md
@@ -34,6 +34,8 @@ The rule accepts an options object with the following properties:
 ```ts
 interface Options {
   /**
+   * Directive names that, when present on the element, cause it to be ignored. Entries wrapped in slashes, e.g. `/^tui/`, are treated as regular expressions.
+   *
    * Default: `[]`
    */
   ignoreWithDirectives?: string[];
@@ -187,6 +189,70 @@ interface Options {
 ```html
 <button myDirective></button>
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+```
+
+<br>
+
+---
+
+<br>
+
+#### Custom Config
+
+```json
+{
+  "rules": {
+    "@angular-eslint/template/button-has-type": [
+      "error",
+      {
+        "ignoreWithDirectives": [
+          "/^tui/"
+        ]
+      }
+    ]
+  }
+}
+```
+
+<br>
+
+#### ❌ Invalid Code
+
+```html
+<button myButton></button>
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+```
+
+<br>
+
+---
+
+<br>
+
+#### Custom Config
+
+```json
+{
+  "rules": {
+    "@angular-eslint/template/button-has-type": [
+      "error",
+      {
+        "ignoreWithDirectives": [
+          "tui"
+        ]
+      }
+    ]
+  }
+}
+```
+
+<br>
+
+#### ❌ Invalid Code
+
+```html
+<button tuiButton></button>
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
 ```
 
 <br>
@@ -548,6 +614,38 @@ interface Options {
 
 ```html
 <button [myButton]></button>
+```
+
+<br>
+
+---
+
+<br>
+
+#### Custom Config
+
+```json
+{
+  "rules": {
+    "@angular-eslint/template/button-has-type": [
+      "error",
+      {
+        "ignoreWithDirectives": [
+          "/^tui/"
+        ]
+      }
+    ]
+  }
+}
+```
+
+<br>
+
+#### ✅ Valid Code
+
+```html
+<button tuiButton></button>
+<button [tuiOption]="option"></button>
 ```
 
 </details>

--- a/packages/eslint-plugin-template/docs/rules/click-events-have-key-events.md
+++ b/packages/eslint-plugin-template/docs/rules/click-events-have-key-events.md
@@ -34,6 +34,8 @@ The rule accepts an options object with the following properties:
 ```ts
 interface Options {
   /**
+   * Directive names that, when present on the element, cause it to be ignored. Entries wrapped in slashes, e.g. `/^tui/`, are treated as regular expressions.
+   *
    * Default: `[]`
    */
   ignoreWithDirectives?: string[];
@@ -374,6 +376,38 @@ interface Options {
         "ignoreWithDirectives": [
           "testDirective",
           "otherDirective"
+        ]
+      }
+    ]
+  }
+}
+```
+
+<br>
+
+#### ❌ Invalid Code
+
+```html
+<div myDirective (click)="onClick()"></div>
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+```
+
+<br>
+
+---
+
+<br>
+
+#### Custom Config
+
+```json
+{
+  "rules": {
+    "@angular-eslint/template/click-events-have-key-events": [
+      "error",
+      {
+        "ignoreWithDirectives": [
+          "/^tui/"
         ]
       }
     ]
@@ -756,6 +790,37 @@ interface Options {
 
 ```html
 <div [myDirective] (click)="onClick()"></div>
+```
+
+<br>
+
+---
+
+<br>
+
+#### Custom Config
+
+```json
+{
+  "rules": {
+    "@angular-eslint/template/click-events-have-key-events": [
+      "error",
+      {
+        "ignoreWithDirectives": [
+          "/^tui/"
+        ]
+      }
+    ]
+  }
+}
+```
+
+<br>
+
+#### ✅ Valid Code
+
+```html
+<div tuiOption (click)="onClick()"></div>
 ```
 
 <br>

--- a/packages/eslint-plugin-template/src/rules/button-has-type.ts
+++ b/packages/eslint-plugin-template/src/rules/button-has-type.ts
@@ -8,6 +8,7 @@ import {
 } from '@angular-eslint/bundled-angular-compiler';
 import { getTemplateParserServices } from '@angular-eslint/utils';
 import { createESLintRule } from '../utils/create-eslint-rule';
+import { createIgnoredDirectiveMatcher } from '../utils/has-ignored-directive';
 
 export type Options = [
   {
@@ -45,6 +46,8 @@ export default createESLintRule<Options, MessageIds>({
             type: 'array',
             items: { type: 'string' },
             uniqueItems: true,
+            description:
+              'Directive names that, when present on the element, cause it to be ignored. Entries wrapped in slashes, e.g. `/^tui/`, are treated as regular expressions.',
             default: DEFAULT_OPTIONS.ignoreWithDirectives as
               string[] | undefined,
           },
@@ -60,11 +63,13 @@ export default createESLintRule<Options, MessageIds>({
   },
   create(context, [{ ignoreWithDirectives }]) {
     const parserServices = getTemplateParserServices(context);
+    const hasIgnoredDirective =
+      createIgnoredDirectiveMatcher(ignoreWithDirectives);
 
     return {
       [`Element[name=/^(button)$/i]`](element: TmplAstElement) {
         if (!isTypeAttributePresentInElement(element)) {
-          if (!isIgnored(ignoreWithDirectives, element)) {
+          if (!hasIgnoredDirective(element)) {
             context.report({
               loc: parserServices.convertNodeSourceSpanToLoc(
                 element.sourceSpan,
@@ -103,26 +108,6 @@ function isTypeAttributePresentInElement({
   return [...inputs, ...attributes].some(
     ({ name }) => name === TYPE_ATTRIBUTE_NAME,
   );
-}
-
-function isIgnored(
-  ignoreWithDirectives: string[] | undefined,
-  { inputs, attributes }: TmplAstElement,
-) {
-  if (ignoreWithDirectives && ignoreWithDirectives.length > 0) {
-    for (const input of inputs) {
-      if (ignoreWithDirectives.includes(input.name)) {
-        return true;
-      }
-    }
-    for (const attribute of attributes) {
-      if (ignoreWithDirectives.includes(attribute.name)) {
-        return true;
-      }
-    }
-  }
-
-  return false;
 }
 
 function getInvalidButtonTypeIfPresent(

--- a/packages/eslint-plugin-template/src/rules/click-events-have-key-events.ts
+++ b/packages/eslint-plugin-template/src/rules/click-events-have-key-events.ts
@@ -4,6 +4,7 @@ import type {
 } from '@angular-eslint/bundled-angular-compiler';
 import { getTemplateParserServices } from '@angular-eslint/utils';
 import { createESLintRule } from '../utils/create-eslint-rule';
+import { createIgnoredDirectiveMatcher } from '../utils/has-ignored-directive';
 import { getDomElements } from '../utils/get-dom-elements';
 import { isHiddenFromScreenReader } from '../utils/is-hidden-from-screen-reader';
 import { isInherentlyInteractiveElement } from '../utils/is-interactive-element';
@@ -47,6 +48,8 @@ export default createESLintRule<Options, MessageIds>({
             type: 'array',
             items: { type: 'string' },
             uniqueItems: true,
+            description:
+              'Directive names that, when present on the element, cause it to be ignored. Entries wrapped in slashes, e.g. `/^tui/`, are treated as regular expressions.',
             default: DEFAULT_OPTIONS.ignoreWithDirectives as
               string[] | undefined,
           },
@@ -82,6 +85,8 @@ export default createESLintRule<Options, MessageIds>({
     const normalizedAllowedKeyCodes = (allowedKeyCodes ?? []).map((keyCode) =>
       keyCode.toLowerCase(),
     );
+    const hasIgnoredDirective =
+      createIgnoredDirectiveMatcher(ignoreWithDirectives);
 
     return {
       Element(node: TmplAstElement) {
@@ -90,7 +95,7 @@ export default createESLintRule<Options, MessageIds>({
         }
 
         if (
-          isIgnored(ignoreWithDirectives, node) ||
+          hasIgnoredDirective(node) ||
           isPresentationRole(node) ||
           isHiddenFromScreenReader(node) ||
           isInherentlyInteractiveElement(node)
@@ -177,26 +182,6 @@ function getKeyCode({ name }: TmplAstBoundEvent): string | undefined {
   }
   const keyCode = segments[segments.length - 1].toLowerCase();
   return keyCode.length > 0 ? keyCode : undefined;
-}
-
-function isIgnored(
-  ignoreWithDirectives: string[] | undefined,
-  { inputs, attributes }: TmplAstElement,
-) {
-  if (ignoreWithDirectives && ignoreWithDirectives.length > 0) {
-    for (const input of inputs) {
-      if (ignoreWithDirectives.includes(input.name)) {
-        return true;
-      }
-    }
-    for (const attribute of attributes) {
-      if (ignoreWithDirectives.includes(attribute.name)) {
-        return true;
-      }
-    }
-  }
-
-  return false;
 }
 
 export const RULE_DOCS_EXTENSION = {

--- a/packages/eslint-plugin-template/src/utils/has-ignored-directive.ts
+++ b/packages/eslint-plugin-template/src/utils/has-ignored-directive.ts
@@ -1,0 +1,39 @@
+import type { TmplAstElement } from '@angular-eslint/bundled-angular-compiler';
+
+type DirectiveMatcher = (name: string) => boolean;
+
+const REGEX_LITERAL_PATTERN = /^\/(.+)\/([a-z]*)$/;
+
+/**
+ * Compiles an `ignoreWithDirectives` option into a predicate that reports
+ * whether an element carries one of the ignored directives.
+ *
+ * Entries wrapped in slashes, e.g. `/^tui/`, are treated as regular
+ * expressions (an optional flags suffix is supported, e.g. `/^tui/i`).
+ * All other entries are matched exactly against the directive name.
+ */
+export function createIgnoredDirectiveMatcher(
+  ignoreWithDirectives: readonly string[] | undefined,
+): (element: TmplAstElement) => boolean {
+  if (!ignoreWithDirectives || ignoreWithDirectives.length === 0) {
+    return () => false;
+  }
+
+  const matchers: readonly DirectiveMatcher[] = ignoreWithDirectives.map(
+    (entry) => {
+      const regexLiteral = REGEX_LITERAL_PATTERN.exec(entry);
+      if (regexLiteral) {
+        const pattern = new RegExp(regexLiteral[1], regexLiteral[2]);
+        return (name) => pattern.test(name);
+      }
+      return (name) => name === entry;
+    },
+  );
+
+  const isIgnoredName: DirectiveMatcher = (name) =>
+    matchers.some((matcher) => matcher(name));
+
+  return ({ inputs, attributes }) =>
+    inputs.some(({ name }) => isIgnoredName(name)) ||
+    attributes.some(({ name }) => isIgnoredName(name));
+}

--- a/packages/eslint-plugin-template/tests/rules/button-has-type/cases.ts
+++ b/packages/eslint-plugin-template/tests/rules/button-has-type/cases.ts
@@ -34,6 +34,14 @@ export const valid: readonly (string | ValidTestCase<Options>)[] = [
     code: `<button [myButton]></button>`,
     options: [{ ignoreWithDirectives: ['myButton'] }],
   },
+  {
+    // It should work when ignoreWithDirectives contains a regex that matches a directive.
+    code: `
+      <button tuiButton></button>
+      <button [tuiOption]="option"></button>
+    `,
+    options: [{ ignoreWithDirectives: ['/^tui/'] }],
+  },
 ];
 
 export const invalid: readonly InvalidTestCase<MessageIds, Options>[] = [
@@ -94,6 +102,26 @@ export const invalid: readonly InvalidTestCase<MessageIds, Options>[] = [
       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     `,
     options: [{ ignoreWithDirectives: ['myButton', 'uiButton'] }],
+    messageId: missingType,
+  }),
+  convertAnnotatedSourceToFailureCase({
+    description:
+      'should fail if a button has no type attribute, and ignoreWithDirectives option specifies a regex, but no directive matches it',
+    annotatedSource: `
+      <button myButton></button>
+      ~~~~~~~~~~~~~~~~~~~~~~~~~~
+    `,
+    options: [{ ignoreWithDirectives: ['/^tui/'] }],
+    messageId: missingType,
+  }),
+  convertAnnotatedSourceToFailureCase({
+    description:
+      'should treat entries that are not wrapped in slashes as exact names rather than patterns',
+    annotatedSource: `
+      <button tuiButton></button>
+      ~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    `,
+    options: [{ ignoreWithDirectives: ['tui'] }],
     messageId: missingType,
   }),
   convertAnnotatedSourceToFailureCase({

--- a/packages/eslint-plugin-template/tests/rules/click-events-have-key-events/cases.ts
+++ b/packages/eslint-plugin-template/tests/rules/click-events-have-key-events/cases.ts
@@ -71,6 +71,11 @@ export const valid: readonly (string | ValidTestCase<Options>)[] = [
     options: [{ ignoreWithDirectives: ['myDirective'] }],
   },
   {
+    // It should work when ignoreWithDirectives contains a regex that matches a directive.
+    code: `<div tuiOption (click)="onClick()"></div>`,
+    options: [{ ignoreWithDirectives: ['/^tui/'] }],
+  },
+  {
     // It should work when requireKeyCode is set and the key event specifies a key.
     code: `
         <div (click)="onClick()" (keydown.enter)="onKeydown()"></div>
@@ -211,6 +216,16 @@ export const invalid: readonly InvalidTestCase<MessageIds, Options>[] = [
       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     `,
     options: [{ ignoreWithDirectives: ['testDirective', 'otherDirective'] }],
+  }),
+  convertAnnotatedSourceToFailureCase({
+    messageId,
+    description:
+      'should fail if an element has no key events, and ignoreWithDirectives option specifies a regex, but no directive matches it',
+    annotatedSource: `
+      <div myDirective (click)="onClick()"></div>
+      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    `,
+    options: [{ ignoreWithDirectives: ['/^tui/'] }],
   }),
   convertAnnotatedSourceToFailureCase({
     messageId: keyCodeMessageId,


### PR DESCRIPTION
Closes #2620

The `ignoreWithDirectives` option of `button-has-type` and `click-events-have-key-events` now accepts regular expressions alongside exact directive names. An entry wrapped in slashes, e.g. `/^tui/` (an optional flags suffix such as `/^tui/i` is also supported), is compiled as a `RegExp` and tested against each input and attribute name on the element. Every other entry continues to be matched exactly, so existing configurations are unaffected.

```json
{
  "rules": {
    "@angular-eslint/template/button-has-type": [
      "error",
      { "ignoreWithDirectives": ["/^tui/"] }
    ]
  }
}
```

The previously duplicated `isIgnored` helper in both rules is replaced by a shared `createIgnoredDirectiveMatcher` util that compiles the option once at rule creation.

Rule docs regenerated. All `eslint-plugin-template` tests pass (1276).

---
_Generated by [Claude Code](https://claude.ai/code/session_017yVtH9pxrPj4inf3fyNYpf)_