### PR TITLE
fix(eslint-plugin-template): [eqeqeq] honor allowNullOrUndefined across compiler copies

### DIFF
--- a/packages/eslint-plugin-template/docs/rules/eqeqeq.md
+++ b/packages/eslint-plugin-template/docs/rules/eqeqeq.md
@@ -525,6 +525,96 @@ interface Options {
 <div *appShow="(d == null && e === null && (f | lowercase) == undefined) || g === undefined">
 ```
 
+<br>
+
+---
+
+<br>
+
+#### Custom Config
+
+```json
+{
+  "rules": {
+    "@angular-eslint/template/eqeqeq": [
+      "error",
+      {
+        "allowNullOrUndefined": true
+      }
+    ]
+  }
+}
+```
+
+<br>
+
+#### ✅ Valid Code
+
+```html
+@let value = someSignal();
+@if (value != null) {
+  <span>{{ value }}</span>
+}
+```
+
+<br>
+
+---
+
+<br>
+
+#### Custom Config
+
+```json
+{
+  "rules": {
+    "@angular-eslint/template/eqeqeq": [
+      "error",
+      {
+        "allowNullOrUndefined": true
+      }
+    ]
+  }
+}
+```
+
+<br>
+
+#### ✅ Valid Code
+
+```html
+{{ value == undefined }}
+```
+
+<br>
+
+---
+
+<br>
+
+#### Custom Config
+
+```json
+{
+  "rules": {
+    "@angular-eslint/template/eqeqeq": [
+      "error",
+      {
+        "allowNullOrUndefined": true
+      }
+    ]
+  }
+}
+```
+
+<br>
+
+#### ✅ Valid Code
+
+```html
+<ng-container *ngIf="title != null">title is not null</ng-container>
+```
+
 </details>
 
 <br>

--- a/packages/eslint-plugin-template/src/utils/literal-primitive.ts
+++ b/packages/eslint-plugin-template/src/utils/literal-primitive.ts
@@ -6,7 +6,14 @@ import {
 export type Quote = "'" | '"' | '`';
 
 export function isLiteralPrimitive(node: AST): node is LiteralPrimitive {
-  return node instanceof LiteralPrimitive;
+  // The template parser stamps `type` from `constructor.name`. `instanceof`
+  // fails when more than one copy of `@angular-eslint/bundled-angular-compiler`
+  // is installed (version mismatches, Yarn `hoistingLimits`, etc.).
+  return (
+    !!node &&
+    ((node as { type?: string }).type === 'LiteralPrimitive' ||
+      node instanceof LiteralPrimitive)
+  );
 }
 
 export function isStringLiteralPrimitive(

--- a/packages/eslint-plugin-template/tests/rules/eqeqeq/cases.ts
+++ b/packages/eslint-plugin-template/tests/rules/eqeqeq/cases.ts
@@ -18,6 +18,29 @@ export const valid: readonly (string | ValidTestCase<Options>)[] = [
       `,
     options: [{ allowNullOrUndefined: true }],
   },
+  {
+    // https://github.com/angular-eslint/angular-eslint/issues/3070
+    code: `
+        @let value = someSignal();
+        @if (value != null) {
+          <span>{{ value }}</span>
+        }
+      `,
+    options: [{ allowNullOrUndefined: true }],
+  },
+  {
+    code: `
+        {{ value == undefined }}
+      `,
+    options: [{ allowNullOrUndefined: true }],
+  },
+  {
+    // https://github.com/angular-eslint/angular-eslint/issues/1542
+    code: `
+        <ng-container *ngIf="title != null">title is not null</ng-container>
+      `,
+    options: [{ allowNullOrUndefined: true }],
+  },
 ];
 
 export const invalid: readonly InvalidTestCase<MessageIds, Options>[] = [

--- a/packages/eslint-plugin-template/tests/utils/literal-primitive.spec.ts
+++ b/packages/eslint-plugin-template/tests/utils/literal-primitive.spec.ts
@@ -1,0 +1,37 @@
+import {
+  AbsoluteSourceSpan,
+  LiteralPrimitive,
+  ParseSpan,
+} from '@angular-eslint/bundled-angular-compiler';
+import { describe, expect, it } from 'vitest';
+import { isLiteralPrimitive } from '../../src/utils/literal-primitive';
+
+describe('isLiteralPrimitive', () => {
+  it('matches real compiler LiteralPrimitive instances', () => {
+    const node = new LiteralPrimitive(
+      new ParseSpan(0, 4),
+      new AbsoluteSourceSpan(0, 4),
+      null,
+    );
+
+    expect(node instanceof LiteralPrimitive).toBe(true);
+    expect(isLiteralPrimitive(node)).toBe(true);
+  });
+
+  it('matches parser-stamped nodes from a different compiler copy', () => {
+    const node = {
+      type: 'LiteralPrimitive',
+      value: null,
+    };
+
+    expect(node instanceof LiteralPrimitive).toBe(false);
+    expect(isLiteralPrimitive(node as never)).toBe(true);
+  });
+
+  it('does not match other AST node types', () => {
+    expect(
+      isLiteralPrimitive({ type: 'PropertyRead', value: null } as never),
+    ).toBe(false);
+    expect(isLiteralPrimitive({ type: 'Binary' } as never)).toBe(false);
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`@angular-eslint/template/eqeqeq` ignored `allowNullOrUndefined: true` whenever more than one copy of `@angular-eslint/bundled-angular-compiler` was installed. ESLint still applied the option (`--print-config` was correct), but the skip path used `instanceof LiteralPrimitive`. Duplicate compiler copies each export their own class, so that check failed and `!= null` / `== null` / `== undefined` were still reported.

This showed up as:

- https://github.com/angular-eslint/angular-eslint/issues/3070 — `angular-eslint@22` with a pinned older `@angular-eslint/bundled-angular-compiler`
- https://github.com/angular-eslint/angular-eslint/issues/1542 — Yarn `hoistingLimits: "dependencies"` nesting a second compiler copy

`isLiteralPrimitive()` now also accepts nodes whose parser-stamped `type` is `'LiteralPrimitive'`, which is what the template parser already sets from `constructor.name`. The option then works even when `instanceof` does not.

Aligning `@angular-eslint/*` package versions is still the right consumer workaround, but it is no longer required for this option to function.

## Test plan

- [x] Unit tests for `isLiteralPrimitive` covering a real compiler instance and a duck-typed `{ type: 'LiteralPrimitive' }` node that is not `instanceof` this package's class
- [x] `eqeqeq` valid cases for the issue templates (`@if (value != null)`, `*ngIf="title != null"`, `== undefined`)
- [x] `pnpm nx test eslint-plugin-template tests/rules/eqeqeq/spec.ts`
- [x] `pnpm nx test eslint-plugin-template tests/utils/literal-primitive.spec.ts`
- [x] Required checks: format, nx sync, rule docs/lists/configs
- [x] Confirmed the original npm reproduction by patching `isNilValue` to use `type` (same check this PR now uses in `isLiteralPrimitive`)

Closes #3070
Closes #1542

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-42dff9ca-b7e9-4cad-a72e-81824bb4848e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-42dff9ca-b7e9-4cad-a72e-81824bb4848e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

