### PR TITLE
feat(schematics): add --tseslint-preset for strict and type-checked configs

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,14 @@ ng add angular-eslint
 
 ...and that's it!
 
+You can opt into typescript-eslint's `strict` or type-checked shared configs at the same time:
+
+```sh
+ng add angular-eslint --tseslint-preset=strictTypeChecked
+```
+
+Type-checked presets are more powerful but slower. See [RULES_REQUIRING_TYPE_INFORMATION.md](./docs/RULES_REQUIRING_TYPE_INFORMATION.md) for details.
+
 > NOTE: `ng add angular-eslint` installs the latest version, which is aligned with the latest Angular major. If your workspace is on an older Angular major, pin the matching major instead, e.g. `ng add angular-eslint@21` for an Angular v21 workspace. See [ANGULAR_VERSION_SUPPORT.md](./docs/ANGULAR_VERSION_SUPPORT.md) for details.
 
 As well as installing all relevant dependencies, the `ng add` command will automatically detect that you have a workspace with a single project in it, which does not have a linter configured yet. It can therefore go ahead and wire everything up for you!

--- a/docs/RULES_REQUIRING_TYPE_INFORMATION.md
+++ b/docs/RULES_REQUIRING_TYPE_INFORMATION.md
@@ -150,6 +150,18 @@ module.exports = tseslint.config(
 
 And that's it! Now any rules requiring type information will run correctly when we run `ng lint my-library`.
 
+## Scaffolding typed linting from `ng add`
+
+If you want typed linting (or typescript-eslint's `strict` rules) from the start, pass `--tseslint-preset` when adding `angular-eslint`. This is opt-in because type-checked linting is slower than the default recommended setup.
+
+```sh
+ng add angular-eslint --tseslint-preset=strictTypeChecked
+```
+
+Allowed values are `recommended` (default), `strict`, `recommendedTypeChecked`, and `strictTypeChecked`. Type-checked presets also enable the Project Service in the generated root config, which is required for those rules to run.
+
+The same option is accepted by `add-eslint-to-project`, `application`, and `library`, and is applied when those schematics create the root ESLint config.
+
 ## Generating new projects with typed linting configured automatically
 
 If your workspace is already leveraging rules requiring type information and you want any newly generated projects to be set up for typed linting automatically, you can add the `--set-parser-options-project` flag when generating the new application or library. This causes the generated `eslint.config.js` to include the Project Service:

--- a/docs/RULES_REQUIRING_TYPE_INFORMATION.md
+++ b/docs/RULES_REQUIRING_TYPE_INFORMATION.md
@@ -160,6 +160,8 @@ ng add angular-eslint --tseslint-preset=strictTypeChecked
 
 Allowed values are `recommended` (default), `strict`, `recommendedTypeChecked`, and `strictTypeChecked`. Type-checked presets also enable the Project Service in the generated root config, which is required for those rules to run.
 
+`strictTypeChecked` currently reports findings in Angular CLI's generated `src/main.ts` (the bootstrap `.catch(...)` callback). That is expected from the preset; adjust `main.ts` or override the rules if you want a clean baseline.
+
 The same option is accepted by `add-eslint-to-project`, `application`, and `library`, and is applied when those schematics create the root ESLint config.
 
 ## Generating new projects with typed linting configured automatically

--- a/e2e/src/new-workspace-tseslint-preset-recommended-type-checked.test.ts
+++ b/e2e/src/new-workspace-tseslint-preset-recommended-type-checked.test.ts
@@ -1,0 +1,51 @@
+import path from 'node:path';
+import { setWorkspaceRoot } from 'nx/src/utils/workspace-root';
+import { beforeAll, describe, expect, it, vi } from 'vitest';
+import {
+  FIXTURES_DIR,
+  Fixture,
+  resetFixtureDirectory,
+} from '../utils/fixtures';
+import {
+  LONG_TIMEOUT_MS,
+  runNgAdd,
+  runNgNew,
+} from '../utils/local-registry-process';
+import { runLint } from '../utils/run-lint';
+
+const fixtureDirectory =
+  'new-workspace-tseslint-preset-recommended-type-checked';
+let fixture: Fixture;
+
+describe('new-workspace with --tseslint-preset=recommendedTypeChecked', () => {
+  vi.setConfig({ testTimeout: LONG_TIMEOUT_MS });
+
+  beforeAll(async () => {
+    resetFixtureDirectory(fixtureDirectory);
+    process.chdir(FIXTURES_DIR);
+
+    await runNgNew(fixtureDirectory);
+
+    process.env.NX_DAEMON = 'false';
+    process.env.NX_CACHE_PROJECT_GRAPH = 'false';
+
+    const workspaceRoot = path.join(FIXTURES_DIR, fixtureDirectory);
+    process.chdir(workspaceRoot);
+    process.env.NX_WORKSPACE_ROOT_PATH = workspaceRoot;
+    setWorkspaceRoot(workspaceRoot);
+
+    fixture = new Fixture(workspaceRoot);
+
+    await runNgAdd(['--tseslint-preset=recommendedTypeChecked']);
+  });
+
+  it('should generate the recommended type-checked preset with the Project Service and pass linting', async () => {
+    const eslintConfig = fixture.readFile('eslint.config.js');
+    expect(eslintConfig).toContain('tseslint.configs.recommendedTypeChecked');
+    expect(eslintConfig).toContain('tseslint.configs.stylisticTypeChecked');
+    expect(eslintConfig).toContain('projectService: true');
+
+    const lintOutput = await runLint(fixtureDirectory);
+    expect(lintOutput).toContain('All files pass linting');
+  });
+});

--- a/e2e/src/new-workspace-tseslint-preset-strict-type-checked.test.ts
+++ b/e2e/src/new-workspace-tseslint-preset-strict-type-checked.test.ts
@@ -1,0 +1,53 @@
+import path from 'node:path';
+import { setWorkspaceRoot } from 'nx/src/utils/workspace-root';
+import { beforeAll, describe, expect, it, vi } from 'vitest';
+import {
+  FIXTURES_DIR,
+  Fixture,
+  resetFixtureDirectory,
+} from '../utils/fixtures';
+import {
+  LONG_TIMEOUT_MS,
+  runNgAdd,
+  runNgNew,
+} from '../utils/local-registry-process';
+import { runLint } from '../utils/run-lint';
+
+const fixtureDirectory = 'new-workspace-tseslint-preset-strict-type-checked';
+let fixture: Fixture;
+
+describe('new-workspace with --tseslint-preset=strictTypeChecked', () => {
+  vi.setConfig({ testTimeout: LONG_TIMEOUT_MS });
+
+  beforeAll(async () => {
+    resetFixtureDirectory(fixtureDirectory);
+    process.chdir(FIXTURES_DIR);
+
+    await runNgNew(fixtureDirectory);
+
+    process.env.NX_DAEMON = 'false';
+    process.env.NX_CACHE_PROJECT_GRAPH = 'false';
+
+    const workspaceRoot = path.join(FIXTURES_DIR, fixtureDirectory);
+    process.chdir(workspaceRoot);
+    process.env.NX_WORKSPACE_ROOT_PATH = workspaceRoot;
+    setWorkspaceRoot(workspaceRoot);
+
+    fixture = new Fixture(workspaceRoot);
+
+    await runNgAdd(['--tseslint-preset=strictTypeChecked']);
+  });
+
+  it('should generate the strict type-checked preset with the Project Service and pass linting', async () => {
+    const eslintConfig = fixture.readFile('eslint.config.js');
+    expect(eslintConfig).toContain('tseslint.configs.strictTypeChecked');
+    expect(eslintConfig).toContain('tseslint.configs.stylisticTypeChecked');
+    expect(eslintConfig).toContain('projectService: true');
+    expect(eslintConfig).toContain(
+      'Enable typed linting via the typescript-eslint Project Service',
+    );
+
+    const lintOutput = await runLint(fixtureDirectory);
+    expect(lintOutput).toContain('All files pass linting');
+  });
+});

--- a/e2e/src/new-workspace-tseslint-preset-strict-type-checked.test.ts
+++ b/e2e/src/new-workspace-tseslint-preset-strict-type-checked.test.ts
@@ -38,7 +38,7 @@ describe('new-workspace with --tseslint-preset=strictTypeChecked', () => {
     await runNgAdd(['--tseslint-preset=strictTypeChecked']);
   });
 
-  it('should generate the strict type-checked preset with the Project Service and pass linting', async () => {
+  it('should generate the strict type-checked preset with the Project Service', async () => {
     const eslintConfig = fixture.readFile('eslint.config.js');
     expect(eslintConfig).toContain('tseslint.configs.strictTypeChecked');
     expect(eslintConfig).toContain('tseslint.configs.stylisticTypeChecked');
@@ -48,6 +48,18 @@ describe('new-workspace with --tseslint-preset=strictTypeChecked', () => {
     );
 
     const lintOutput = await runLint(fixtureDirectory);
-    expect(lintOutput).toContain('All files pass linting');
+    // Angular CLI's generated src/main.ts currently uses
+    // `.catch((err) => console.error(err))`, which strictTypeChecked flags.
+    // Assert those known findings rather than a clean lint so we still notice
+    // if additional violations appear.
+    expect(lintOutput).toContain('src/main.ts');
+    expect(lintOutput).toContain(
+      '@typescript-eslint/use-unknown-in-catch-callback-variable',
+    );
+    expect(lintOutput).toContain(
+      '@typescript-eslint/no-confusing-void-expression',
+    );
+    expect(lintOutput).toContain('2 problems (2 errors, 0 warnings)');
+    expect(lintOutput).not.toContain('All files pass linting');
   });
 });

--- a/e2e/src/new-workspace-tseslint-preset-strict.test.ts
+++ b/e2e/src/new-workspace-tseslint-preset-strict.test.ts
@@ -1,0 +1,51 @@
+import path from 'node:path';
+import { setWorkspaceRoot } from 'nx/src/utils/workspace-root';
+import { beforeAll, describe, expect, it, vi } from 'vitest';
+import {
+  FIXTURES_DIR,
+  Fixture,
+  resetFixtureDirectory,
+} from '../utils/fixtures';
+import {
+  LONG_TIMEOUT_MS,
+  runNgAdd,
+  runNgNew,
+} from '../utils/local-registry-process';
+import { runLint } from '../utils/run-lint';
+
+const fixtureDirectory = 'new-workspace-tseslint-preset-strict';
+let fixture: Fixture;
+
+describe('new-workspace with --tseslint-preset=strict', () => {
+  vi.setConfig({ testTimeout: LONG_TIMEOUT_MS });
+
+  beforeAll(async () => {
+    resetFixtureDirectory(fixtureDirectory);
+    process.chdir(FIXTURES_DIR);
+
+    await runNgNew(fixtureDirectory);
+
+    process.env.NX_DAEMON = 'false';
+    process.env.NX_CACHE_PROJECT_GRAPH = 'false';
+
+    const workspaceRoot = path.join(FIXTURES_DIR, fixtureDirectory);
+    process.chdir(workspaceRoot);
+    process.env.NX_WORKSPACE_ROOT_PATH = workspaceRoot;
+    setWorkspaceRoot(workspaceRoot);
+
+    fixture = new Fixture(workspaceRoot);
+
+    await runNgAdd(['--tseslint-preset=strict']);
+  });
+
+  it('should generate the strict typescript-eslint preset and pass linting', async () => {
+    const eslintConfig = fixture.readFile('eslint.config.js');
+    expect(eslintConfig).toContain('tseslint.configs.strict');
+    expect(eslintConfig).toContain('tseslint.configs.stylistic');
+    expect(eslintConfig).not.toContain('projectService');
+    expect(eslintConfig).not.toContain('TypeChecked');
+
+    const lintOutput = await runLint(fixtureDirectory);
+    expect(lintOutput).toContain('All files pass linting');
+  });
+});

--- a/e2e/utils/local-registry-process.ts
+++ b/e2e/utils/local-registry-process.ts
@@ -35,7 +35,9 @@ export async function runNpmInstall(): Promise<
   return await runCommandOnLocalRegistry('npm', ['install']);
 }
 
-export async function runNgAdd(): Promise<execa.ExecaChildProcess<string>> {
+export async function runNgAdd(
+  extraArgs: string[] = [],
+): Promise<execa.ExecaChildProcess<string>> {
   /**
    * Force our e2e published version to be readily available on disk to
    * ensure that the @angular/cli resolves it correctly during `ng add`.
@@ -57,6 +59,7 @@ export async function runNgAdd(): Promise<execa.ExecaChildProcess<string>> {
     'add',
     `@angular-eslint/schematics@${publishedVersion}`,
     `--skip-confirmation`,
+    ...extraArgs,
   ]);
 }
 

--- a/packages/schematics/README.md
+++ b/packages/schematics/README.md
@@ -25,7 +25,7 @@ Allowed values:
 - `recommendedTypeChecked` — `tseslint.configs.recommendedTypeChecked` + `tseslint.configs.stylisticTypeChecked`, and enables `parserOptions.projectService`
 - `strictTypeChecked` — `tseslint.configs.strictTypeChecked` + `tseslint.configs.stylisticTypeChecked`, and enables `parserOptions.projectService`
 
-Type-checked presets make linting more powerful but slower. See [RULES_REQUIRING_TYPE_INFORMATION.md](../../docs/RULES_REQUIRING_TYPE_INFORMATION.md).
+Type-checked presets make linting more powerful but slower. See [RULES_REQUIRING_TYPE_INFORMATION.md](../../docs/RULES_REQUIRING_TYPE_INFORMATION.md). `strictTypeChecked` currently flags Angular CLI's generated `src/main.ts` bootstrap `.catch(...)` callback; that is expected from the preset.
 
 ```
 ng add @angular-eslint/schematics --tseslint-preset=strictTypeChecked

--- a/packages/schematics/README.md
+++ b/packages/schematics/README.md
@@ -13,3 +13,30 @@ Skips installing npm packages when running `ng add @angular-eslint/schematics`. 
 ```
 ng add @angular-eslint/schematics --skip-install
 ```
+
+### `--tseslint-preset`
+
+Chooses which typescript-eslint shared config the generated `eslint.config.js` extends. Defaults to `recommended`.
+
+Allowed values:
+
+- `recommended` — `tseslint.configs.recommended` + `tseslint.configs.stylistic` (default)
+- `strict` — `tseslint.configs.strict` + `tseslint.configs.stylistic`
+- `recommendedTypeChecked` — `tseslint.configs.recommendedTypeChecked` + `tseslint.configs.stylisticTypeChecked`, and enables `parserOptions.projectService`
+- `strictTypeChecked` — `tseslint.configs.strictTypeChecked` + `tseslint.configs.stylisticTypeChecked`, and enables `parserOptions.projectService`
+
+Type-checked presets make linting more powerful but slower. See [RULES_REQUIRING_TYPE_INFORMATION.md](../../docs/RULES_REQUIRING_TYPE_INFORMATION.md).
+
+```
+ng add @angular-eslint/schematics --tseslint-preset=strictTypeChecked
+```
+
+The same option is accepted by `add-eslint-to-project`, `application`, and `library`. It is applied when the root ESLint config is created.
+
+### `--set-parser-options-project`
+
+Enables `parserOptions.projectService` in the generated ESLint config so that rules requiring type information can run, without changing the typescript-eslint preset. Type-checked `tseslintPreset` values imply this option.
+
+```
+ng add @angular-eslint/schematics --set-parser-options-project
+```

--- a/packages/schematics/src/add-eslint-to-project/index.ts
+++ b/packages/schematics/src/add-eslint-to-project/index.ts
@@ -4,11 +4,14 @@ import {
   addESLintTargetToProject,
   createESLintConfigForProject,
   determineTargetProjectName,
+  resolveTseslintPreset,
+  type TseslintPreset,
 } from '../utils';
 
 interface Schema {
   project?: string;
   setParserOptionsProject?: boolean;
+  tseslintPreset?: TseslintPreset;
 }
 
 export default function addESLintToProject(schema: Schema): Rule {
@@ -29,6 +32,7 @@ E.g. npx ng g @angular-eslint/schematics:add-eslint-to-project {{YOUR_PROJECT_NA
       createESLintConfigForProject(
         projectName,
         schema.setParserOptionsProject ?? false,
+        resolveTseslintPreset(schema.tseslintPreset),
       ),
       // Set the lint builder and config in angular.json
       addESLintTargetToProject(projectName, 'lint'),

--- a/packages/schematics/src/add-eslint-to-project/schema.json
+++ b/packages/schematics/src/add-eslint-to-project/schema.json
@@ -14,8 +14,19 @@
     },
     "setParserOptionsProject": {
       "type": "boolean",
-      "description": "Whether or not to enable rules that require type information by configuring the ESLint `parserOptions.projectService` option. We do not do this by default for lint performance reasons.",
+      "description": "Whether or not to enable rules that require type information by configuring the ESLint `parserOptions.projectService` option. We do not do this by default for lint performance reasons. Implied when tseslintPreset is a type-checked preset.",
       "default": false
+    },
+    "tseslintPreset": {
+      "type": "string",
+      "enum": [
+        "recommended",
+        "strict",
+        "recommendedTypeChecked",
+        "strictTypeChecked"
+      ],
+      "default": "recommended",
+      "description": "Which typescript-eslint shared config preset to extend in the generated ESLint config. Type-checked presets also enable parserOptions.projectService (required for those rules, but slower). See https://typescript-eslint.io/users/configs/"
     }
   },
   "required": []

--- a/packages/schematics/src/application/index.ts
+++ b/packages/schematics/src/application/index.ts
@@ -9,10 +9,13 @@ import type { Schema as AngularSchema } from '@schematics/angular/application/sc
 import {
   addESLintTargetToProject,
   createESLintConfigForProject,
+  resolveTseslintPreset,
+  type TseslintPreset,
 } from '../utils';
 
 interface Schema extends AngularSchema {
   setParserOptionsProject?: boolean;
+  tseslintPreset?: TseslintPreset;
 }
 
 function eslintRelatedChanges(options: Schema) {
@@ -21,6 +24,7 @@ function eslintRelatedChanges(options: Schema) {
     createESLintConfigForProject(
       options.name,
       options.setParserOptionsProject ?? false,
+      resolveTseslintPreset(options.tseslintPreset),
     ),
     // Update the lint builder and config in angular.json
     addESLintTargetToProject(options.name, 'lint'),
@@ -31,7 +35,8 @@ export default function (options: Schema): Rule {
   return (host: Tree, context: SchematicContext) => {
     // Remove angular-eslint specific options before passing to the Angular schematic
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    const { setParserOptionsProject, ...angularOptions } = options;
+    const { setParserOptionsProject, tseslintPreset, ...angularOptions } =
+      options;
 
     return chain([
       externalSchematic('@schematics/angular', 'application', angularOptions),

--- a/packages/schematics/src/application/schema.json
+++ b/packages/schematics/src/application/schema.json
@@ -141,8 +141,19 @@
     },
     "setParserOptionsProject": {
       "type": "boolean",
-      "description": "Whether or not to enable rules that require type information by configuring the ESLint `parserOptions.projectService` option. We do not do this by default for lint performance reasons.",
+      "description": "Whether or not to enable rules that require type information by configuring the ESLint `parserOptions.projectService` option. We do not do this by default for lint performance reasons. Implied when tseslintPreset is a type-checked preset.",
       "default": false
+    },
+    "tseslintPreset": {
+      "type": "string",
+      "enum": [
+        "recommended",
+        "strict",
+        "recommendedTypeChecked",
+        "strictTypeChecked"
+      ],
+      "default": "recommended",
+      "description": "Which typescript-eslint shared config preset to extend in the generated ESLint config. Type-checked presets also enable parserOptions.projectService (required for those rules, but slower). See https://typescript-eslint.io/users/configs/"
     }
   },
   "required": ["name"]

--- a/packages/schematics/src/library/index.ts
+++ b/packages/schematics/src/library/index.ts
@@ -9,10 +9,13 @@ import type { Schema as AngularSchema } from '@schematics/angular/library/schema
 import {
   addESLintTargetToProject,
   createESLintConfigForProject,
+  resolveTseslintPreset,
+  type TseslintPreset,
 } from '../utils';
 
 interface Schema extends AngularSchema {
   setParserOptionsProject?: boolean;
+  tseslintPreset?: TseslintPreset;
 }
 
 function eslintRelatedChanges(options: Schema) {
@@ -21,6 +24,7 @@ function eslintRelatedChanges(options: Schema) {
     createESLintConfigForProject(
       options.name,
       options.setParserOptionsProject ?? false,
+      resolveTseslintPreset(options.tseslintPreset),
     ),
     // Update the lint builder and config in angular.json
     addESLintTargetToProject(options.name, 'lint'),
@@ -31,7 +35,8 @@ export default function (options: Schema): Rule {
   return (host: Tree, context: SchematicContext) => {
     // Remove angular-eslint specific options before passing to the Angular schematic
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    const { setParserOptionsProject, ...angularOptions } = options;
+    const { setParserOptionsProject, tseslintPreset, ...angularOptions } =
+      options;
 
     return chain([
       externalSchematic('@schematics/angular', 'library', angularOptions),

--- a/packages/schematics/src/library/schema.json
+++ b/packages/schematics/src/library/schema.json
@@ -62,8 +62,19 @@
     },
     "setParserOptionsProject": {
       "type": "boolean",
-      "description": "Whether or not to enable rules that require type information by configuring the ESLint `parserOptions.projectService` option. We do not do this by default for lint performance reasons.",
+      "description": "Whether or not to enable rules that require type information by configuring the ESLint `parserOptions.projectService` option. We do not do this by default for lint performance reasons. Implied when tseslintPreset is a type-checked preset.",
       "default": false
+    },
+    "tseslintPreset": {
+      "type": "string",
+      "enum": [
+        "recommended",
+        "strict",
+        "recommendedTypeChecked",
+        "strictTypeChecked"
+      ],
+      "default": "recommended",
+      "description": "Which typescript-eslint shared config preset to extend in the generated ESLint config. Type-checked presets also enable parserOptions.projectService (required for those rules, but slower). See https://typescript-eslint.io/users/configs/"
     }
   },
   "required": ["name"]

--- a/packages/schematics/src/ng-add/index.ts
+++ b/packages/schematics/src/ng-add/index.ts
@@ -18,9 +18,12 @@ import {
   createStringifiedRootESLintConfig,
   getTargetsConfigFromProject,
   readJsonInTree,
+  resolveTseslintPreset,
+  shouldEnableProjectService,
   sortObjectByKeys,
   updateJsonInTree,
   updateSchematicCollections,
+  warnIfTypeCheckedPreset,
 } from '../utils';
 
 const packageJSON = require('../../package.json');
@@ -119,8 +122,13 @@ function applyDevDependenciesForFlatConfig(
   delete json.devDependencies['@typescript-eslint/utils'];
 }
 
-function applyESLintConfigIfSingleProjectWithNoExistingTSLint() {
+function applyESLintConfigIfSingleProjectWithNoExistingTSLint(options: Schema) {
   return (host: Tree, context: SchematicContext) => {
+    const tseslintPreset = resolveTseslintPreset(options.tseslintPreset);
+    const setParserOptionsProject = shouldEnableProjectService(
+      options.setParserOptionsProject ?? false,
+      tseslintPreset,
+    );
     const angularJson = readJsonInTree(host, 'angular.json');
     if (!angularJson || !angularJson.projects) {
       return;
@@ -136,16 +144,20 @@ function applyESLintConfigIfSingleProjectWithNoExistingTSLint() {
      */
     const projectNames = Object.keys(angularJson.projects);
     if (projectNames.length === 0) {
+      warnIfTypeCheckedPreset(context, tseslintPreset);
       return chain([
-        (host) => {
+        (tree) => {
           // If the root package.json uses type: module, generate ESM content
-          const packageJson = readJsonInTree(host, 'package.json');
+          const packageJson = readJsonInTree(tree, 'package.json');
           const isESM = packageJson.type === 'module';
-          host.create(
+          tree.create(
             'eslint.config.js',
-            createStringifiedRootESLintConfig(null, isESM),
+            createStringifiedRootESLintConfig(null, isESM, {
+              tseslintPreset,
+              setParserOptionsProject,
+            }),
           );
-          return host;
+          return tree;
         },
         updateJsonInTree('angular.json', (json) =>
           updateSchematicCollections(json, 'angular-eslint'),
@@ -183,7 +195,10 @@ Please see https://github.com/angular-eslint/angular-eslint for more information
     );
 
     return chain([
-      schematic('add-eslint-to-project', {}),
+      schematic('add-eslint-to-project', {
+        tseslintPreset,
+        setParserOptionsProject,
+      }),
       updateJsonInTree('angular.json', (json) =>
         updateSchematicCollections(json, 'angular-eslint'),
       ),
@@ -239,7 +254,7 @@ export default function (options: Schema): Rule {
 
     return chain([
       addAngularESLintPackages(json, options),
-      applyESLintConfigIfSingleProjectWithNoExistingTSLint(),
+      applyESLintConfigIfSingleProjectWithNoExistingTSLint(options),
     ])(host, context);
   };
 }

--- a/packages/schematics/src/ng-add/schema.json
+++ b/packages/schematics/src/ng-add/schema.json
@@ -9,6 +9,22 @@
       "description": "Skip package installation after adding dependencies",
       "default": false,
       "alias": "skip-install"
+    },
+    "setParserOptionsProject": {
+      "type": "boolean",
+      "description": "Whether or not to enable rules that require type information by configuring the ESLint `parserOptions.projectService` option. We do not do this by default for lint performance reasons. Implied when tseslintPreset is a type-checked preset.",
+      "default": false
+    },
+    "tseslintPreset": {
+      "type": "string",
+      "enum": [
+        "recommended",
+        "strict",
+        "recommendedTypeChecked",
+        "strictTypeChecked"
+      ],
+      "default": "recommended",
+      "description": "Which typescript-eslint shared config preset to extend in the generated ESLint config. Type-checked presets also enable parserOptions.projectService (required for those rules, but slower). See https://typescript-eslint.io/users/configs/"
     }
   },
   "required": []

--- a/packages/schematics/src/ng-add/schema.ts
+++ b/packages/schematics/src/ng-add/schema.ts
@@ -1,3 +1,5 @@
+import type { TseslintPreset } from '../utils';
+
 /**
  * Options available to the ng-add schematic.
  */
@@ -6,4 +8,13 @@ export interface Schema {
    * Skip installing dependencies after modifying package.json.
    */
   skipInstall?: boolean;
+  /**
+   * Enable rules that require type information by configuring
+   * `parserOptions.projectService`. Implied by type-checked tseslintPreset values.
+   */
+  setParserOptionsProject?: boolean;
+  /**
+   * typescript-eslint shared config preset to extend in the generated ESLint config.
+   */
+  tseslintPreset?: TseslintPreset;
 }

--- a/packages/schematics/src/utils.ts
+++ b/packages/schematics/src/utils.ts
@@ -224,10 +224,108 @@ export function visitNotIgnoredFiles(
 
 type ProjectType = 'application' | 'library';
 
+/**
+ * typescript-eslint shared config presets that the schematics can scaffold.
+ *
+ * Type-checked variants also enable `parserOptions.projectService` in the
+ * generated root config, which is required for those rules to run.
+ */
+export const TS_ESLINT_PRESETS = [
+  'recommended',
+  'strict',
+  'recommendedTypeChecked',
+  'strictTypeChecked',
+] as const;
+
+export type TseslintPreset = (typeof TS_ESLINT_PRESETS)[number];
+
+export const DEFAULT_TS_ESLINT_PRESET: TseslintPreset = 'recommended';
+
+export interface CreateRootESLintConfigOptions {
+  tseslintPreset?: TseslintPreset;
+  setParserOptionsProject?: boolean;
+}
+
+export function isTypeCheckedTseslintPreset(preset: TseslintPreset): boolean {
+  return preset === 'recommendedTypeChecked' || preset === 'strictTypeChecked';
+}
+
+export function resolveTseslintPreset(
+  value: string | undefined,
+): TseslintPreset {
+  if (value && (TS_ESLINT_PRESETS as readonly string[]).includes(value)) {
+    return value as TseslintPreset;
+  }
+  return DEFAULT_TS_ESLINT_PRESET;
+}
+
+export function shouldEnableProjectService(
+  setParserOptionsProject: boolean,
+  tseslintPreset: TseslintPreset = DEFAULT_TS_ESLINT_PRESET,
+): boolean {
+  return setParserOptionsProject || isTypeCheckedTseslintPreset(tseslintPreset);
+}
+
+export function warnIfTypeCheckedPreset(
+  context: SchematicContext,
+  tseslintPreset: TseslintPreset,
+): void {
+  if (!isTypeCheckedTseslintPreset(tseslintPreset)) {
+    return;
+  }
+  context.logger.warn(
+    `Typed linting is enabled because tseslintPreset="${tseslintPreset}". This makes ESLint more powerful but slower than the default recommended preset. See https://github.com/angular-eslint/angular-eslint/blob/main/docs/RULES_REQUIRING_TYPE_INFORMATION.md`,
+  );
+}
+
+function getTsEslintExtendsSnippet(preset: TseslintPreset): string {
+  switch (preset) {
+    case 'strict':
+      return `tseslint.configs.strict,
+      tseslint.configs.stylistic,`;
+    case 'recommendedTypeChecked':
+      return `tseslint.configs.recommendedTypeChecked,
+      tseslint.configs.stylisticTypeChecked,`;
+    case 'strictTypeChecked':
+      return `tseslint.configs.strictTypeChecked,
+      tseslint.configs.stylisticTypeChecked,`;
+    case 'recommended':
+    default:
+      return `tseslint.configs.recommended,
+      tseslint.configs.stylistic,`;
+  }
+}
+
+function getProjectServiceBlock(
+  enabled: boolean,
+  includeTypeCheckedComment: boolean,
+): string {
+  if (!enabled) {
+    return '';
+  }
+  const comment = includeTypeCheckedComment
+    ? `
+    // Enable typed linting via the typescript-eslint Project Service.
+    // This is slower than untyped linting; see https://typescript-eslint.io/getting-started/typed-linting`
+    : '';
+  return `${comment}
+    languageOptions: {
+      parserOptions: {
+        projectService: true,
+      },
+    },`;
+}
+
 export function createStringifiedRootESLintConfig(
   prefix: string | null,
   isESM: boolean,
+  options: CreateRootESLintConfigOptions = {},
 ): string {
+  const tseslintPreset = resolveTseslintPreset(options.tseslintPreset);
+  const includeProjectService = shouldEnableProjectService(
+    options.setParserOptionsProject ?? false,
+    tseslintPreset,
+  );
   return `// @ts-check
 ${isESM ? 'import eslint from "@eslint/js";' : 'const eslint = require("@eslint/js");'}
 ${isESM ? 'import { defineConfig } from "eslint/config";' : 'const { defineConfig } = require("eslint/config");'}
@@ -236,11 +334,13 @@ ${isESM ? 'import angular from "angular-eslint";' : 'const angular = require("an
 
 ${isESM ? 'export default' : 'module.exports ='} defineConfig([
   {
-    files: ["**/*.ts"],
+    files: ["**/*.ts"],${getProjectServiceBlock(
+      includeProjectService,
+      isTypeCheckedTseslintPreset(tseslintPreset),
+    )}
     extends: [
       eslint.configs.recommended,
-      tseslint.configs.recommended,
-      tseslint.configs.stylistic,
+      ${getTsEslintExtendsSnippet(tseslintPreset)}
       angular.configs.tsRecommended,
     ],
     processor: angular.processInlineTemplates,
@@ -335,8 +435,16 @@ ${isESM ? 'export default' : 'module.exports ='} defineConfig([
 export function createESLintConfigForProject(
   projectName: string,
   setParserOptionsProject: boolean,
+  tseslintPreset: TseslintPreset = DEFAULT_TS_ESLINT_PRESET,
 ): Rule {
-  return (tree: Tree) => {
+  return (tree: Tree, context: SchematicContext) => {
+    const resolvedPreset = resolveTseslintPreset(tseslintPreset);
+    const enableProjectService = shouldEnableProjectService(
+      setParserOptionsProject,
+      resolvedPreset,
+    );
+    warnIfTypeCheckedPreset(context, resolvedPreset);
+
     const angularJSON = readJsonInTree(tree, 'angular.json');
     const {
       root: projectRoot,
@@ -348,36 +456,46 @@ export function createESLintConfigForProject(
       tree.exists(name),
     );
 
+    const rootConfigOptions: CreateRootESLintConfigOptions = {
+      tseslintPreset: resolvedPreset,
+      setParserOptionsProject: enableProjectService,
+    };
+
     /**
      * If the root is an empty string it must be the initial project created at the
      * root by the Angular CLI's workspace schematic
      */
     if (projectRoot === '') {
-      return createRootESLintConfigFile(prefix || DEFAULT_PREFIX);
+      return createRootESLintConfigFile(
+        prefix || DEFAULT_PREFIX,
+        rootConfigOptions,
+      );
     }
 
     const rules = [];
 
     // If, for whatever reason, the root eslint.config.* doesn't exist yet, create it
     if (!alreadyHasRootFlatConfig) {
-      rules.push(createRootESLintConfigFile(prefix || DEFAULT_PREFIX));
+      rules.push(
+        createRootESLintConfigFile(prefix || DEFAULT_PREFIX, rootConfigOptions),
+      );
     }
 
     const rootConfigPath =
       resolveRootESLintConfigPath(tree) ?? 'eslint.config.js';
-    rules.push((tree: Tree) => {
+    rules.push((host: Tree) => {
       const { isESM, ext } = determineNewProjectESLintConfigContentAndExtension(
-        tree,
+        host,
         rootConfigPath,
         projectRoot,
       );
-      return tree.create(
+      return host.create(
         join(normalize(projectRoot), `eslint.config.${ext}`),
         createStringifiedProjectESLintConfig(
           projectRoot,
           projectType || 'library',
           prefix || DEFAULT_PREFIX,
-          setParserOptionsProject,
+          enableProjectService,
           isESM,
           rootConfigPath,
         ),
@@ -388,14 +506,17 @@ export function createESLintConfigForProject(
   };
 }
 
-function createRootESLintConfigFile(prefix: string): Rule {
+function createRootESLintConfigFile(
+  prefix: string | null,
+  options: CreateRootESLintConfigOptions = {},
+): Rule {
   return (tree) => {
     // If the root package.json uses type: module, generate ESM content
     const packageJson = readJsonInTree(tree, 'package.json');
     const isESM = packageJson.type === 'module';
     return tree.create(
       'eslint.config.js',
-      createStringifiedRootESLintConfig(prefix, isESM),
+      createStringifiedRootESLintConfig(prefix, isESM, options),
     );
   };
 }

--- a/packages/schematics/tests/add-eslint-to-project/index.test.ts
+++ b/packages/schematics/tests/add-eslint-to-project/index.test.ts
@@ -154,6 +154,22 @@ describe('add-eslint-to-project', () => {
         `);
     });
 
+    it('should apply tseslintPreset=strictTypeChecked to the root project config', async () => {
+      await schematicRunner.runSchematic(
+        'add-eslint-to-project',
+        {
+          project: rootProjectName,
+          tseslintPreset: 'strictTypeChecked',
+        },
+        appTree,
+      );
+
+      const eslintConfig = appTree.read('eslint.config.js')?.toString() ?? '';
+      expect(eslintConfig).toContain('tseslint.configs.strictTypeChecked');
+      expect(eslintConfig).toContain('tseslint.configs.stylisticTypeChecked');
+      expect(eslintConfig).toContain('projectService: true');
+    });
+
     it('should add ESLint to the legacy Angular CLI projects which are generated with e2e after the workspace already exists', async () => {
       const options = {
         project: legacyProjectName,
@@ -431,6 +447,31 @@ describe('add-eslint-to-project', () => {
           ]);
           "
         `);
+      });
+    });
+
+    describe('--tseslintPreset=strictTypeChecked', () => {
+      it('should put type-checked presets in the created root config for an additional project', async () => {
+        await schematicRunner.runSchematic(
+          'add-eslint-to-project',
+          {
+            project: otherProjectName,
+            tseslintPreset: 'strictTypeChecked',
+          },
+          appTree,
+        );
+
+        expect(appTree.read('eslint.config.js')?.toString()).toContain(
+          'tseslint.configs.strictTypeChecked',
+        );
+        expect(appTree.read('eslint.config.js')?.toString()).toContain(
+          'projectService: true',
+        );
+        expect(
+          appTree
+            .read(`projects/${otherProjectName}/eslint.config.js`)
+            ?.toString(),
+        ).toContain('projectService: true');
       });
     });
 

--- a/packages/schematics/tests/application/index.test.ts
+++ b/packages/schematics/tests/application/index.test.ts
@@ -156,6 +156,28 @@ describe('application', () => {
         `);
     });
 
+    it('should add the ESLint config for the project (--tseslintPreset=strictTypeChecked)', async () => {
+      const tree = await schematicRunner.runSchematic(
+        'application',
+        {
+          name: 'foo',
+          prefix: 'something-custom',
+          tseslintPreset: 'strictTypeChecked',
+        },
+        appTree,
+      );
+
+      expect(tree.read('eslint.config.js')?.toString()).toContain(
+        'tseslint.configs.strictTypeChecked',
+      );
+      expect(tree.read('eslint.config.js')?.toString()).toContain(
+        'projectService: true',
+      );
+      expect(tree.read('projects/foo/eslint.config.js')?.toString()).toContain(
+        'projectService: true',
+      );
+    });
+
     it('should add an appropriate ESLint config extends for a project with a scope in its name', async () => {
       const tree = await schematicRunner.runSchematic(
         'application',

--- a/packages/schematics/tests/library/index.test.ts
+++ b/packages/schematics/tests/library/index.test.ts
@@ -156,6 +156,28 @@ describe('library', () => {
         `);
     });
 
+    it('should add the ESLint config for the project (--tseslintPreset=strictTypeChecked)', async () => {
+      const tree = await schematicRunner.runSchematic(
+        'library',
+        {
+          name: 'bar',
+          prefix: 'something-else-custom',
+          tseslintPreset: 'strictTypeChecked',
+        },
+        appTree,
+      );
+
+      expect(tree.read('eslint.config.js')?.toString()).toContain(
+        'tseslint.configs.strictTypeChecked',
+      );
+      expect(tree.read('eslint.config.js')?.toString()).toContain(
+        'projectService: true',
+      );
+      expect(tree.read('projects/bar/eslint.config.js')?.toString()).toContain(
+        'projectService: true',
+      );
+    });
+
     it('should add an appropriate ESLint config extends for a project with a scope in its name', async () => {
       const tree = await schematicRunner.runSchematic(
         'library',

--- a/packages/schematics/tests/ng-add/index.test.ts
+++ b/packages/schematics/tests/ng-add/index.test.ts
@@ -183,6 +183,65 @@ describe('ng-add', () => {
           "
         `);
       });
+
+      it('should create a type-checked root ESLint config when tseslintPreset is strictTypeChecked', async () => {
+        const tree = await schematicRunner.runSchematic(
+          'ng-add',
+          { tseslintPreset: 'strictTypeChecked' },
+          workspaceTree,
+        );
+        const eslintConfig = tree.readContent('/eslint.config.js');
+        expect(eslintConfig).toContain('tseslint.configs.strictTypeChecked');
+        expect(eslintConfig).toContain('tseslint.configs.stylisticTypeChecked');
+        expect(eslintConfig).toContain('projectService: true');
+        expect(eslintConfig).toContain(
+          'Enable typed linting via the typescript-eslint Project Service',
+        );
+      });
+
+      it('should create a strict root ESLint config without the Project Service', async () => {
+        const tree = await schematicRunner.runSchematic(
+          'ng-add',
+          { tseslintPreset: 'strict' },
+          workspaceTree,
+        );
+        const eslintConfig = tree.readContent('/eslint.config.js');
+        expect(eslintConfig).toContain('tseslint.configs.strict');
+        expect(eslintConfig).toContain('tseslint.configs.stylistic');
+        expect(eslintConfig).not.toContain('projectService');
+        expect(eslintConfig).not.toContain('TypeChecked');
+      });
+
+      it('should enable the Project Service on the root config when setParserOptionsProject is true', async () => {
+        const tree = await schematicRunner.runSchematic(
+          'ng-add',
+          { setParserOptionsProject: true },
+          workspaceTree,
+        );
+        const eslintConfig = tree.readContent('/eslint.config.js');
+        expect(eslintConfig).toContain('tseslint.configs.recommended');
+        expect(eslintConfig).toContain('projectService: true');
+      });
+
+      it('should warn when a type-checked preset is selected', async () => {
+        const messages: string[] = [];
+        const subscription = schematicRunner.logger.subscribe((entry) => {
+          messages.push(`${entry.level}: ${entry.message}`);
+        });
+        await schematicRunner.runSchematic(
+          'ng-add',
+          { tseslintPreset: 'recommendedTypeChecked' },
+          workspaceTree,
+        );
+        subscription.unsubscribe();
+        expect(
+          messages.some((message) =>
+            message.includes(
+              'Typed linting is enabled because tseslintPreset="recommendedTypeChecked"',
+            ),
+          ),
+        ).toBe(true);
+      });
     });
 
     describe('workspace created with `--create-application=false` - no existings projects', () => {
@@ -302,6 +361,20 @@ describe('ng-add', () => {
           ]);
           "
         `);
+      });
+
+      it('should apply tseslintPreset to the root config when there are no projects', async () => {
+        const tree = await schematicRunner.runSchematic(
+          'ng-add',
+          { tseslintPreset: 'strictTypeChecked' },
+          workspaceTree,
+        );
+        const eslintConfig = tree.readContent('/eslint.config.js');
+        expect(eslintConfig).toContain('tseslint.configs.strictTypeChecked');
+        expect(eslintConfig).toContain('projectService: true');
+        expect(eslintConfig).not.toContain(
+          '@angular-eslint/directive-selector',
+        );
       });
     });
 

--- a/packages/schematics/tests/utils.test.ts
+++ b/packages/schematics/tests/utils.test.ts
@@ -12,8 +12,11 @@ import {
   determineNewProjectESLintConfigContentAndExtension,
   determineTargetProjectName,
   getTargetsConfigFromProject,
+  isTypeCheckedTseslintPreset,
   readJsonInTree,
   resolveRootESLintConfigPath,
+  resolveTseslintPreset,
+  shouldEnableProjectService,
   sortObjectByKeys,
   updateJsonInTree,
   updateSchematicCollections,
@@ -421,14 +424,49 @@ describe('updateSchematicDefaults', () => {
   });
 });
 
+describe('tseslintPreset helpers', () => {
+  it('should resolve known presets and fall back to recommended', () => {
+    expect(resolveTseslintPreset('recommended')).toBe('recommended');
+    expect(resolveTseslintPreset('strict')).toBe('strict');
+    expect(resolveTseslintPreset('recommendedTypeChecked')).toBe(
+      'recommendedTypeChecked',
+    );
+    expect(resolveTseslintPreset('strictTypeChecked')).toBe(
+      'strictTypeChecked',
+    );
+    expect(resolveTseslintPreset(undefined)).toBe('recommended');
+    expect(resolveTseslintPreset('nope')).toBe('recommended');
+  });
+
+  it('should identify type-checked presets', () => {
+    expect(isTypeCheckedTseslintPreset('recommended')).toBe(false);
+    expect(isTypeCheckedTseslintPreset('strict')).toBe(false);
+    expect(isTypeCheckedTseslintPreset('recommendedTypeChecked')).toBe(true);
+    expect(isTypeCheckedTseslintPreset('strictTypeChecked')).toBe(true);
+  });
+
+  it('should enable the Project Service for the explicit flag or type-checked presets', () => {
+    expect(shouldEnableProjectService(false, 'recommended')).toBe(false);
+    expect(shouldEnableProjectService(true, 'recommended')).toBe(true);
+    expect(shouldEnableProjectService(false, 'strict')).toBe(false);
+    expect(shouldEnableProjectService(false, 'recommendedTypeChecked')).toBe(
+      true,
+    );
+    expect(shouldEnableProjectService(false, 'strictTypeChecked')).toBe(true);
+  });
+});
+
 describe('createStringifiedRootESLintConfig', () => {
   it('should generate a CommonJS config with selector rules when a prefix is given', () => {
     const content = createStringifiedRootESLintConfig('app', false);
     expect(content).toContain('const eslint = require("@eslint/js");');
     expect(content).toContain('module.exports = defineConfig([');
     expect(content).toContain('angular.configs.tsRecommended');
+    expect(content).toContain('tseslint.configs.recommended');
+    expect(content).toContain('tseslint.configs.stylistic');
     expect(content).toContain('@angular-eslint/directive-selector');
     expect(content).toContain('prefix: "app"');
+    expect(content).not.toContain('projectService');
   });
 
   it('should generate an ESM config when isESM is true', () => {
@@ -442,6 +480,84 @@ describe('createStringifiedRootESLintConfig', () => {
     const content = createStringifiedRootESLintConfig(null, false);
     expect(content).not.toContain('@angular-eslint/directive-selector');
     expect(content).not.toContain('@angular-eslint/component-selector');
+  });
+
+  it('should extend the strict typescript-eslint configs when tseslintPreset is strict', () => {
+    const content = createStringifiedRootESLintConfig('app', false, {
+      tseslintPreset: 'strict',
+    });
+    expect(content).toContain('tseslint.configs.strict');
+    expect(content).toContain('tseslint.configs.stylistic');
+    expect(content).not.toContain('tseslint.configs.recommended');
+    expect(content).not.toContain('TypeChecked');
+    expect(content).not.toContain('projectService');
+  });
+
+  it('should extend recommendedTypeChecked configs and enable the Project Service', () => {
+    const content = createStringifiedRootESLintConfig('app', false, {
+      tseslintPreset: 'recommendedTypeChecked',
+    });
+    expect(content).toContain('tseslint.configs.recommendedTypeChecked');
+    expect(content).toContain('tseslint.configs.stylisticTypeChecked');
+    expect(content).toContain('projectService: true');
+    expect(content).toContain(
+      'Enable typed linting via the typescript-eslint Project Service',
+    );
+    expect(content).not.toContain('tseslint.configs.recommended,');
+  });
+
+  it('should extend strictTypeChecked configs and enable the Project Service', () => {
+    const content = createStringifiedRootESLintConfig(null, false, {
+      tseslintPreset: 'strictTypeChecked',
+    });
+    expect(content).toMatchInlineSnapshot(`
+      "// @ts-check
+      const eslint = require("@eslint/js");
+      const { defineConfig } = require("eslint/config");
+      const tseslint = require("typescript-eslint");
+      const angular = require("angular-eslint");
+
+      module.exports = defineConfig([
+        {
+          files: ["**/*.ts"],
+          // Enable typed linting via the typescript-eslint Project Service.
+          // This is slower than untyped linting; see https://typescript-eslint.io/getting-started/typed-linting
+          languageOptions: {
+            parserOptions: {
+              projectService: true,
+            },
+          },
+          extends: [
+            eslint.configs.recommended,
+            tseslint.configs.strictTypeChecked,
+            tseslint.configs.stylisticTypeChecked,
+            angular.configs.tsRecommended,
+          ],
+          processor: angular.processInlineTemplates,
+          rules: {},
+        },
+        {
+          files: ["**/*.html"],
+          extends: [
+            angular.configs.templateRecommended,
+            angular.configs.templateAccessibility,
+          ],
+          rules: {},
+        }
+      ]);
+      "
+    `);
+  });
+
+  it('should include the Project Service for the recommended preset when setParserOptionsProject is true', () => {
+    const content = createStringifiedRootESLintConfig('app', false, {
+      setParserOptionsProject: true,
+    });
+    expect(content).toContain('tseslint.configs.recommended');
+    expect(content).toContain('projectService: true');
+    expect(content).not.toContain(
+      'Enable typed linting via the typescript-eslint Project Service',
+    );
   });
 });
 
@@ -602,6 +718,78 @@ describe('createESLintConfigForProject', () => {
     );
 
     expect(result.exists('libs/lib/eslint.config.js')).toBe(true);
+    expect(result.readContent('libs/lib/eslint.config.js')).toContain(
+      'projectService: true',
+    );
+  });
+
+  it('should include the Project Service in the root config for a root project when setParserOptionsProject is true', async () => {
+    const tree = new UnitTestTree(Tree.empty());
+    tree.create('package.json', JSON.stringify({}));
+    tree.create(
+      'angular.json',
+      JSON.stringify({
+        version: 1,
+        projects: {
+          root: { root: '', projectType: 'application', prefix: 'app' },
+        },
+      }),
+    );
+
+    const result = await runRule(
+      createESLintConfigForProject('root', true),
+      tree,
+    );
+
+    const content = result.readContent('eslint.config.js');
+    expect(content).toContain('projectService: true');
+    expect(content).toContain('tseslint.configs.recommended');
+  });
+
+  it('should put type-checked presets and the Project Service in the root config', async () => {
+    const tree = new UnitTestTree(Tree.empty());
+    tree.create('package.json', JSON.stringify({}));
+    tree.create(
+      'angular.json',
+      JSON.stringify({
+        version: 1,
+        projects: {
+          root: { root: '', projectType: 'application', prefix: 'app' },
+        },
+      }),
+    );
+
+    const result = await runRule(
+      createESLintConfigForProject('root', false, 'strictTypeChecked'),
+      tree,
+    );
+
+    const content = result.readContent('eslint.config.js');
+    expect(content).toContain('tseslint.configs.strictTypeChecked');
+    expect(content).toContain('tseslint.configs.stylisticTypeChecked');
+    expect(content).toContain('projectService: true');
+  });
+
+  it('should enable the Project Service on an additional project for a type-checked preset', async () => {
+    const tree = new UnitTestTree(Tree.empty());
+    tree.create('package.json', JSON.stringify({}));
+    tree.create('eslint.config.js', 'module.exports = [];');
+    tree.create(
+      'angular.json',
+      JSON.stringify({
+        version: 1,
+        projects: {
+          lib: { root: 'libs/lib', projectType: 'library', prefix: 'lib' },
+        },
+      }),
+    );
+
+    const result = await runRule(
+      createESLintConfigForProject('lib', false, 'recommendedTypeChecked'),
+      tree,
+    );
+
+    expect(result.readContent('eslint.config.js')).toBe('module.exports = [];');
     expect(result.readContent('libs/lib/eslint.config.js')).toContain(
       'projectService: true',
     );

--- a/tools/scripts/enhance-angular-schemas.ts
+++ b/tools/scripts/enhance-angular-schemas.ts
@@ -6,8 +6,26 @@ import { format, resolveConfig } from 'prettier';
   const setParserOptionsProjectConfig = {
     type: 'boolean',
     description:
-      'Whether or not to enable rules that require type information by configuring the ESLint `parserOptions.projectService` option. We do not do this by default for lint performance reasons.',
+      'Whether or not to enable rules that require type information by configuring the ESLint `parserOptions.projectService` option. We do not do this by default for lint performance reasons. Implied when tseslintPreset is a type-checked preset.',
     default: false,
+  };
+
+  const tseslintPresetConfig = {
+    type: 'string',
+    enum: [
+      'recommended',
+      'strict',
+      'recommendedTypeChecked',
+      'strictTypeChecked',
+    ],
+    default: 'recommended',
+    description:
+      'Which typescript-eslint shared config preset to extend in the generated ESLint config. Type-checked presets also enable parserOptions.projectService (required for those rules, but slower). See https://typescript-eslint.io/users/configs/',
+  };
+
+  const angularEslintSchemaProperties = {
+    setParserOptionsProject: setParserOptionsProjectConfig,
+    tseslintPreset: tseslintPresetConfig,
   };
 
   const applicationSchemaJsonPath = join(
@@ -15,18 +33,20 @@ import { format, resolveConfig } from 'prettier';
     '../../packages/schematics/src/application/schema.json',
   );
 
-  await enhanceSchemaWithProperties(applicationSchemaJsonPath, {
-    setParserOptionsProject: setParserOptionsProjectConfig,
-  });
+  await enhanceSchemaWithProperties(
+    applicationSchemaJsonPath,
+    angularEslintSchemaProperties,
+  );
 
   const librarySchemaJsonPath = join(
     __dirname,
     '../../packages/schematics/src/library/schema.json',
   );
 
-  await enhanceSchemaWithProperties(librarySchemaJsonPath, {
-    setParserOptionsProject: setParserOptionsProjectConfig,
-  });
+  await enhanceSchemaWithProperties(
+    librarySchemaJsonPath,
+    angularEslintSchemaProperties,
+  );
 })();
 
 async function enhanceSchemaWithProperties(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #2850

Adds an opt-in `--tseslint-preset` flag so `ng add` (and the related project schematics) can scaffold typescript-eslint's `strict` / type-checked shared configs instead of only the default `recommended` setup.

The name is `tseslintPreset` / `--tseslint-preset` on purpose: `ts-config` would read like `tsconfig.json`, while this flag chooses `tseslint.configs.*`.

## Usage

```sh
ng add angular-eslint --tseslint-preset=strictTypeChecked
```

Allowed values:

- `recommended` (default) — `tseslint.configs.recommended` + `tseslint.configs.stylistic`
- `strict` — `tseslint.configs.strict` + `tseslint.configs.stylistic`
- `recommendedTypeChecked` — `tseslint.configs.recommendedTypeChecked` + `tseslint.configs.stylisticTypeChecked`
- `strictTypeChecked` — `tseslint.configs.strictTypeChecked` + `tseslint.configs.stylisticTypeChecked`

Type-checked presets also enable `parserOptions.projectService` on the **root** ESLint config (required for those rules, and previously unreachable from `ng add` for a single-project workspace). They log a performance warning and include a short comment in the generated config.

The same option is accepted by `add-eslint-to-project`, `application`, and `library`. `--set-parser-options-project` is now also wired through `ng add`; type-checked presets imply it.

## Tests

- Unit coverage for all four presets, `ng add` plumbing, and the existing `setParserOptionsProject` root-config gap
- E2E cases for `strict`, `recommendedTypeChecked`, and `strictTypeChecked` (default `recommended` is already covered)
- `strictTypeChecked` e2e asserts the two known findings in Angular CLI's generated `src/main.ts` rather than a clean lint, so extra violations still fail CI

## Notes

`strictTypeChecked` currently flags Angular CLI's generated bootstrap `.catch((err) => console.error(err))`. The schematic does not weaken the preset to hide that.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ee04a28c-cad6-41c3-8d88-4bc8478a9d6e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ee04a28c-cad6-41c3-8d88-4bc8478a9d6e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

