### PR TITLE
fix(eslint-plugin): [prefer-signal-model] rewrite the emit calls of the removed output

### DIFF
--- a/packages/eslint-plugin/docs/rules/prefer-signal-model.md
+++ b/packages/eslint-plugin/docs/rules/prefer-signal-model.md
@@ -524,6 +524,74 @@ class Test {
 }
 ```
 
+<br>
+
+---
+
+<br>
+
+#### Default Config
+
+```json
+{
+  "rules": {
+    "@angular-eslint/prefer-signal-model": [
+      "error"
+    ]
+  }
+}
+```
+
+<br>
+
+#### ❌ Invalid Code
+
+```ts
+class Test {
+  readonly enabled = input<boolean>();
+  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  readonly enabledChange = output<boolean>();
+
+  toggle(): void {
+    this.enabledChange.emit(true);
+  }
+}
+```
+
+<br>
+
+---
+
+<br>
+
+#### Default Config
+
+```json
+{
+  "rules": {
+    "@angular-eslint/prefer-signal-model": [
+      "error"
+    ]
+  }
+}
+```
+
+<br>
+
+#### ❌ Invalid Code
+
+```ts
+class Test {
+  readonly enabled = input<boolean>();
+  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  readonly enabledChange = output<boolean>();
+
+  forward(): unknown {
+    return this.enabledChange;
+  }
+}
+```
+
 </details>
 
 <br>

--- a/packages/eslint-plugin/src/rules/prefer-signal-model.ts
+++ b/packages/eslint-plugin/src/rules/prefer-signal-model.ts
@@ -37,10 +37,6 @@ interface TwoWayBinding {
   readonly output: SignalDeclaration;
 }
 
-/**
- * Returns the `this.someOutput.emit` callee when the reference is the object of
- * such a call, so the fix can turn it into `this.someInput.set`.
- */
 function getEmitCallee(
   reference: TSESTree.MemberExpression,
 ): TSESTree.MemberExpression | undefined {
@@ -233,9 +229,6 @@ export default createESLintRule<Options, MessageIds>({
           );
 
         for (const { name, input, output } of twoWayBindings) {
-          // Removing the output breaks whatever used it, so the fix has to
-          // rewrite every use. `this.someOutput.emit(value)` becomes
-          // `this.someInput.set(value)`; anything else is left to the author.
           const emitCallees = (thisReferences.get(`${name}Change`) ?? []).map(
             getEmitCallee,
           );

--- a/packages/eslint-plugin/src/rules/prefer-signal-model.ts
+++ b/packages/eslint-plugin/src/rules/prefer-signal-model.ts
@@ -32,8 +32,29 @@ interface SignalDeclaration {
 }
 
 interface TwoWayBinding {
+  readonly name: string;
   readonly input: SignalDeclaration;
   readonly output: SignalDeclaration;
+}
+
+/**
+ * Returns the `this.someOutput.emit` callee when the reference is the object of
+ * such a call, so the fix can turn it into `this.someInput.set`.
+ */
+function getEmitCallee(
+  reference: TSESTree.MemberExpression,
+): TSESTree.MemberExpression | undefined {
+  const { parent } = reference;
+
+  return parent?.type === AST_NODE_TYPES.MemberExpression &&
+    parent.object === reference &&
+    !parent.computed &&
+    parent.property.type === AST_NODE_TYPES.Identifier &&
+    parent.property.name === 'emit' &&
+    parent.parent?.type === AST_NODE_TYPES.CallExpression &&
+    parent.parent.callee === parent
+    ? parent
+    : undefined;
 }
 
 function hasTransformOption(
@@ -83,6 +104,7 @@ export default createESLintRule<Options, MessageIds>({
     const { sourceCode } = context;
     const inputs = new Map<string, SignalDeclaration>();
     const outputs = new Map<string, SignalDeclaration>();
+    const thisReferences = new Map<string, TSESTree.MemberExpression[]>();
     let services: ParserServicesWithTypeInformation | undefined;
 
     function getTypeServices() {
@@ -184,9 +206,23 @@ export default createESLintRule<Options, MessageIds>({
       "PropertyDefinition > CallExpression[callee.name='output']":
         createSignalCollector(outputs, { hasInitialValueArgument: false }),
 
+      'MemberExpression[object.type="ThisExpression"][computed=false][property.type="Identifier"]'(
+        node: TSESTree.MemberExpression,
+      ) {
+        const { name } = node.property as TSESTree.Identifier;
+        const references = thisReferences.get(name);
+
+        if (references) {
+          references.push(node);
+        } else {
+          thisReferences.set(name, [node]);
+        }
+      },
+
       'ClassDeclaration:exit'() {
         const twoWayBindings = [...inputs]
           .map(([name, input]) => ({
+            name,
             input,
             output: outputs.get(`${name}Change`),
           }))
@@ -196,26 +232,40 @@ export default createESLintRule<Options, MessageIds>({
               haveMergeableTypes(binding.input, binding.output),
           );
 
-        for (const { input, output } of twoWayBindings) {
+        for (const { name, input, output } of twoWayBindings) {
+          // Removing the output breaks whatever used it, so the fix has to
+          // rewrite every use. `this.someOutput.emit(value)` becomes
+          // `this.someInput.set(value)`; anything else is left to the author.
+          const emitCallees = (thisReferences.get(`${name}Change`) ?? []).map(
+            getEmitCallee,
+          );
+          const isRewritable = emitCallees.every(isNotNullOrUndefined);
+
           context.report({
             node: input.property,
             messageId: 'preferSignalModel',
-            fix: (fixer) =>
-              [
-                RuleFixes.getImportAddFix({
-                  fixer,
-                  importName: 'model',
-                  moduleName: '@angular/core',
-                  node: input.property,
-                }),
-                fixer.replaceText(input.callee, 'model'),
-                fixer.remove(output.property),
-              ].filter(isNotNullOrUndefined),
+            fix: isRewritable
+              ? (fixer) =>
+                  [
+                    RuleFixes.getImportAddFix({
+                      fixer,
+                      importName: 'model',
+                      moduleName: '@angular/core',
+                      node: input.property,
+                    }),
+                    fixer.replaceText(input.callee, 'model'),
+                    fixer.remove(output.property),
+                    ...emitCallees.map((callee) =>
+                      fixer.replaceText(callee, `this.${name}.set`),
+                    ),
+                  ].filter(isNotNullOrUndefined)
+              : undefined,
           });
         }
 
         inputs.clear();
         outputs.clear();
+        thisReferences.clear();
       },
     };
   },

--- a/packages/eslint-plugin/tests/rules/prefer-signal-model/cases.ts
+++ b/packages/eslint-plugin/tests/rules/prefer-signal-model/cases.ts
@@ -458,4 +458,47 @@ export const invalid = [
       }
       `,
   }),
