### PR TITLE
fix(eslint-plugin-template): [prefer-at-else] avoid unsafe content projection fixes

### DIFF
--- a/packages/eslint-plugin-template/docs/rules/prefer-at-else.md
+++ b/packages/eslint-plugin-template/docs/rules/prefer-at-else.md
@@ -726,6 +726,113 @@ The rule does not have any configuration options.
 #### ❌ Invalid Code
 
 ```html
+<my-component>
+  @if (a) {
+    <button>1</button>
+  } @else {
+    <button>2</button>
+  }
+  @if (!a) {
+  ~~~~
+    <button>3</button>
+  }
+</my-component>
+```
+
+<br>
+
+---
+
+<br>
+
+#### Default Config
+
+```json
+{
+  "rules": {
+    "@angular-eslint/template/prefer-at-else": [
+      "error"
+    ]
+  }
+}
+```
+
+<br>
+
+#### ❌ Invalid Code
+
+```html
+<my-component>
+  @if (a) {
+    <button>1</button>
+  }
+  @if (!a) {
+  ~~~~
+    <button>2</button>
+  } @else {
+    <button>3</button>
+  }
+</my-component>
+```
+
+<br>
+
+---
+
+<br>
+
+#### Default Config
+
+```json
+{
+  "rules": {
+    "@angular-eslint/template/prefer-at-else": [
+      "error"
+    ]
+  }
+}
+```
+
+<br>
+
+#### ❌ Invalid Code
+
+```html
+@if (a) {
+  <button>1</button>
+}
+@if (!a) {
+~~~~
+  <button>2</button>
+}
+@if (!a) {
+  <button>3</button>
+}
+```
+
+<br>
+
+---
+
+<br>
+
+#### Default Config
+
+```json
+{
+  "rules": {
+    "@angular-eslint/template/prefer-at-else": [
+      "error"
+    ]
+  }
+}
+```
+
+<br>
+
+#### ❌ Invalid Code
+
+```html
 @if (a) {}
 
 @if (!a) {}

--- a/packages/eslint-plugin-template/src/rules/prefer-at-else.ts
+++ b/packages/eslint-plugin-template/src/rules/prefer-at-else.ts
@@ -6,6 +6,7 @@ import {
   PrefixNot,
   TmplAstElement,
   TmplAstIfBlock,
+  TmplAstNode,
   TmplAstTemplate,
   TmplAstText,
 } from '@angular-eslint/bundled-angular-compiler';
@@ -52,7 +53,7 @@ export default createESLintRule<Options, MessageIds>({
     const parserServices = getTemplateParserServices(context);
     const previousNodeStack: (IfNodeInfo | undefined)[] = [undefined];
 
-    function wouldPreventContentProjection(nodes: Node[]): boolean {
+    function wouldPreventContentProjection(nodes: TmplAstNode[]): boolean {
       let rootNodeCount = 0;
       let hasProjectableNode = false;
 

--- a/packages/eslint-plugin-template/src/rules/prefer-at-else.ts
+++ b/packages/eslint-plugin-template/src/rules/prefer-at-else.ts
@@ -4,7 +4,10 @@ import {
   Binary,
   Node,
   PrefixNot,
+  TmplAstElement,
   TmplAstIfBlock,
+  TmplAstTemplate,
+  TmplAstText,
 } from '@angular-eslint/bundled-angular-compiler';
 import { getTemplateParserServices } from '@angular-eslint/utils';
 import { createESLintRule } from '../utils/create-eslint-rule';
@@ -49,6 +52,28 @@ export default createESLintRule<Options, MessageIds>({
     const parserServices = getTemplateParserServices(context);
     const previousNodeStack: (IfNodeInfo | undefined)[] = [undefined];
 
+    function wouldPreventContentProjection(nodes: Node[]): boolean {
+      let rootNodeCount = 0;
+      let hasProjectableNode = false;
+
+      for (const node of nodes) {
+        if (
+          node instanceof TmplAstText &&
+          context.sourceCode.text
+            .slice(node.sourceSpan.start.offset, node.sourceSpan.end.offset)
+            .trim() === ''
+        ) {
+          continue;
+        }
+
+        rootNodeCount++;
+        hasProjectableNode ||=
+          node instanceof TmplAstElement || node instanceof TmplAstTemplate;
+      }
+
+      return rootNodeCount > 1 && hasProjectableNode;
+    }
+
     function getFix(
       previous: IfNodeInfo,
       current: IfNodeInfo,
@@ -62,6 +87,25 @@ export default createESLintRule<Options, MessageIds>({
       // we won't fix it because the alias won't exist
       // in the `@else` block of the previous `@if` block.
       if (currentIf.expressionAlias) {
+        return null;
+      }
+
+      // Angular's content projection through control flow only works reliably
+      // when a branch has a single root node. If fixing this violation would
+      // merge multiple roots into an existing branch, keep reporting the
+      // violation but do not offer an unsafe automatic fix.
+      if (
+        (previousElse &&
+          wouldPreventContentProjection([
+            ...previousElse.children,
+            ...currentIf.children,
+          ])) ||
+        (currentElse &&
+          wouldPreventContentProjection([
+            ...previousIf.children,
+            ...currentElse.children,
+          ]))
+      ) {
         return null;
       }
 

--- a/packages/eslint-plugin-template/tests/rules/prefer-at-else/cases.ts
+++ b/packages/eslint-plugin-template/tests/rules/prefer-at-else/cases.ts
@@ -202,6 +202,40 @@ export const invalid: readonly InvalidTestCase<MessageIds, Options>[] = [
     `,
   }),
   convertAnnotatedSourceToFailureCase({
+    description: `reports but does not fix when merging into @else would create multiple projectable roots`,
+    annotatedSource: `
+      <my-component>
+        @if (a) {
+          <button>1</button>
+        } @else {
+          <button>2</button>
+        }
+        @if (!a) {
+        ~~~~
+          <button>3</button>
+        }
+      </my-component>
+    `,
+    messageId,
+  }),
+  convertAnnotatedSourceToFailureCase({
+    description: `reports but does not fix when merging @else into @if would create multiple projectable roots`,
+    annotatedSource: `
+      <my-component>
+        @if (a) {
+          <button>1</button>
+        }
+        @if (!a) {
+        ~~~~
+          <button>2</button>
+        } @else {
+          <button>3</button>
+        }
+      </my-component>
+    `,
+    messageId,
+  }),
+  convertAnnotatedSourceToFailureCase({
     description: `fails for second @if when separated from the first @if by whitespace`,
     annotatedSource: `
       @if (a) {}

--- a/packages/eslint-plugin-template/tests/rules/prefer-at-else/cases.ts
+++ b/packages/eslint-plugin-template/tests/rules/prefer-at-else/cases.ts
@@ -235,6 +235,37 @@ export const invalid: readonly InvalidTestCase<MessageIds, Options>[] = [
     `,
     messageId,
   }),
