### PR TITLE
fix(eslint-plugin-template): [no-nested-tags] treat ng-template as a nesting boundary

### DIFF
--- a/packages/eslint-plugin-template/docs/rules/no-nested-tags.md
+++ b/packages/eslint-plugin-template/docs/rules/no-nested-tags.md
@@ -23,7 +23,7 @@ Denies nesting of `<p>` and `<a>` tags.
 
 ## Rationale
 
-Nesting `<p>` tags inside other `<p>` tags, or `<a>` tags inside other `<a>` tags, is invalid HTML and causes serious issues with Angular hydration. All browsers automatically close the outer tag when they encounter the inner tag, transforming `<p>1<p>2</p>3</p>` into `<p>1</p><p>2</p>3` in the DOM. This creates a mismatch between the server-rendered HTML and what Angular expects during hydration, breaking incremental hydration and potentially causing runtime errors. The browser's automatic correction of invalid HTML happens before Angular processes the template, so Angular cannot fix or work around it. Always use different elements (like `<p>` and `<span>`, or nested `<div>` tags) or restructure your template to avoid nesting these specific tags.
+Nesting `<p>` tags inside other `<p>` tags, or `<a>` tags inside other `<a>` tags, is invalid HTML and causes serious issues with Angular hydration. All browsers automatically close the outer tag when they encounter the inner tag, transforming `<p>1<p>2</p>3</p>` into `<p>1</p><p>2</p>3` in the DOM. This creates a mismatch between the server-rendered HTML and what Angular expects during hydration, breaking incremental hydration and potentially causing runtime errors. The browser's automatic correction of invalid HTML happens before Angular processes the template, so Angular cannot fix or work around it. Always use different elements (like `<p>` and `<span>`, or nested `<div>` tags) or restructure your template to avoid nesting these specific tags. Explicit `<ng-template>` elements are an exception because they are not rendered in-place; tags inside them are not nested in the parent element's DOM.
 
 <br>
 
@@ -90,6 +90,60 @@ The rule does not have any configuration options.
 ```html
 <p>@if(true) {<p></p>}</p>
               ~~~~~~~
+```
+
+<br>
+
+---
+
+<br>
+
+#### Default Config
+
+```json
+{
+  "rules": {
+    "@angular-eslint/template/no-nested-tags": [
+      "error"
+    ]
+  }
+}
+```
+
+<br>
+
+#### ❌ Invalid Code
+
+```html
+<a><a *ngFor="let item of items"></a></a>
+   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+```
+
+<br>
+
+---
+
+<br>
+
+#### Default Config
+
+```json
+{
+  "rules": {
+    "@angular-eslint/template/no-nested-tags": [
+      "error"
+    ]
+  }
+}
+```
+
+<br>
+
+#### ❌ Invalid Code
+
+```html
+<p><ng-container><p></p></ng-container></p>
+                 ~~~~~~~
 ```
 
 <br>
@@ -230,6 +284,37 @@ The rule does not have any configuration options.
 
 ```html
 <p></p><p></p>
+```
+
+<br>
+
+---
+
+<br>
+
+#### Default Config
+
+```json
+{
+  "rules": {
+    "@angular-eslint/template/no-nested-tags": [
+      "error"
+    ]
+  }
+}
+```
+
+<br>
+
+#### ✅ Valid Code
+
+```html
+<p>
+  Text
+  <ng-template #content>
+    <p>Text</p>
+  </ng-template>
+</p>
 ```
 
 </details>

--- a/packages/eslint-plugin-template/src/rules/no-nested-tags.ts
+++ b/packages/eslint-plugin-template/src/rules/no-nested-tags.ts
@@ -9,11 +9,9 @@ export type Options = [];
 export type MessageIds = 'noNestedTags';
 export const RULE_NAME = 'no-nested-tags';
 
