### PR TITLE
fix(eslint-plugin-template): [prefer-self-closing-tags] ignore all index.html files

### DIFF
--- a/packages/eslint-plugin-template/docs/rules/prefer-self-closing-tags.md
+++ b/packages/eslint-plugin-template/docs/rules/prefer-self-closing-tags.md
@@ -990,6 +990,34 @@ The rule does not have any configuration options.
 
 #### ✅ Valid Code
 
+**Filename: sub_projects/acme/index.html**
+
+```html
+<acme-root></acme-root>
+```
+
+<br>
+
+---
+
+<br>
+
+#### Default Config
+
+```json
+{
+  "rules": {
+    "@angular-eslint/template/prefer-self-closing-tags": [
+      "error"
+    ]
+  }
+}
+```
+
+<br>
+
+#### ✅ Valid Code
+
 ```html
 <ng-container>&nbsp;</ng-container>
 ```

--- a/packages/eslint-plugin-template/src/rules/prefer-self-closing-tags.ts
+++ b/packages/eslint-plugin-template/src/rules/prefer-self-closing-tags.ts
@@ -31,9 +31,11 @@ export default createESLintRule<Options, MessageIds>({
   create(context) {
     const parserServices = getTemplateParserServices(context);
 
-    // angular 18 doesn't support self closing tags in index.html
-    if (/src[\\/]index\.html$/.test(context.physicalFilename)) {
-      // If it is, return an empty object to skip this rule
+    // An index.html file is served to the browser as-is rather than being
+    // compiled as an Angular template, and browsers do not support
+    // self-closing tags for custom elements, so skip the rule for any
+    // file with that name regardless of where it lives.
+    if (/(^|[\\/])index\.html$/.test(context.physicalFilename)) {
       return {};
     }
     return {

--- a/packages/eslint-plugin-template/tests/rules/prefer-self-closing-tags/cases.ts
+++ b/packages/eslint-plugin-template/tests/rules/prefer-self-closing-tags/cases.ts
@@ -67,6 +67,17 @@ export const valid: readonly (string | ValidTestCase<Options>)[] = [
   `<ng-content select="[slot='foo>bar']" />`,
   `<ng-content select="[slot='foo>bar']">Fallback</ng-content>`,
   { code: '<app-root></app-root>', filename: 'src/index.html' },
+  {
+    code: '<acme-root></acme-root>',
+    filename: 'sub_projects/acme/index.html',
+  },
+  {
+    code: '<app-root></app-root>',
+    filename: 'C:\\projects\\acme\\index.html',
+    settings: {
+      hideFromDocs: true,
+    },
+  },
   '<ng-container>&nbsp;</ng-container>',
   '<my-component>  <!-- not empty -->  </my-component>',
 ];


### PR DESCRIPTION
## Summary

Closes #3051

`prefer-self-closing-tags` already skipped `src/index.html`, because an `index.html` is served to the browser as-is rather than compiled as an Angular template, and browsers do not honour self-closing syntax on custom elements. The `src/` prefix was too narrow: workspaces with sub-projects or non-standard layouts (for example `sub_projects/foo/index.html`) had their bootstrap element rewritten to `<app-root />`, which breaks the app at runtime.

## Changes

- Skip the rule for any file named `index.html`, regardless of the directory it lives in (both `/` and `\` separators are handled).
- Add valid cases for a nested `index.html` outside `src/` and for a Windows-style path.
- Regenerate the rule docs from the updated test cases.

## Why not an `ignore` option

The issue asked for a per-tag ignore list, with `app-root` as the example. The root selector is user-configurable via the CLI `prefix`, so a tag-based exception does not generalise, and inside an `index.html` no custom element should be self-closed anyway. Broadening the filename check addresses the actual cause. The separate SVG breakage mentioned in the comments was fixed in #3181.

## Risk

A component template deliberately named `index.html` would no longer be checked by this rule. That is rare, and the rule is stylistic, so a missed report there has no runtime consequence.
