### PR TITLE
feat(eslint-plugin-template): [no-inline-styles] add "dynamic" option value for style bindings

### DIFF
--- a/packages/eslint-plugin-template/docs/rules/no-inline-styles.md
+++ b/packages/eslint-plugin-template/docs/rules/no-inline-styles.md
@@ -23,7 +23,7 @@ Disallows the use of inline styles in HTML templates
 
 ## Rationale
 
-Inline styles in templates (style attribute, ngStyle directive, [style] bindings, or [style.property] bindings) make it difficult to maintain consistent styling across an application and can violate Content Security Policy (CSP) restrictions. Styles should be defined in component stylesheets or CSS classes where they can be managed centrally, reused, cached by browsers, and easily modified. Inline styles also mix presentation concerns with template structure, making templates harder to read. Using CSS classes with [class] or [ngClass] bindings provides the same dynamic styling capabilities while keeping styles organized and maintainable. This rule can be configured to allow ngStyle or style bindings if needed for specific use cases.
+Inline styles in templates (style attribute, ngStyle directive, [style] bindings, or [style.property] bindings) make it difficult to maintain consistent styling across an application and can violate Content Security Policy (CSP) restrictions. Styles should be defined in component stylesheets or CSS classes where they can be managed centrally, reused, cached by browsers, and easily modified. Inline styles also mix presentation concerns with template structure, making templates harder to read. Using CSS classes with [class] or [ngClass] bindings provides the same dynamic styling capabilities while keeping styles organized and maintainable. This rule can be configured to allow ngStyle or style bindings if needed for specific use cases. Setting an option to "dynamic" allows a binding only when its value cannot be known ahead of time (for example `[style.width.px]="column.width"`), while still reporting bindings whose value is a constant (for example `[style.color]="'red'"`), since those could be expressed as a class instead.
 
 <br>
 
@@ -34,13 +34,17 @@ The rule accepts an options object with the following properties:
 ```ts
 interface Options {
   /**
+   * Whether `[ngStyle]` bindings are allowed. `true` allows them unconditionally. `"dynamic"` allows them only when the bound value is not a constant (e.g. `{ color: textColor }` is allowed, but `{ color: 'red' }` is reported because it could be a class).
+   *
    * Default: `false`
    */
-  allowNgStyle?: boolean;
+  allowNgStyle?: boolean | "dynamic";
   /**
+   * Whether `[style]`, `[style.property]` and `style="{{ }}"` bindings are allowed. `true` allows them unconditionally. `"dynamic"` allows them only when the bound value is not a constant (e.g. `[style.width.px]="column.width"` is allowed, but `[style.color]="'red'"` is reported because it could be a class).
+   *
    * Default: `false`
    */
-  allowBindToStyle?: boolean;
+  allowBindToStyle?: boolean | "dynamic";
 }
 
 ```
