### PR TITLE
fix(schematics): error in ng-add on Angular major mismatch and say what to rerun

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,8 @@ ng add angular-eslint
 
 ...and that's it!
 
+> NOTE: `ng add angular-eslint` installs the latest version, which is aligned with the latest Angular major. If your workspace is on an older Angular major, pin the matching major instead, e.g. `ng add angular-eslint@21` for an Angular v21 workspace. See [ANGULAR_VERSION_SUPPORT.md](./docs/ANGULAR_VERSION_SUPPORT.md) for details.
+
 As well as installing all relevant dependencies, the `ng add` command will automatically detect that you have a workspace with a single project in it, which does not have a linter configured yet. It can therefore go ahead and wire everything up for you!
 
 You will also see that it added the following in your angular.json:

--- a/docs/ANGULAR_VERSION_SUPPORT.md
+++ b/docs/ANGULAR_VERSION_SUPPORT.md
@@ -13,7 +13,13 @@ Therefore, as an example (because these versions may or may not exist yet when y
 
 > NOTE: the exact minor and patch versions of each library represented here by `x`'s do not need to match each other, just the first (major) number
 
-`ng add angular-eslint` and `ng lint` will warn when they can see that the workspace's `@angular/core` or `@angular/cli` major does not match the installed `angular-eslint` major. This is informational: installation and linting still proceed.
+`ng add angular-eslint` (with no version) always installs the `latest` version of `angular-eslint`, because the Angular CLI only uses `peerDependencies` to pick a compatible version and `angular-eslint` intentionally does not declare a peer dependency on `@angular/cli` (that would pull the whole CLI into workspaces that only want ESLint). So if your workspace is on an older Angular major, pin the matching major when adding:
+
+```sh
+ng add angular-eslint@21 # for an Angular v21 workspace
+```
+
+If you forget, the `ng add` schematic will fail before it changes any files, and its error message tells you the exact `ng add angular-eslint@<major>` command to rerun. `ng lint` only warns on the same mismatch and linting still proceeds.
 
 ## Prior to v12
 

--- a/packages/schematics/src/angular-version-compat.ts
+++ b/packages/schematics/src/angular-version-compat.ts
@@ -102,7 +102,10 @@ export function hasDetectableAngularVersion(
   });
 }
 