+  // The first opposite `@if` can still become `@else`. A later `--fix` pass
+  // must not then fold the remaining same-condition `@if` into that branch,
+  // which is the content-projection break reported in issue #3076.
+  convertAnnotatedSourceToFailureCase({
+    description: `does not keep merging projectable roots across autofix passes`,
+    annotatedSource: `
+      @if (a) {
+        <button>1</button>
+      }
+      @if (!a) {
+      ~~~~
+        <button>2</button>
+      }
+      @if (!a) {
+        <button>3</button>
+      }
+    `,
+    messageId,
+    annotatedOutput: `
+      @if (a) {
+        <button>1</button>
+      }
+      @else {
+      
+        <button>2</button>
+      }
+      @if (!a) {
+        <button>3</button>
+      }
+    `,
+  }),
   convertAnnotatedSourceToFailureCase({
     description: `fails for second @if when separated from the first @if by whitespace`,
     annotatedSource: `


### PR DESCRIPTION
## Summary
- keep reporting `prefer-at-else` violations when opposite control-flow blocks can be combined
- skip the autofix when merging branch contents would create multiple root nodes that can interfere with Angular content projection
- add regression coverage for both unsafe merge directions while preserving existing text-only autofixes

Fixes #3076

## Rationale
Angular control-flow content projection can fail when a projected element is inside a control-flow branch with multiple root nodes. The existing fixer can create exactly that structure when it merges the contents of an existing `@else` or a current `@else` into another branch.

The simple `@if (...)` -> `@else` rewrite remains fixable because it does not merge branch contents or change the number of roots in either branch.