### PR TITLE
fix(eslint-plugin-template): [prefer-self-closing-tags] ignore children of svg and math elements

### DIFF
--- a/packages/eslint-plugin-template/docs/rules/prefer-self-closing-tags.md
+++ b/packages/eslint-plugin-template/docs/rules/prefer-self-closing-tags.md
@@ -511,6 +511,62 @@ The rule does not have any configuration options.
 #### ✅ Valid Code
 
 ```html
+<svg>
+  <title></title>
+  <use href="#icon"></use>
+  <path d=""></path>
+</svg>
+```
+
+<br>
+
+---
+
+<br>
+
+#### Default Config
+
+```json
+{
+  "rules": {
+    "@angular-eslint/template/prefer-self-closing-tags": [
+      "error"
+    ]
+  }
+}
+```
+
+<br>
+
+#### ✅ Valid Code
+
+```html
+<math><mi></mi></math>
+```
+
+<br>
+
+---
+
+<br>
+
+#### Default Config
+
+```json
+{
+  "rules": {
+    "@angular-eslint/template/prefer-self-closing-tags": [
+      "error"
+    ]
+  }
+}
+```
+
+<br>
+
+#### ✅ Valid Code
+
+```html
 <div></div>
 ```
 

--- a/packages/eslint-plugin-template/src/rules/prefer-self-closing-tags.ts
+++ b/packages/eslint-plugin-template/src/rules/prefer-self-closing-tags.ts
@@ -44,7 +44,7 @@ export default createESLintRule<Options, MessageIds>({
           processContentNode(node);
         } else {
           // Ignore native elements.
-          if ('name' in node && getDomElements().has(node.name.toLowerCase())) {
+          if ('name' in node && isNativeElement(node.name)) {
             return;
           }
           processElementOrTemplateNode(node);
@@ -172,6 +172,19 @@ export default createESLintRule<Options, MessageIds>({
     }
   },
 });
+
+function isNativeElement(name: string): boolean {
+  const lowerCaseName = name.toLowerCase();
+  // The Angular compiler namespaces the children of `<svg>` and `<math>`
+  // (e.g. `:svg:use` and `:math:mi`). These are foreign elements that are
+  // native to the browser, and self-closing some of them (such as `<title />`)
+  // produces a template that Angular cannot parse.
+  return (
+    lowerCaseName.startsWith(':svg:') ||
+    lowerCaseName.startsWith(':math:') ||
+    getDomElements().has(lowerCaseName)
+  );
+}
 
 function isContentNode(
   node: TmplAstElement | TmplAstTemplate | TmplAstContent,

--- a/packages/eslint-plugin-template/tests/rules/prefer-self-closing-tags/cases.ts
+++ b/packages/eslint-plugin-template/tests/rules/prefer-self-closing-tags/cases.ts
@@ -24,6 +24,15 @@ export const valid: readonly (string | ValidTestCase<Options>)[] = [
   '<img src="foo" *ngIf="condition" />',
   // These elements cannot be self-closing
   '<slot></slot><math></math><rb></rb><svg></svg><template></template><selectedcontent></selectedcontent>',
+  // Children of svg and math are foreign (native) elements, which the Angular compiler namespaces
+  `
+    <svg>
+      <title></title>
+      <use href="#icon"></use>
+      <path d=""></path>
+    </svg>
+  `,
+  '<math><mi></mi></math>',
   '<div></div>',
   {
     code: '<DIV></DIV>',


### PR DESCRIPTION
## Summary

The `prefer-self-closing-tags` rule intends to skip native elements, but it did not skip the children of `<svg>` and `<math>`. The Angular compiler namespaces those children (e.g. `:svg:use`, `:math:mi`), and only the `:svg:svg` and `:math:math` roots are present in the shared DOM element list, so every empty child of an SVG or MathML block was reported and auto-fixed.

For some of those elements the autofix produced a template Angular cannot parse. For example, `<svg><title></title></svg>` was rewritten to `<svg><title /></svg>`, which fails with `Unexpected character "EOF"` and breaks the build. This is the breakage described in the comment on #3051.

## Changes

- Treat any element whose name carries the `:svg:` or `:math:` namespace prefix as native, alongside the existing DOM element lookup. The change is scoped to this rule so that the shared `getDomElements()` utility used by other rules is unaffected.
- Add regression cases for `<svg>` children (`title`, `use`, `path`) and `<math>` children (`mi`).
- Regenerate the rule docs from the updated test cases.