-export function formatAngularVersionMismatchMessage(
+const ANGULAR_VERSION_SUPPORT_DOCS_URL =
+  'https://github.com/angular-eslint/angular-eslint/blob/main/docs/ANGULAR_VERSION_SUPPORT.md';
+
+function formatAngularVersionMismatchDetails(
   expectedMajor: number,
   mismatches: AngularVersionMismatch[],
 ): string {
@@ -116,8 +119,17 @@ export function formatAngularVersionMismatchMessage(
 angular-eslint v${expectedMajor} is intended for Angular v${expectedMajor}.
 This workspace is using a different Angular major:
 ${details}
+`.trim();
+}
 
-See https://github.com/angular-eslint/angular-eslint/blob/main/docs/ANGULAR_VERSION_SUPPORT.md
+export function formatAngularVersionMismatchMessage(
+  expectedMajor: number,
+  mismatches: AngularVersionMismatch[],
+): string {
+  return `
+${formatAngularVersionMismatchDetails(expectedMajor, mismatches)}
+
+See ${ANGULAR_VERSION_SUPPORT_DOCS_URL}
 `.trim();
 }
 
@@ -125,4 +137,44 @@ export function formatAngularVersionMatchMessage(
   expectedMajor: number,
 ): string {
   return `angular-eslint v${expectedMajor} matches this workspace's Angular v${expectedMajor}.`;
+}
+
+/**
+ * The Angular major that the user should install angular-eslint for, based on
+ * the mismatches found. `@angular/core` is the source of truth for the
+ * workspace's Angular version, so prefer it over `@angular/cli`.
+ */
+export function getRecommendedAngularMajor(
+  mismatches: AngularVersionMismatch[],
+): number | null {
+  const core = mismatches.find(
+    (mismatch) => mismatch.packageName === '@angular/core',
+  );
+  return core?.foundMajor ?? mismatches[0]?.foundMajor ?? null;
+}
+
+/**
+ * Error shown by `ng add` when the workspace Angular major does not match the
+ * angular-eslint major being added. Unlike the warning used by `ng lint`, this
+ * stops the schematic and tells the user exactly what to rerun.
+ */
+export function formatAngularVersionMismatchError(
+  expectedMajor: number,
+  mismatches: AngularVersionMismatch[],
+): string {
+  const major =
+    getRecommendedAngularMajor(mismatches) ?? '<your Angular major>';
+  return `
+${formatAngularVersionMismatchDetails(expectedMajor, mismatches)}
+
+\`ng add\` installs the latest angular-eslint by default, which does not match this workspace.
+Rerun the command with the Angular major of this workspace:
+
+  ng add angular-eslint@${major}
+
+If you added @angular-eslint/schematics directly, rerun \`ng add @angular-eslint/schematics@${major}\` instead.
+The mismatched package that \`ng add\` just installed will be replaced when you rerun it.
+
+See ${ANGULAR_VERSION_SUPPORT_DOCS_URL}
+`.trim();
 }

--- a/packages/schematics/src/ng-add/index.ts
+++ b/packages/schematics/src/ng-add/index.ts
@@ -1,11 +1,15 @@
 import type { Rule, SchematicContext, Tree } from '@angular-devkit/schematics';
-import { chain, schematic } from '@angular-devkit/schematics';
+import {
+  chain,
+  schematic,
+  SchematicsException,
+} from '@angular-devkit/schematics';
 import { NodePackageInstallTask } from '@angular-devkit/schematics/tasks';
 import type { Schema } from './schema';
 import {
   findAngularVersionMismatches,
   formatAngularVersionMatchMessage,
-  formatAngularVersionMismatchMessage,
+  formatAngularVersionMismatchError,
   hasDetectableAngularVersion,
   parseMajorVersion,
   type PackageJsonLike,
@@ -188,11 +192,16 @@ Please see https://github.com/angular-eslint/angular-eslint for more information
 }
 
 /**
- * Entry point for the ng-add schematic.
+ * `ng add` always resolves to the `latest` angular-eslint unless the user
+ * pins a major (the Angular CLI only consults `peerDependencies` when picking
+ * a version, and we intentionally do not declare a peer on `@angular/cli`, see
+ * docs/ANGULAR_VERSION_SUPPORT.md). So when the workspace is on a different
+ * Angular major we fail fast, before touching any files, and tell the user
+ * exactly which command to rerun.
  *
- * @param options Configuration options passed to the schematic.
+ * `ng lint` and `ng update` migrations only warn on the same mismatch.
  */
-function reportAngularVersionCompatibility(
+function assertAngularVersionCompatibility(
   workspacePackageJson: PackageJsonLike,
   context: SchematicContext,
 ): void {
@@ -205,16 +214,20 @@ function reportAngularVersionCompatibility(
     expectedMajor,
   );
   if (mismatches.length > 0) {
-    context.logger.warn(
-      formatAngularVersionMismatchMessage(expectedMajor, mismatches),
+    throw new SchematicsException(
+      formatAngularVersionMismatchError(expectedMajor, mismatches),
     );
-    return;
   }
   if (hasDetectableAngularVersion(workspacePackageJson)) {
     context.logger.info(formatAngularVersionMatchMessage(expectedMajor));
   }
 }
 
+/**
+ * Entry point for the ng-add schematic.
+ *
+ * @param options Configuration options passed to the schematic.
+ */
 export default function (options: Schema): Rule {
   return (host: Tree, context: SchematicContext) => {
     const workspacePackageJSON = (host.read('package.json') as Buffer).toString(
@@ -222,7 +235,7 @@ export default function (options: Schema): Rule {
     );
     const json = JSON.parse(workspacePackageJSON);
 
-    reportAngularVersionCompatibility(json, context);
+    assertAngularVersionCompatibility(json, context);
 
     return chain([
       addAngularESLintPackages(json, options),

--- a/packages/schematics/tests/angular-version-compat.test.ts
+++ b/packages/schematics/tests/angular-version-compat.test.ts
@@ -2,7 +2,9 @@ import { describe, expect, it } from 'vitest';
 import {
   findAngularVersionMismatches,
   formatAngularVersionMatchMessage,
+  formatAngularVersionMismatchError,
   formatAngularVersionMismatchMessage,
+  getRecommendedAngularMajor,
   hasDetectableAngularVersion,
   parseMajorVersion,
 } from '../src/angular-version-compat';
@@ -135,6 +137,29 @@ describe('messages', () => {
     expect(message).toContain('ANGULAR_VERSION_SUPPORT.md');
   });
 
+  it('formats a mismatch error that says exactly what to rerun', () => {
+    const message = formatAngularVersionMismatchError(22, [
+      {
+        packageName: '@angular/core',
+        specifier: '^21.2.0',
+        foundMajor: 21,
+      },
+      {
+        packageName: '@angular/cli',
+        specifier: '21.2.0',
+        foundMajor: 21,
+      },
+    ]);
+    expect(message).toContain(
+      'angular-eslint v22 is intended for Angular v22.',
+    );
+    expect(message).toContain('@angular/core@^21.2.0 (v21)');
+    expect(message).toContain('@angular/cli@21.2.0 (v21)');
+    expect(message).toContain('  ng add angular-eslint@21');
+    expect(message).toContain('ng add @angular-eslint/schematics@21');
+    expect(message).toContain('ANGULAR_VERSION_SUPPORT.md');
+  });
+
   it('formats a match confirmation', () => {
     expect(formatAngularVersionMatchMessage(22)).toBe(
       "angular-eslint v22 matches this workspace's Angular v22.",
@@ -149,5 +174,28 @@ describe('messages', () => {
       }),
     ).toBe(true);
     expect(hasDetectableAngularVersion({}, { '@angular/core': 22 })).toBe(true);
+  });
+});
+
+describe('getRecommendedAngularMajor', () => {
+  it('returns null when there are no mismatches', () => {
+    expect(getRecommendedAngularMajor([])).toBeNull();
+  });
+
+  it('prefers the @angular/core major over @angular/cli', () => {
+    expect(
+      getRecommendedAngularMajor([
+        { packageName: '@angular/cli', specifier: '20.0.0', foundMajor: 20 },
+        { packageName: '@angular/core', specifier: '^21.0.0', foundMajor: 21 },
+      ]),
+    ).toBe(21);
+  });
+
+  it('falls back to the first mismatch when @angular/core is not mismatched', () => {
+    expect(
+      getRecommendedAngularMajor([
+        { packageName: '@angular/cli', specifier: '20.0.0', foundMajor: 20 },
+      ]),
+    ).toBe(20);
   });
 });

--- a/packages/schematics/tests/ng-add/index.test.ts
+++ b/packages/schematics/tests/ng-add/index.test.ts
@@ -476,7 +476,7 @@ describe('ng-add', () => {
       );
     });
 
-    it('should warn when the workspace Angular major does not match', async () => {
+    it('should error and tell the user what to rerun when the workspace Angular major does not match', async () => {
       workspaceTree.create(
         'package.json',
         JSON.stringify({
@@ -484,22 +484,37 @@ describe('ng-add', () => {
           devDependencies: { '@angular/cli': '21.2.0' },
         }),
       );
-      const messages: string[] = [];
-      const subscription = schematicRunner.logger.subscribe((entry) => {
-        messages.push(`${entry.level}: ${entry.message}`);
+      let error: unknown;
+      try {
+        await schematicRunner.runSchematic('ng-add', {}, workspaceTree);
+      } catch (e) {
+        error = e;
+      }
+      expect(error).toBeInstanceOf(Error);
+      const message = (error as Error).message;
+      expect(message).toContain(
+        'angular-eslint v22 is intended for Angular v22',
+      );
+      expect(message).toContain('@angular/core@^21.2.0 (v21)');
+      expect(message).toContain('@angular/cli@21.2.0 (v21)');
+      expect(message).toContain('ng add angular-eslint@21');
+      expect(message).toContain('ng add @angular-eslint/schematics@21');
+      expect(message).toContain('ANGULAR_VERSION_SUPPORT.md');
+    });
+
+    it('should not modify the workspace when the Angular major does not match', async () => {
+      const originalPackageJson = JSON.stringify({
+        dependencies: { '@angular/core': '^21.2.0' },
+        devDependencies: { '@angular/cli': '21.2.0' },
       });
-      await schematicRunner.runSchematic('ng-add', {}, workspaceTree);
-      subscription.unsubscribe();
-      expect(
-        messages.some(
-          (message) =>
-            message.startsWith('warn:') &&
-            message.includes(
-              'angular-eslint v22 is intended for Angular v22',
-            ) &&
-            message.includes('@angular/core@^21.2.0 (v21)'),
-        ),
-      ).toBe(true);
+      workspaceTree.create('package.json', originalPackageJson);
+      await expect(
+        schematicRunner.runSchematic('ng-add', {}, workspaceTree),
+      ).rejects.toThrow('ng add angular-eslint@21');
+      expect(workspaceTree.readContent('package.json')).toBe(
+        originalPackageJson,
+      );
+      expect(workspaceTree.exists('eslint.config.js')).toBe(false);
     });
 
     it('should confirm when the workspace Angular major matches', async () => {


### PR DESCRIPTION
`ng add angular-eslint` with no version always resolves to `latest`: the Angular CLI only consults `peerDependencies` when searching for a compatible version, and angular-eslint deliberately declares no peer on `@angular/cli` so that the CLI is not pulled into workspaces that only want ESLint. As a result a workspace on an older Angular major silently got the wrong angular-eslint major, with only a warning.

The ng-add schematic now throws before modifying any files when the workspace's `@angular/core` or `@angular/cli` major differs from the angular-eslint major, and the error names the exact command to rerun, e.g. `ng add angular-eslint@21`. `ng lint` and `ng update` migrations keep warning only.

Closes #2180