+  convertAnnotatedSourceToFailureCase({
+    description: 'should rewrite the emit calls of the removed output',
+    annotatedSource: `
+      class Test {
+        readonly enabled = input<boolean>();
+        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+        readonly enabledChange = output<boolean>();
+
+        toggle(): void {
+          this.enabledChange.emit(true);
+        }
+      }
+      `,
+    messageId: messageIdPreferSignalModel,
+    annotatedOutput: `import { model } from '@angular/core';
+
+      class Test {
+        readonly enabled = model<boolean>();
+        
+        
+
+        toggle(): void {
+          this.enabled.set(true);
+        }
+      }
+      `,
+  }),
+  convertAnnotatedSourceToFailureCase({
+    description:
+      'should not fix when the output is used for anything but an emit call',
+    annotatedSource: `
+      class Test {
+        readonly enabled = input<boolean>();
+        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+        readonly enabledChange = output<boolean>();
+
+        forward(): unknown {
+          return this.enabledChange;
+        }
+      }
+      `,
+    messageId: messageIdPreferSignalModel,
+  }),
 ];


### PR DESCRIPTION
## Overview

`prefer-signal-model`'s fix merges the input and the output into a `model()` and removes the output property, but leaves every `this.someOutput.emit(value)` behind, pointing at a member that no longer exists. Running `--fix` turns compiling code into code that does not compile.

```ts
// before
protected readonly sort = input.required<Sort>();
protected readonly sortChange = output<Sort>();

changeSort(next: Sort): void {
  this.sortChange.emit(next);
}

// after --fix: sortChange is gone, the call is not
protected readonly sort = model.required<Sort>();

changeSort(next: Sort): void {
  this.sortChange.emit(next); // TS2339
}
```

## What this changes

The fix now rewrites those calls to `this.someInput.set(value)`. When the output is referenced for anything other than an `emit` call, the rule reports without a fix rather than removing a member it cannot fully account for — the same stance `prefer-output-emitter-ref` takes by offering no fix at all.

Two test cases cover both paths.

## Worth knowing before reviewing

A call sitting in an **external template** stays out of reach: a TypeScript rule cannot fix an HTML file. That case is what made this expensive to spot in practice — when the `emit` is in the `.ts`, the fallout at least surfaces as `no-unsafe-call` / `no-unsafe-member-access`; when it is in the template, lint stays green and only the build fails.

If you would rather the fix not run at all while that hole exists, downgrading it to a suggestion would be the safer contract, but that is your call rather than something I wanted to decide in a bug fix.

## Context

Found while upgrading a shared ESLint config across six Angular repositories: the rule fired on two of them, and left orphan `emit` calls on both — once in a `.ts`, once in a set of templates.