@@ -365,6 +369,398 @@ interface Options {
 ```html
 <input [ngStyle]="{ 'padding': '10px' }" [style]="'border: 1px solid black;'">
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+```
+
+<br>
+
+---
+
+<br>
+
+#### Custom Config
+
+```json
+{
+  "rules": {
+    "@angular-eslint/template/no-inline-styles": [
+      "error",
+      {
+        "allowBindToStyle": "dynamic"
+      }
+    ]
+  }
+}
+```
+
+<br>
+
+#### ❌ Invalid Code
+
+```html
+<div [style.color]="'red'"></div>
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+```
+
+<br>
+
+---
+
+<br>
+
+#### Custom Config
+
+```json
+{
+  "rules": {
+    "@angular-eslint/template/no-inline-styles": [
+      "error",
+      {
+        "allowBindToStyle": "dynamic"
+      }
+    ]
+  }
+}
+```
+
+<br>
+
+#### ❌ Invalid Code
+
+```html
+<div [style.width.px]="100"></div>
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+```
+
+<br>
+
+---
+
+<br>
+
+#### Custom Config
+
+```json
+{
+  "rules": {
+    "@angular-eslint/template/no-inline-styles": [
+      "error",
+      {
+        "allowBindToStyle": "dynamic"
+      }
+    ]
+  }
+}
+```
+
+<br>
+
+#### ❌ Invalid Code
+
+```html
+<div [style]="'color: red'"></div>
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+```
+
+<br>
+
+---
+
+<br>
+
+#### Custom Config
+
+```json
+{
+  "rules": {
+    "@angular-eslint/template/no-inline-styles": [
+      "error",
+      {
+        "allowBindToStyle": "dynamic"
+      }
+    ]
+  }
+}
+```
+
+<br>
+
+#### ❌ Invalid Code
+
+```html
+<div [style]="{ color: 'red', 'background-color': '#fff' }"></div>
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+```
+
+<br>
+
+---
+
+<br>
+
+#### Custom Config
+
+```json
+{
+  "rules": {
+    "@angular-eslint/template/no-inline-styles": [
+      "error",
+      {
+        "allowBindToStyle": "dynamic"
+      }
+    ]
+  }
+}
+```
+
+<br>
+
+#### ❌ Invalid Code
+
+```html
+<div [style.width]="10 + 'px'"></div>
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+```
+
+<br>
+
+---
+
+<br>
+
+#### Custom Config
+
+```json
+{
+  "rules": {
+    "@angular-eslint/template/no-inline-styles": [
+      "error",
+      {
+        "allowBindToStyle": "dynamic"
+      }
+    ]
+  }
+}
+```
+
+<br>
+
+#### ❌ Invalid Code
+
+```html
+<div [style.color]="true ? 'red' : 'blue'"></div>
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+```
+
+<br>
+
+---
+
+<br>
+
+#### Custom Config
+
+```json
+{
+  "rules": {
+    "@angular-eslint/template/no-inline-styles": [
+      "error",
+      {
+        "allowBindToStyle": "dynamic"
+      }
+    ]
+  }
+}
+```
+
+<br>
+
+#### ❌ Invalid Code
+
+```html
+<div [style.width]="`100px`"></div>
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+```
+
+<br>
+
+---
+
+<br>
+
+#### Custom Config
+
+```json
+{
+  "rules": {
+    "@angular-eslint/template/no-inline-styles": [
+      "error",
+      {
+        "allowBindToStyle": "dynamic"
+      }
+    ]
+  }
+}
+```
+
+<br>
+
+#### ❌ Invalid Code
+
+```html
+<div style="color: {{ 'red' }}"></div>
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+```
+
+<br>
+
+---
+
+<br>
+
+#### Custom Config
+
+```json
+{
+  "rules": {
+    "@angular-eslint/template/no-inline-styles": [
+      "error",
+      {
+        "allowBindToStyle": "dynamic"
+      }
+    ]
+  }
+}
+```
+
+<br>
+
+#### ❌ Invalid Code
+
+```html
+<div [attr.style]="styles"></div>
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+```
+
+<br>
+
+---
+
+<br>
+
+#### Custom Config
+
+```json
+{
+  "rules": {
+    "@angular-eslint/template/no-inline-styles": [
+      "error",
+      {
+        "allowNgStyle": "dynamic"
+      }
+    ]
+  }
+}
+```
+
+<br>
+
+#### ❌ Invalid Code
+
+```html
+<div [ngStyle]="{ color: 'red' }"></div>
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+```
+
+<br>
+
+---
+
+<br>
+
+#### Custom Config
+
+```json
+{
+  "rules": {
+    "@angular-eslint/template/no-inline-styles": [
+      "error",
+      {
+        "allowNgStyle": "dynamic"
+      }
+    ]
+  }
+}
+```
+
+<br>
+
+#### ❌ Invalid Code
+
+```html
+<div [ngStyle]="'color: red'"></div>
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+```
+
+<br>
+
+---
+
+<br>
+
+#### Custom Config
+
+```json
+{
+  "rules": {
+    "@angular-eslint/template/no-inline-styles": [
+      "error",
+      {
+        "allowNgStyle": "dynamic",
+        "allowBindToStyle": "dynamic"
+      }
+    ]
+  }
+}
+```
+
+<br>
+
+#### ❌ Invalid Code
+
+```html
+<div [ngStyle]="{ color: 'red' }" [style.width.px]="column.width"></div>
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+```
+
+<br>
+
+---
+
+<br>
+
+#### Custom Config
+
+```json
+{
+  "rules": {
+    "@angular-eslint/template/no-inline-styles": [
+      "error",
+      {
+        "allowNgStyle": true,
+        "allowBindToStyle": "dynamic"
+      }
+    ]
+  }
+}
+```
+
+<br>
+
+#### ❌ Invalid Code
+
+```html
+<div [ngStyle]="{ color: 'red' }" [style.color]="'blue'"></div>
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 ```
 
 </details>
@@ -1051,6 +1447,588 @@ interface Options {
 
 ```html
 <input [ngStyle]="{ 'background-color': 'red' }" [style]="styleObject" [style.background-color]="'#fff'">
+```
+
+<br>
+
+---
+
+<br>
+
+#### Custom Config
+
+```json
+{
+  "rules": {
+    "@angular-eslint/template/no-inline-styles": [
+      "error",
+      {
+        "allowBindToStyle": "dynamic"
+      }
+    ]
+  }
+}
+```
+
+<br>
+
+#### ✅ Valid Code
+
+```html
+<div [style.color]="textColor"></div>
+```
+
+<br>
+
+---
+
+<br>
+
+#### Custom Config
+
+```json
+{
+  "rules": {
+    "@angular-eslint/template/no-inline-styles": [
+      "error",
+      {
+        "allowBindToStyle": "dynamic"
+      }
+    ]
+  }
+}
+```
+
+<br>
+
+#### ✅ Valid Code
+
+```html
+<div [style.width.px]="column.width"></div>
+```
+
+<br>
+
+---
+
+<br>
+
+#### Custom Config
+
+```json
+{
+  "rules": {
+    "@angular-eslint/template/no-inline-styles": [
+      "error",
+      {
+        "allowBindToStyle": "dynamic"
+      }
+    ]
+  }
+}
+```
+
+<br>
+
+#### ✅ Valid Code
+
+```html
+<div [style]="styleObject"></div>
+```
+
+<br>
+
+---
+
+<br>
+
+#### Custom Config
+
+```json
+{
+  "rules": {
+    "@angular-eslint/template/no-inline-styles": [
+      "error",
+      {
+        "allowBindToStyle": "dynamic"
+      }
+    ]
+  }
+}
+```
+
+<br>
+
+#### ✅ Valid Code
+
+```html
+<div [style]="{ color: textColor, 'background-color': backgroundColor }"></div>
+```
+
+<br>
+
+---
+
+<br>
+
+#### Custom Config
+
+```json
+{
+  "rules": {
+    "@angular-eslint/template/no-inline-styles": [
+      "error",
+      {
+        "allowBindToStyle": "dynamic"
+      }
+    ]
+  }
+}
+```
+
+<br>
+
+#### ✅ Valid Code
+
+```html
+<div [style]="{ color: 'red', 'background-color': backgroundColor }"></div>
+```
+
+<br>
+
+---
+
+<br>
+
+#### Custom Config
+
+```json
+{
+  "rules": {
+    "@angular-eslint/template/no-inline-styles": [
+      "error",
+      {
+        "allowBindToStyle": "dynamic"
+      }
+    ]
+  }
+}
+```
+
+<br>
+
+#### ✅ Valid Code
+
+```html
+<div [style.width.px]="getWidth()"></div>
+```
+
+<br>
+
+---
+
+<br>
+
+#### Custom Config
+
+```json
+{
+  "rules": {
+    "@angular-eslint/template/no-inline-styles": [
+      "error",
+      {
+        "allowBindToStyle": "dynamic"
+      }
+    ]
+  }
+}
+```
+
+<br>
+
+#### ✅ Valid Code
+
+```html
+<div [style.color]="color$ | async"></div>
+```
+
+<br>
+
+---
+
+<br>
+
+#### Custom Config
+
+```json
+{
+  "rules": {
+    "@angular-eslint/template/no-inline-styles": [
+      "error",
+      {
+        "allowBindToStyle": "dynamic"
+      }
+    ]
+  }
+}
+```
+
+<br>
+
+#### ✅ Valid Code
+
+```html
+<div [style.color]="isActive ? 'green' : 'gray'"></div>
+```
+
+<br>
+
+---
+
+<br>
+
+#### Custom Config
+
+```json
+{
+  "rules": {
+    "@angular-eslint/template/no-inline-styles": [
+      "error",
+      {
+        "allowBindToStyle": "dynamic"
+      }
+    ]
+  }
+}
+```
+
+<br>
+
+#### ✅ Valid Code
+
+```html
+<div [style.width]="width + 'px'"></div>
+```
+
+<br>
+
+---
+
+<br>
+
+#### Custom Config
+
+```json
+{
+  "rules": {
+    "@angular-eslint/template/no-inline-styles": [
+      "error",
+      {
+        "allowBindToStyle": "dynamic"
+      }
+    ]
+  }
+}
+```
+
+<br>
+
+#### ✅ Valid Code
+
+```html
+<div [style.width]="`${width}px`"></div>
+```
+
+<br>
+
+---
+
+<br>
+
+#### Custom Config
+
+```json
+{
+  "rules": {
+    "@angular-eslint/template/no-inline-styles": [
+      "error",
+      {
+        "allowBindToStyle": "dynamic"
+      }
+    ]
+  }
+}
+```
+
+<br>
+
+#### ✅ Valid Code
+
+```html
+<div [style.opacity]="-offset"></div>
+```
+
+<br>
+
+---
+
+<br>
+
+#### Custom Config
+
+```json
+{
+  "rules": {
+    "@angular-eslint/template/no-inline-styles": [
+      "error",
+      {
+        "allowBindToStyle": "dynamic"
+      }
+    ]
+  }
+}
+```
+
+<br>
+
+#### ✅ Valid Code
+
+```html
+<div [style.top.px]="positions[index]"></div>
+```
+
+<br>
+
+---
+
+<br>
+
+#### Custom Config
+
+```json
+{
+  "rules": {
+    "@angular-eslint/template/no-inline-styles": [
+      "error",
+      {
+        "allowBindToStyle": "dynamic"
+      }
+    ]
+  }
+}
+```
+
+<br>
+
+#### ✅ Valid Code
+
+```html
+<div [style.color]="config?.color"></div>
+```
+
+<br>
+
+---
+
+<br>
+
+#### Custom Config
+
+```json
+{
+  "rules": {
+    "@angular-eslint/template/no-inline-styles": [
+      "error",
+      {
+        "allowBindToStyle": "dynamic"
+      }
+    ]
+  }
+}
+```
+
+<br>
+
+#### ✅ Valid Code
+
+```html
+<div style="color: {{ textColor }}"></div>
+```
+
+<br>
+
+---
+
+<br>
+
+#### Custom Config
+
+```json
+{
+  "rules": {
+    "@angular-eslint/template/no-inline-styles": [
+      "error",
+      {
+        "allowBindToStyle": "dynamic"
+      }
+    ]
+  }
+}
+```
+
+<br>
+
+#### ✅ Valid Code
+
+```html
+<div bind-style="styleObject"></div>
+```
+
+<br>
+
+---
+
+<br>
+
+#### Custom Config
+
+```json
+{
+  "rules": {
+    "@angular-eslint/template/no-inline-styles": [
+      "error",
+      {
+        "allowBindToStyle": "dynamic"
+      }
+    ]
+  }
+}
+```
+
+<br>
+
+#### ✅ Valid Code
+
+```html
+<div [style]="{ ...baseStyles }"></div>
+```
+
+<br>
+
+---
+
+<br>
+
+#### Custom Config
+
+```json
+{
+  "rules": {
+    "@angular-eslint/template/no-inline-styles": [
+      "error",
+      {
+        "allowNgStyle": "dynamic"
+      }
+    ]
+  }
+}
+```
+
+<br>
+
+#### ✅ Valid Code
+
+```html
+<div [ngStyle]="{ color: textColor }"></div>
+```
+
+<br>
+
+---
+
+<br>
+
+#### Custom Config
+
+```json
+{
+  "rules": {
+    "@angular-eslint/template/no-inline-styles": [
+      "error",
+      {
+        "allowNgStyle": "dynamic"
+      }
+    ]
+  }
+}
+```
+
+<br>
+
+#### ✅ Valid Code
+
+```html
+<div [ngStyle]="styleObject"></div>
+```
+
+<br>
+
+---
+
+<br>
+
+#### Custom Config
+
+```json
+{
+  "rules": {
+    "@angular-eslint/template/no-inline-styles": [
+      "error",
+      {
+        "allowNgStyle": "dynamic",
+        "allowBindToStyle": "dynamic"
+      }
+    ]
+  }
+}
+```
+
+<br>
+
+#### ✅ Valid Code
+
+```html
+<div [ngStyle]="{ 'font-size.px': fontSize }" [style.color]="textColor"></div>
+```
+
+<br>
+
+---
+
+<br>
+
+#### Custom Config
+
+```json
+{
+  "rules": {
+    "@angular-eslint/template/no-inline-styles": [
+      "error",
+      {
+        "allowNgStyle": "dynamic",
+        "allowBindToStyle": true
+      }
+    ]
+  }
+}
+```
+
+<br>
+
+#### ✅ Valid Code
+
+```html
+<div [ngStyle]="{ color: textColor }" [style.color]="'red'"></div>
 ```
 
 </details>

--- a/packages/eslint-plugin-template/src/rules/no-inline-styles.ts
+++ b/packages/eslint-plugin-template/src/rules/no-inline-styles.ts
@@ -1,14 +1,25 @@
 import {
+  type AST,
   BindingType,
   type TmplAstElement,
 } from '@angular-eslint/bundled-angular-compiler';
 import { getTemplateParserServices } from '@angular-eslint/utils';
 import { createESLintRule } from '../utils/create-eslint-rule';
+import { isConstantExpression } from '../utils/is-constant-expression';
+
+/**
+ * - `false`: never allowed.
+ * - `true`: always allowed.
+ * - `'dynamic'`: allowed only when the bound value is not a constant
+ *   (a literal, or an expression built exclusively from literals). Constant
+ *   values could live in a stylesheet, so they are still reported.
+ */
+export type AllowOption = boolean | 'dynamic';
 
 export type Options = [
   {
-    readonly allowNgStyle?: boolean;
-    readonly allowBindToStyle?: boolean;
+    readonly allowNgStyle?: AllowOption;
+    readonly allowBindToStyle?: AllowOption;
   },
 ];
 const DEFAULT_OPTIONS: Options[number] = {
@@ -34,11 +45,15 @@ export default createESLintRule<Options, MessageIds>({
         type: 'object',
         properties: {
           allowNgStyle: {
-            type: 'boolean',
+            oneOf: [{ type: 'boolean' }, { type: 'string', enum: ['dynamic'] }],
+            description:
+              'Whether `[ngStyle]` bindings are allowed. `true` allows them unconditionally. `"dynamic"` allows them only when the bound value is not a constant (e.g. `{ color: textColor }` is allowed, but `{ color: \'red\' }` is reported because it could be a class).',
             default: DEFAULT_OPTIONS.allowNgStyle,
           },
           allowBindToStyle: {
-            type: 'boolean',
+            oneOf: [{ type: 'boolean' }, { type: 'string', enum: ['dynamic'] }],
+            description:
+              'Whether `[style]`, `[style.property]` and `style="{{ }}"` bindings are allowed. `true` allows them unconditionally. `"dynamic"` allows them only when the bound value is not a constant (e.g. `[style.width.px]="column.width"` is allowed, but `[style.color]="\'red\'"` is reported because it could be a class).',
             default: DEFAULT_OPTIONS.allowBindToStyle,
           },
         },
@@ -64,13 +79,13 @@ export default createESLintRule<Options, MessageIds>({
             case BindingType.Attribute:
               return input.name === 'style';
             case BindingType.Style:
-              return !allowBindToStyle;
+              return !isAllowed(allowBindToStyle, input.value);
             case BindingType.Property:
               if (input.name === 'style') {
-                return !allowBindToStyle;
+                return !isAllowed(allowBindToStyle, input.value);
               }
               if (input.name === 'ngStyle') {
-                return !allowNgStyle;
+                return !isAllowed(allowNgStyle, input.value);
               }
               return false;
             default:
@@ -100,7 +115,14 @@ export default createESLintRule<Options, MessageIds>({
   },
 });
 
+function isAllowed(option: AllowOption | undefined, value: AST): boolean {
+  if (option === 'dynamic') {
+    return !isConstantExpression(value);
+  }
+  return option === true;
+}
+
 export const RULE_DOCS_EXTENSION = {
   rationale:
-    'Inline styles in templates (style attribute, ngStyle directive, [style] bindings, or [style.property] bindings) make it difficult to maintain consistent styling across an application and can violate Content Security Policy (CSP) restrictions. Styles should be defined in component stylesheets or CSS classes where they can be managed centrally, reused, cached by browsers, and easily modified. Inline styles also mix presentation concerns with template structure, making templates harder to read. Using CSS classes with [class] or [ngClass] bindings provides the same dynamic styling capabilities while keeping styles organized and maintainable. This rule can be configured to allow ngStyle or style bindings if needed for specific use cases.',
+    'Inline styles in templates (style attribute, ngStyle directive, [style] bindings, or [style.property] bindings) make it difficult to maintain consistent styling across an application and can violate Content Security Policy (CSP) restrictions. Styles should be defined in component stylesheets or CSS classes where they can be managed centrally, reused, cached by browsers, and easily modified. Inline styles also mix presentation concerns with template structure, making templates harder to read. Using CSS classes with [class] or [ngClass] bindings provides the same dynamic styling capabilities while keeping styles organized and maintainable. This rule can be configured to allow ngStyle or style bindings if needed for specific use cases. Setting an option to "dynamic" allows a binding only when its value cannot be known ahead of time (for example `[style.width.px]="column.width"`), while still reporting bindings whose value is a constant (for example `[style.color]="\'red\'"`), since those could be expressed as a class instead.',
 };

--- a/packages/eslint-plugin-template/src/utils/is-constant-expression.ts
+++ b/packages/eslint-plugin-template/src/utils/is-constant-expression.ts
@@ -1,0 +1,87 @@
+import {
+  type AST,
+  ASTWithSource,
+  Binary,
+  Conditional,
+  EmptyExpr,
+  Interpolation,
+  LiteralArray,
+  LiteralMap,
+  LiteralPrimitive,
+  NonNullAssert,
+  ParenthesizedExpression,
+  PrefixNot,
+  TemplateLiteral,
+  TypeofExpression,
+  Unary,
+  VoidExpression,
+} from '@angular-eslint/bundled-angular-compiler';
+
+/**
+ * Determines whether a template expression is a constant, i.e. its value is
+ * fully determined by the template source alone and can never change at
+ * runtime.
+ *
+ * An expression is constant when it is built exclusively from literals
+ * (strings, numbers, booleans, `null`, `undefined`, literal maps, literal
+ * arrays and template literals) combined with pure operators (arithmetic,
+ * logical, comparison, conditional, `typeof`, `void`, `!`, `!!`, parentheses).
+ *
+ * Anything that reads component state (property reads, keyed reads), performs
+ * a call, or applies a pipe is dynamic. Unknown node types are also treated as
+ * dynamic, so that this helper fails open rather than reporting false
+ * positives.
+ */
+export function isConstantExpression(node: AST): boolean {
+  if (node instanceof ASTWithSource) {
+    return isConstantExpression(node.ast);
+  }
+
+  if (node instanceof LiteralPrimitive || node instanceof EmptyExpr) {
+    return true;
+  }
+
+  if (node instanceof LiteralMap) {
+    return node.values.every(isConstantExpression);
+  }
+
+  if (node instanceof LiteralArray) {
+    return node.expressions.every(isConstantExpression);
+  }
+
+  if (node instanceof Interpolation || node instanceof TemplateLiteral) {
+    return node.expressions.every(isConstantExpression);
+  }
+
+  if (node instanceof ParenthesizedExpression) {
+    return isConstantExpression(node.expression);
+  }
+
+  // `Unary` extends `Binary`, so it must be checked first.
+  if (node instanceof Unary) {
+    return isConstantExpression(node.expr);
+  }
+
+  if (node instanceof Binary) {
+    return isConstantExpression(node.left) && isConstantExpression(node.right);
+  }
+
+  if (node instanceof Conditional) {
+    return (
+      isConstantExpression(node.condition) &&
+      isConstantExpression(node.trueExp) &&
+      isConstantExpression(node.falseExp)
+    );
+  }
+
+  if (
+    node instanceof PrefixNot ||
+    node instanceof TypeofExpression ||
+    node instanceof VoidExpression ||
+    node instanceof NonNullAssert
+  ) {
+    return isConstantExpression(node.expression);
+  }
+
+  return false;
+}

--- a/packages/eslint-plugin-template/tests/rules/no-inline-styles/cases.ts
+++ b/packages/eslint-plugin-template/tests/rules/no-inline-styles/cases.ts
@@ -65,6 +65,88 @@ export const valid: readonly (string | ValidTestCase<Options>)[] = [
       },
     ],
   },
+  // allowBindToStyle: 'dynamic' allows bindings whose value is not a constant
+  {
+    code: `<div [style.color]="textColor"></div>`,
+    options: [{ allowBindToStyle: 'dynamic' }],
+  },
+  {
+    code: `<div [style.width.px]="column.width"></div>`,
+    options: [{ allowBindToStyle: 'dynamic' }],
+  },
+  {
+    code: `<div [style]="styleObject"></div>`,
+    options: [{ allowBindToStyle: 'dynamic' }],
+  },
+  {
+    code: `<div [style]="{ color: textColor, 'background-color': backgroundColor }"></div>`,
+    options: [{ allowBindToStyle: 'dynamic' }],
+  },
+  {
+    code: `<div [style]="{ color: 'red', 'background-color': backgroundColor }"></div>`,
+    options: [{ allowBindToStyle: 'dynamic' }],
+  },
+  {
+    code: `<div [style.width.px]="getWidth()"></div>`,
+    options: [{ allowBindToStyle: 'dynamic' }],
+  },
+  {
+    code: `<div [style.color]="color$ | async"></div>`,
+    options: [{ allowBindToStyle: 'dynamic' }],
+  },
+  {
+    code: `<div [style.color]="isActive ? 'green' : 'gray'"></div>`,
+    options: [{ allowBindToStyle: 'dynamic' }],
+  },
+  {
+    code: `<div [style.width]="width + 'px'"></div>`,
+    options: [{ allowBindToStyle: 'dynamic' }],
+  },
+  {
+    code: '<div [style.width]="`${width}px`"></div>',
+    options: [{ allowBindToStyle: 'dynamic' }],
+  },
+  {
+    code: `<div [style.opacity]="-offset"></div>`,
+    options: [{ allowBindToStyle: 'dynamic' }],
+  },
+  {
+    code: `<div [style.top.px]="positions[index]"></div>`,
+    options: [{ allowBindToStyle: 'dynamic' }],
+  },
+  {
+    code: `<div [style.color]="config?.color"></div>`,
+    options: [{ allowBindToStyle: 'dynamic' }],
+  },
+  {
+    code: `<div style="color: {{ textColor }}"></div>`,
+    options: [{ allowBindToStyle: 'dynamic' }],
+  },
+  {
+    code: `<div bind-style="styleObject"></div>`,
+    options: [{ allowBindToStyle: 'dynamic' }],
+  },
+  {
+    code: `<div [style]="{ ...baseStyles }"></div>`,
+    options: [{ allowBindToStyle: 'dynamic' }],
+  },
+  // allowNgStyle: 'dynamic' allows ngStyle bindings whose value is not a constant
+  {
+    code: `<div [ngStyle]="{ color: textColor }"></div>`,
+    options: [{ allowNgStyle: 'dynamic' }],
+  },
+  {
+    code: `<div [ngStyle]="styleObject"></div>`,
+    options: [{ allowNgStyle: 'dynamic' }],
+  },
+  {
+    code: `<div [ngStyle]="{ 'font-size.px': fontSize }" [style.color]="textColor"></div>`,
+    options: [{ allowNgStyle: 'dynamic', allowBindToStyle: 'dynamic' }],
+  },
+  {
+    code: `<div [ngStyle]="{ color: textColor }" [style.color]="'red'"></div>`,
+    options: [{ allowNgStyle: 'dynamic', allowBindToStyle: true }],
+  },
 ];
 
 export const invalid: readonly InvalidTestCase<MessageIds, Options>[] = [
@@ -179,5 +261,146 @@ export const invalid: readonly InvalidTestCase<MessageIds, Options>[] = [
       `,
     data: { element: 'input' },
     options: [{ allowNgStyle: true, allowBindToStyle: false }],
+  }),
+  convertAnnotatedSourceToFailureCase({
+    messageId,
+    description:
+      'should fail when style property binding value is a string literal and allowBindToStyle is "dynamic"',
+    annotatedSource: `
+        <div [style.color]="'red'"></div>
+        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      `,
+    data: { element: 'div' },
+    options: [{ allowBindToStyle: 'dynamic' }],
+  }),
+  convertAnnotatedSourceToFailureCase({
+    messageId,
+    description:
+      'should fail when style property binding value is a number literal and allowBindToStyle is "dynamic"',
+    annotatedSource: `
+        <div [style.width.px]="100"></div>
+        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      `,
+    data: { element: 'div' },
+    options: [{ allowBindToStyle: 'dynamic' }],
+  }),
+  convertAnnotatedSourceToFailureCase({
+    messageId,
+    description:
+      'should fail when style binding value is a string literal and allowBindToStyle is "dynamic"',
+    annotatedSource: `
+        <div [style]="'color: red'"></div>
+        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      `,
+    data: { element: 'div' },
+    options: [{ allowBindToStyle: 'dynamic' }],
+  }),
+  convertAnnotatedSourceToFailureCase({
+    messageId,
+    description:
+      'should fail when style binding value is a literal map of literals and allowBindToStyle is "dynamic"',
+    annotatedSource: `
+        <div [style]="{ color: 'red', 'background-color': '#fff' }"></div>
+        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      `,
+    data: { element: 'div' },
+    options: [{ allowBindToStyle: 'dynamic' }],
+  }),
+  convertAnnotatedSourceToFailureCase({
+    messageId,
+    description:
+      'should fail when style property binding value only combines literals and allowBindToStyle is "dynamic"',
+    annotatedSource: `
+        <div [style.width]="10 + 'px'"></div>
+        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      `,
+    data: { element: 'div' },
+    options: [{ allowBindToStyle: 'dynamic' }],
+  }),
+  convertAnnotatedSourceToFailureCase({
+    messageId,
+    description:
+      'should fail when style property binding value is a conditional of literals and allowBindToStyle is "dynamic"',
+    annotatedSource: `
+        <div [style.color]="true ? 'red' : 'blue'"></div>
+        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      `,
+    data: { element: 'div' },
+    options: [{ allowBindToStyle: 'dynamic' }],
+  }),
+  convertAnnotatedSourceToFailureCase({
+    messageId,
+    description:
+      'should fail when style property binding value is a template literal without expressions and allowBindToStyle is "dynamic"',
+    annotatedSource:
+      '\n        <div [style.width]="`100px`"></div>\n        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~\n      ',
+    data: { element: 'div' },
+    options: [{ allowBindToStyle: 'dynamic' }],
+  }),
+  convertAnnotatedSourceToFailureCase({
+    messageId,
+    description:
+      'should fail when style interpolation only contains literals and allowBindToStyle is "dynamic"',
+    annotatedSource: `
+        <div style="color: {{ 'red' }}"></div>
+        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      `,
+    data: { element: 'div' },
+    options: [{ allowBindToStyle: 'dynamic' }],
+  }),
+  convertAnnotatedSourceToFailureCase({
+    messageId,
+    description:
+      'should fail when attr.style binding exists even with allowBindToStyle set to "dynamic"',
+    annotatedSource: `
+        <div [attr.style]="styles"></div>
+        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      `,
+    data: { element: 'div' },
+    options: [{ allowBindToStyle: 'dynamic' }],
+  }),
+  convertAnnotatedSourceToFailureCase({
+    messageId,
+    description:
+      'should fail when ngStyle binding value is a literal map of literals and allowNgStyle is "dynamic"',
+    annotatedSource: `
+        <div [ngStyle]="{ color: 'red' }"></div>
+        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      `,
+    data: { element: 'div' },
+    options: [{ allowNgStyle: 'dynamic' }],
+  }),
+  convertAnnotatedSourceToFailureCase({
+    messageId,
+    description:
+      'should fail when ngStyle binding value is a string literal and allowNgStyle is "dynamic"',
+    annotatedSource: `
+        <div [ngStyle]="'color: red'"></div>
+        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      `,
+    data: { element: 'div' },
+    options: [{ allowNgStyle: 'dynamic' }],
+  }),
+  convertAnnotatedSourceToFailureCase({
+    messageId,
+    description:
+      'should fail when a dynamic style binding is allowed but ngStyle is not dynamic',
+    annotatedSource: `
+        <div [ngStyle]="{ color: 'red' }" [style.width.px]="column.width"></div>
+        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      `,
+    data: { element: 'div' },
+    options: [{ allowNgStyle: 'dynamic', allowBindToStyle: 'dynamic' }],
+  }),
+  convertAnnotatedSourceToFailureCase({
+    messageId,
+    description:
+      'should fail when style property binding value is constant and allowBindToStyle is "dynamic" even if allowNgStyle is true',
+    annotatedSource: `
+        <div [ngStyle]="{ color: 'red' }" [style.color]="'blue'"></div>
+        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      `,
+    data: { element: 'div' },
+    options: [{ allowNgStyle: true, allowBindToStyle: 'dynamic' }],
   }),
 ];


### PR DESCRIPTION
Closes #3186

## Summary

`no-inline-styles` exists because styling that could live in a stylesheet should live there. Its `allow*` options were keyed purely on syntax, so with `allowBindToStyle: true` both a static inline style written in binding syntax (`[style.color]="'red'"`) and a genuinely dynamic one (`[style.width.px]="column.width"`) passed. The rule's rationale objects to the first and not the second, but the option could not tell them apart.

This PR lets both `allowBindToStyle` and `allowNgStyle` accept `'dynamic'` in addition to `true`/`false`:

| Value | Behaviour |
| --- | --- |
| `false` (default) | Bindings are always reported (unchanged) |
| `true` | Bindings are always allowed (unchanged) |
| `'dynamic'` | Bindings are allowed only when the bound value is **not** a constant |

With `{ allowBindToStyle: 'dynamic' }`:

```html
<div [style.width.px]="column.width"></div>  <!-- ✅ dynamic -->
<div [style]="{ color: textColor }"></div>    <!-- ✅ dynamic -->
<div [style.color]="'red'"></div>             <!-- ❌ constant, should be a class -->
<div [style]="{ color: 'red' }"></div>        <!-- ❌ constant, should be a class -->
```

## Design notes

**Why extend the existing options rather than add `allowDynamicStyleBindings`?**

- Fully backwards compatible: `true` and `false` keep their exact meaning.
- No redundant or contradictory combinations. A separate boolean would make `allowBindToStyle: true` + `allowDynamicStyleBindings: true` redundant and `allowBindToStyle: true` + `allowDynamicStyleBindings: false` contradictory.
- `allowNgStyle` gets the same treatment for free (this was one of the open questions on the issue), with no new options needed. `[ngStyle]="{ color: textColor }"` is allowed under `'dynamic'`, `[ngStyle]="{ color: 'red' }"` is not.
- Reads naturally in config: `allowBindToStyle: 'dynamic'`.

**What counts as constant?**

The analysis is purely on the template expression AST, no type information needed. An expression is constant when it is built exclusively from literals (strings, numbers, booleans, `null`, `undefined`, literal maps, literal arrays, template literals) combined with pure operators (arithmetic, logical, comparison, conditional, `typeof`, `void`, `!`, parentheses). Anything containing a property read, keyed read, call, safe navigation, or pipe is dynamic. Unknown node types are treated as dynamic so the check fails open rather than producing false positives.

The helper lives in `src/utils/is-constant-expression.ts` so other rules can reuse it.

## Changes

- `src/rules/no-inline-styles.ts`: options accept `boolean | 'dynamic'`; schema uses `oneOf`; per-option descriptions added; rationale updated.
- `src/utils/is-constant-expression.ts`: new helper.
- `tests/rules/no-inline-styles/cases.ts`: 20 new valid cases (property reads, calls, pipes, conditionals with reads, binary/template-literal concatenation, keyed reads, safe navigation, interpolation, `bind-style`, spread, `ngStyle` variants) and 13 new invalid cases (string/number literals, literal maps of literals, binary/conditional/template literal of literals, literal-only interpolation, `attr.style` still reported, `ngStyle` variants, mixed options).
- `docs/rules/no-inline-styles.md`: regenerated.

## Verification

- `pnpm nx test eslint-plugin-template` – 1355 tests pass (69 in this rule's spec).
- `pnpm nx run-many -t lint,typecheck -p eslint-plugin-template` – pass.
- `pnpm format-check`, `pnpm nx sync:check`, `check-rule-docs`, `check-rule-lists`, `check-rule-configs` – pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q2VLqDmxjReiu2c21UVVXJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q2VLqDmxjReiu2c21UVVXJ)_