-type NodeWithParent = {
-  parent?: NodeWithParent;
+type TmplAstElementWithAncestor = TmplAstElement & {
+  parent?: TmplAstElementWithAncestor;
 };
-
-type TmplAstElementWithAncestor = TmplAstElement & NodeWithParent;
 
 export default createESLintRule<Options, MessageIds>({
   name: RULE_NAME,
@@ -55,7 +53,7 @@ export default createESLintRule<Options, MessageIds>({
 });
 
 function hasAncestorOfSameType(node: TmplAstElementWithAncestor) {
-  let parent: NodeWithParent | undefined = node.parent;
+  let parent = node.parent;
 
   while (parent) {
     // Explicit <ng-template> is not rendered in-place, so tags inside it
@@ -78,7 +76,7 @@ function hasAncestorOfSameType(node: TmplAstElementWithAncestor) {
   return false;
 }
 
-function isExplicitNgTemplate(node: NodeWithParent): node is TmplAstTemplate {
+function isExplicitNgTemplate(node: unknown): boolean {
   return (
     node instanceof TmplAstTemplate &&
     typeof node.tagName === 'string' &&

--- a/packages/eslint-plugin-template/src/rules/no-nested-tags.ts
+++ b/packages/eslint-plugin-template/src/rules/no-nested-tags.ts
@@ -1,4 +1,7 @@
-import { TmplAstElement } from '@angular-eslint/bundled-angular-compiler';
+import {
+  TmplAstElement,
+  TmplAstTemplate,
+} from '@angular-eslint/bundled-angular-compiler';
 import { getTemplateParserServices } from '@angular-eslint/utils';
 import { createESLintRule } from '../utils/create-eslint-rule';
 
@@ -6,9 +9,11 @@ export type Options = [];
 export type MessageIds = 'noNestedTags';
 export const RULE_NAME = 'no-nested-tags';
 
-type TmplAstElementWithAncestor = TmplAstElement & {
-  parent?: TmplAstElementWithAncestor;
+type NodeWithParent = {
+  parent?: NodeWithParent;
 };
+
+type TmplAstElementWithAncestor = TmplAstElement & NodeWithParent;
 
 export default createESLintRule<Options, MessageIds>({
   name: RULE_NAME,
@@ -50,9 +55,16 @@ export default createESLintRule<Options, MessageIds>({
 });
 
 function hasAncestorOfSameType(node: TmplAstElementWithAncestor) {
-  let parent = node.parent;
+  let parent: NodeWithParent | undefined = node.parent;
 
   while (parent) {
+    // Explicit <ng-template> is not rendered in-place, so tags inside it
+    // are not nested in the parent element's DOM. Structural directives
+    // like *ngFor compile to implicit templates and must still be reported.
+    if (isExplicitNgTemplate(parent)) {
+      return false;
+    }
+
     if (
       parent instanceof TmplAstElement &&
       parent.name.toLowerCase() === node.name.toLowerCase()
@@ -66,7 +78,15 @@ function hasAncestorOfSameType(node: TmplAstElementWithAncestor) {
   return false;
 }
 
+function isExplicitNgTemplate(node: NodeWithParent): node is TmplAstTemplate {
+  return (
+    node instanceof TmplAstTemplate &&
+    typeof node.tagName === 'string' &&
+    /^(:svg:)?ng-template$/i.test(node.tagName)
+  );
+}
+
 export const RULE_DOCS_EXTENSION = {
   rationale:
-    "Nesting `<p>` tags inside other `<p>` tags, or `<a>` tags inside other `<a>` tags, is invalid HTML and causes serious issues with Angular hydration. All browsers automatically close the outer tag when they encounter the inner tag, transforming `<p>1<p>2</p>3</p>` into `<p>1</p><p>2</p>3` in the DOM. This creates a mismatch between the server-rendered HTML and what Angular expects during hydration, breaking incremental hydration and potentially causing runtime errors. The browser's automatic correction of invalid HTML happens before Angular processes the template, so Angular cannot fix or work around it. Always use different elements (like `<p>` and `<span>`, or nested `<div>` tags) or restructure your template to avoid nesting these specific tags.",
+    "Nesting `<p>` tags inside other `<p>` tags, or `<a>` tags inside other `<a>` tags, is invalid HTML and causes serious issues with Angular hydration. All browsers automatically close the outer tag when they encounter the inner tag, transforming `<p>1<p>2</p>3</p>` into `<p>1</p><p>2</p>3` in the DOM. This creates a mismatch between the server-rendered HTML and what Angular expects during hydration, breaking incremental hydration and potentially causing runtime errors. The browser's automatic correction of invalid HTML happens before Angular processes the template, so Angular cannot fix or work around it. Always use different elements (like `<p>` and `<span>`, or nested `<div>` tags) or restructure your template to avoid nesting these specific tags. Explicit `<ng-template>` elements are an exception because they are not rendered in-place; tags inside them are not nested in the parent element's DOM.",
 };

--- a/packages/eslint-plugin-template/tests/rules/no-nested-tags/cases.ts
+++ b/packages/eslint-plugin-template/tests/rules/no-nested-tags/cases.ts
@@ -18,6 +18,22 @@ export const valid: readonly (string | ValidTestCase<Options>)[] = [
   },
   '<p></p>',
   '<p></p><p></p>',
+  // Explicit <ng-template> is not rendered in the parent DOM, so nested
+  // <p>/<a> tags inside it are not actually nested for hydration purposes.
+  `
+    <p>
+      Text
+      <ng-template #content>
+        <p>Text</p>
+      </ng-template>
+    </p>
+  `,
+  {
+    code: '<a><ng-template><a></a></ng-template></a>',
+    settings: {
+      hideFromDocs: true,
+    },
+  },
 ];
 
 export const invalid: readonly InvalidTestCase<MessageIds, Options>[] = [
@@ -48,6 +64,24 @@ export const invalid: readonly InvalidTestCase<MessageIds, Options>[] = [
     annotatedSource: `
         <p>@if(true) {<p></p>}</p>
                       ~~~~~~~
+      `,
+    data: { tag: 'p' },
+  }),
+  convertAnnotatedSourceToFailureCase({
+    messageId,
+    description: 'should fail on nested tag with a structural directive',
+    annotatedSource: `
+        <a><a *ngFor="let item of items"></a></a>
+           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      `,
+    data: { tag: 'a' },
+  }),
+  convertAnnotatedSourceToFailureCase({
+    messageId,
+    description: 'should fail on nested p tag inside ng-container',
+    annotatedSource: `
+        <p><ng-container><p></p></ng-container></p>
+                         ~~~~~~~
       `,
     data: { tag: 'p' },
   }),


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes #3075, a false positive in `@angular-eslint/template/no-nested-tags`.

The rule walked all ancestors looking for another `<p>` or `<a>`. That incorrectly flagged tags that only appear nested in the AST because they live inside an explicit `<ng-template>`. `ng-template` is not rendered in-place, so this is not the hydration DOM mismatch the rule exists to catch:

```html
<p>
  Text
  <ng-template #content>
    <p>Text</p>
  </ng-template>
</p>
```

## Approach

Stop walking ancestors when an explicit `<ng-template>` (including `:svg:ng-template`) is reached. Implicit templates from structural directives such as `*ngFor` still report, as do transparent wrappers like `ng-container` and control-flow blocks (`@if`).

## Reproduction

On current `main`, the issue example fails `no-nested-tags`. After this change it is valid; `*ngFor` nesting and `ng-container` nesting remain invalid.

## Test plan

- [x] Reproduced the #3075 false positive against current `main`
- [x] `pnpm nx test eslint-plugin-template tests/rules/no-nested-tags/spec.ts`
- [x] `pnpm format-check`
- [x] `pnpm nx sync:check`
- [x] `pnpm nx run-many -t check-rule-docs`
- [x] `pnpm nx run-many -t check-rule-lists`
- [x] `pnpm nx run-many -t check-rule-configs`
- [x] `pnpm nx run eslint-plugin-template:lint`
- [x] `pnpm nx run eslint-plugin-template:typecheck`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a914c71b-4111-4c37-907d-fb922dfc387c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a914c71b-4111-4c37-907d-fb922dfc387c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

