### PR TITLE
fix(schematics): declare peer dependencies required by nested plugins

### DIFF
--- a/packages/schematics/package.json
+++ b/packages/schematics/package.json
@@ -50,5 +50,12 @@
     "@typescript-eslint/utils": "catalog:typescript-eslint",
     "eslint": "catalog:"
   },
+  "peerDependencies": {
+    "@angular-eslint/template-parser": "workspace:*",
+    "@typescript-eslint/types": "^8.0.0",
+    "@typescript-eslint/utils": "^8.0.0",
+    "eslint": "^9.0.0 || ^10.0.0",
+    "typescript": "*"
+  },
   "gitHead": "e2006e5e9c99e5a943d1a999e0efa5247d29ec24"
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Yarn Berry (`yarn explain peer-requirements`) reports unmet peer requirements when `angular-eslint` is installed, because `@angular-eslint/schematics` depends on `@angular-eslint/eslint-plugin` and `@angular-eslint/eslint-plugin-template` without providing the peers those plugins request.

This was reproduced with **Yarn 4.18.0** and **angular-eslint 22.3.0**:

```
✘ @angular-eslint/schematics doesn't provide @angular-eslint/template-parser to @angular-eslint/eslint-plugin-template
✘ @angular-eslint/schematics doesn't provide @typescript-eslint/types to @angular-eslint/eslint-plugin-template
✘ @angular-eslint/schematics doesn't provide @typescript-eslint/utils to @angular-eslint/eslint-plugin-template
✘ @angular-eslint/schematics doesn't provide eslint to @angular-eslint/eslint-plugin-template
✘ @angular-eslint/schematics doesn't provide typescript to @angular-eslint/eslint-plugin-template
```

Declaring those packages as `peerDependencies` of `@angular-eslint/schematics` lets Yarn resolve them from `angular-eslint` and the consuming project. After this change, the five failed peer requirements above no longer appear.

Fixes #2588

## Test plan

- [x] Reproduce the original `yarn explain peer-requirements` failures with Yarn 4.18.0 + `angular-eslint@22.3.0`
- [x] Confirm the same peers, applied via Yarn `packageExtensions`, clear every `✘` for `@angular-eslint/schematics`
- [ ] Run schematics unit tests
- [ ] Run required workspace checks (`format-check`, `nx sync:check`)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bf7ecabe-994c-4c57-a08f-5c03388a2695?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bf7ecabe-994c-4c57-a08f-5c03388a2695&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

